### PR TITLE
docs: refresh contributor guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,23 @@
-# Agent Guidelines for Book Read History
+# Repository Guidelines
 
-## Build/Lint/Test Commands
-- **Build**: `npm run build` (Next.js production build)
-- **Dev server**: `npm run dev` (starts on localhost:3000)
-- **Lint**: `npm run lint` (Biome linter)
-- **Format**: `npm run format` (Biome formatter) or `npm run lint:fix` (Biome auto-fix)
-- **Data conversion**: `npm run convert` or `npm run books:update` (CSV to TypeScript)
-- **Test**: No test runner configured (Playwright available in dependencies but no test scripts)
+## Project Structure & Module Organization
+Source code lives in `src/`, with routing under `src/pages`, shared UI in `src/components`, hooks in `src/hooks`, and TypeScript contracts in `src/types`. Tailwind-first styling is extended through modules in `src/styles`. Public assets, favicons, and Open Graph images belong in `public/`. CSV exports tracked in `export.json` feed the conversion scripts at the repo root (`convert.js`, `npm run books:update`) to regenerate typed data.
 
-## Code Style Guidelines
+## Build, Test, and Development Commands
+- `npm run dev`: Start the Next.js dev server on http://localhost:3000 with hot reload.
+- `npm run build`: Produce the production bundle; keep it passing before PR merge.
+- `npm run lint`: Run Biome lint rules for formatting and quality checks.
+- `npm run format`: Apply Biome formatting; use `npm run lint:fix` for autofixes.
+- `npm run convert` / `npm run books:update`: Rebuild TypeScript data from the CSV exports.
 
-### TypeScript & React
-- Use TypeScript with strict mode enabled
-- Define interfaces for component props
-- Use functional components with hooks
-- Follow PascalCase for component names and types
-- Use camelCase for variables, functions, and properties
+## Coding Style & Naming Conventions
+TypeScript strict mode is enabled; define explicit prop interfaces and prefer functional components. Imports use the `@/` alias, ordered with external packages before internal modules. Components and types use PascalCase, hooks use `use`-prefixed camelCase, and utilities stay camelCase. Indent with two spaces and avoid trailing whitespace. Compose layouts with Tailwind classes, adding module overrides only when the utility palette falls short.
 
-### Imports & Paths
-- Use absolute imports with path aliases: `@/components/*`, `@/hooks/*`, `@/styles/*`, `@/types/*`
-- Group imports: external packages first, then internal modules
-- Use relative imports only for files in the same directory
+## Testing Guidelines
+Playwright is available for e2e coverage. Place specs under `tests/e2e` and name them `<feature>.spec.ts`. Run suites with `npx playwright test` and document any fixtures or auth steps in the PR description. When tests are absent, verify `npm run lint` and `npm run build` locally before opening a PR.
 
-### Formatting & Linting
-- 2-space indentation (Biome configuration)
-- Use Biome for consistent formatting and linting
-- Include TypeScript files (*.ts, *.tsx) only, exclude node_modules
+## Commit & Pull Request Guidelines
+Follow Conventional Commits (`feat:`, `fix:`, `chore:`) with concise imperatives. PRs should describe the change, link relevant issues, and include before/after screenshots for UI updates. Mention data regeneration commands (e.g., `npm run books:update`) so reviewers can confirm generated diffs. Keep branches up to date with `main` and ensure lint/build checks succeed before requesting review.
 
-### Naming Conventions
-- Components: PascalCase (e.g., `BookCard`, `YearFilter`)
-- Hooks: camelCase with `use` prefix (e.g., `useBookFilter`)
-- Types/Interfaces: PascalCase (e.g., `Book`, `Highlight`)
-- Files: PascalCase for components, camelCase for utilities
-
-### Error Handling
-- Leverage TypeScript strict mode for compile-time error prevention
-- Use optional chaining (`?.`) and nullish coalescing (`??`)
-- Handle async operations with proper error boundaries where needed
-
-### Styling
-- Use Tailwind CSS classes for styling
-- Follow responsive design patterns
-- Use CSS Modules for component-specific styles when needed
-- Include accessibility attributes (aria-label, role, tabIndex)
-
-### Best Practices
-- Use Next.js Image component for optimized images
-- Implement proper keyboard navigation and ARIA labels
-- Store user preferences in sessionStorage with SSR-safe checks
-- Follow Japanese language conventions for UI text and comments
+## Environment & Tooling Notes
+Node.js 18+ keeps parity with the Next.js toolchain. Configure editor integrations for Tailwind IntelliSense and Biome to catch style issues early. ENV secrets belong in `.env.local` (never commit). Restart the dev server after updating conversion outputs to ensure hot data reloads.

--- a/README.md
+++ b/README.md
@@ -1,133 +1,102 @@
 # 読書管理アプリ
 
-読んだ本を記録・管理するためのWebアプリケーションです。[Next.js](https://nextjs.org/)を使用して構築されています。
+読んだ本を記録・管理するNext.js製のWebアプリケーションです。モバイル/デスクトップ双方で快適に利用でき、Tailwind CSSによる柔軟なUIカスタマイズにも対応しています。
 
-## 機能
+## 主な機能
 
 - **本の一覧表示**: 読了した本をグリッド形式で表示
-- **年別フィルタリング**: 読了年（2015年〜2024年）で本を絞り込み
-- **無限スクロール**: 48冊ずつ段階的に本を読み込み
-- **詳細ページ**: 各本の詳細情報（著者、出版社、ISBN、読了日など）を表示
-- **レスポンシブデザイン**: PC・スマートフォン両対応
+- **年別フィルタリング**: 読了年（2015年〜2024年）で絞り込み
+- **無限スクロール**: 48冊ずつ段階的に読み込み
+- **詳細ページ**: 著者・出版社・ISBN・読了日などを表示
+- **アクセシビリティ**: キーボード操作とARIA属性に対応
 
 ## 技術スタック
 
-- **フレームワーク**: Next.js 15.2.4
-- **言語**: TypeScript 4.9.4
-- **スタイリング**: CSS Modules
-- **リンター**: ESLint + Prettier
-- **画像最適化**: Next.js Image コンポーネント
+- **フレームワーク**: Next.js 15.x (App Router未使用のPages構成)
+- **言語**: TypeScript 5.9（strictモード）
+- **スタイリング**: Tailwind CSS + カスタムクラス
+- **リンター/フォーマッター**: Biome (lint / format)
+- **データ加工**: Node.jsスクリプト `convert.js`
 
 ## セットアップ
 
 ### 前提条件
-
 - Node.js 18以上
-- npm または yarn
+- npm
 
-### インストール
-
+### インストールと開発開始
 ```bash
-# リポジトリをクローン
 git clone <repository-url>
 cd book-read-history
-
-# 依存関係をインストール
 npm install
-```
-
-### 開発環境の起動
-
-```bash
 npm run dev
 ```
-
-ブラウザで [http://localhost:3000](http://localhost:3000) を開いてアプリケーションを確認できます。
+http://localhost:3000 でアプリを確認できます。
 
 ## 利用可能なコマンド
 
 ```bash
-# 開発サーバーを起動
-npm run dev
-
-# 本番用ビルドを作成
-npm run build
-
-# 本番サーバーを起動
-npm start
-
-# ESLintでコードをチェック
-npm run lint
-
-# ESLint + Prettierでコードを整形
-npm run format
-
-# CSVから本データを自動変換・更新
-npm run convert
-# または
-npm run books:update
+npm run dev          # 開発サーバー起動
+npm run build        # 本番ビルド生成
+npm start            # 本番ビルドを起動
+npm run lint         # BiomeでLintチェック
+npm run lint:fix     # Lint違反の自動修正
+npm run format       # Biomeで整形のみ実行
+npm run convert      # CSV→TypeScriptデータ変換
+npm run books:update # convertと同じ処理（エイリアス）
 ```
 
 ## データ管理
 
-### 本のデータ追加
+1. `public/books.csv` に新しい本の情報を追記
+2. 必要なら `public/highlights.csv` も更新
+3. `npm run convert` で `public/books.ts` などの型付きデータを再生成
+4. 年の追加がある場合は `src/pages/index.tsx` のフィルターリストを更新
 
-1. `/public/books.csv` に新しい本の情報を追加
-2. 自動変換スクリプトを実行: `npm run convert`
-3. 新しい年度が追加された場合は、`/pages/index.tsx` の年フィルターボタンを更新
-
-**自動化により、手動でのコピー作業は不要になりました！**
-
-### データ形式
-
-各本のデータには以下の情報が含まれます：
+TypeScriptで扱う本データは `src/types/book.ts` に定義されています。
 
 ```typescript
-{
-  id: string;           // SHA-256ハッシュ（タイトル+著者から生成）
-  title: string;        // 書籍タイトル
-  author: string;       // 著者名
-  publisher: string;    // 出版社
-  isbn: string;         // ISBN
-  readDate: string;     // 読了日（YYYY/MM/DD形式）
-  thumnailImage: string; // サムネイル画像URL
+export interface Highlight {
+  text: string;
+  location: string;
+}
+
+export interface Book {
+  id: string;
+  title: string;
+  author: string;
+  publisher: string;
+  isbn: string;
+  asin: string | null;
+  readDate: string;
+  thumbnailImage: string;
+  highlights: Highlight[];
 }
 ```
 
 ## プロジェクト構造
 
 ```
-├── pages/
-│   ├── index.tsx          # メインページ（本の一覧）
-│   ├── items/[id].tsx     # 本の詳細ページ
-│   └── _app.tsx           # Next.jsアプリのルート
-├── public/
-│   ├── books.csv          # 本のデータ（CSV形式）
-│   ├── books.ts           # 本のデータ（TypeScript）
-│   └── favicon.ico
-├── styles/
-│   ├── Home.module.css    # メインページのスタイル
-│   ├── Detail.module.css  # 詳細ページのスタイル
-│   └── globals.css        # グローバルスタイル
-├── convert.js             # CSV→JSON変換スクリプト
-├── next.config.js         # Next.js設定
-└── tsconfig.json          # TypeScript設定
+├── src/
+│   ├── pages/           # Next.jsページ（ルーティング）
+│   ├── components/      # UIコンポーネント
+│   ├── hooks/           # カスタムフック
+│   ├── styles/          # グローバルスタイル
+│   └── types/           # 型定義
+├── public/              # 画像・データCSV/TS
+├── convert.js           # データ変換スクリプト
+├── export.json          # CSVエクスポート設定
+├── AGENTS.md            # コントリビューター向けガイドライン
+└── package.json
 ```
+
+## コントリビューションガイド
+
+開発方針・コーディング規約・レビュー手順については [AGENTS.md](./AGENTS.md) を参照してください。コミット前に `npm run lint` と `npm run build` の完走を確認するとスムーズです。
 
 ## デプロイ
 
-### Vercelでのデプロイ
-
-最も簡単なデプロイ方法は [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) を使用することです。
-
-詳細は [Next.js deployment documentation](https://nextjs.org/docs/deployment) をご確認ください。
-
-## 開発ガイドライン
-
-- コミット前には必ず `npm run lint` を実行してコード品質を確認
-- 新機能追加時は既存のコードスタイルに従う
-- 画像最適化のため、Next.js Imageコンポーネントを使用
-- CSS ModulesまたはグローバルCSSでスタイリング
+[Vercel](https://vercel.com/) へのデプロイを推奨しています。GitHubリポジトリを接続すると自動ビルド・プレビューが利用できます。詳細は [Next.js deployment documentation](https://nextjs.org/docs/deployment) を参照してください。
 
 ## ライセンス
 

--- a/convert.js
+++ b/convert.js
@@ -39,7 +39,7 @@ try {
 
   // 先頭にヘッダー行を追加
   const booksHeader =
-    "title,_0,author,_,publisher,isbn,readDate,_1,_2,thumnailImage,_3,_4,_5,_6\n";
+    "title,_0,author,_,publisher,isbn,readDate,_1,_2,thumbnailImage,_3,_4,_5,_6\n";
   const booksDataWithHeader = booksHeader + booksData;
 
   // CSVをパース
@@ -125,7 +125,7 @@ try {
       isbn: row.isbn,
       asin: asin,
       readDate: row.readDate,
-      thumnailImage: row.thumnailImage.replace(/\?.*$/, ""),
+      thumbnailImage: row.thumbnailImage.replace(/\?.*$/, ""),
       highlights: highlights,
     };
   });

--- a/export.json
+++ b/export.json
@@ -7,7 +7,7 @@
     "isbn": "9784492224168",
     "asin": "4492224165",
     "readDate": "2025/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4168/9784492224168_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4168/9784492224168_1_4.jpg",
     "highlights": []
   },
   {
@@ -18,7 +18,7 @@
     "isbn": "9784320023680",
     "asin": "4320023684",
     "readDate": "2025/08/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784320023680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784320023680.jpg",
     "highlights": []
   },
   {
@@ -29,7 +29,7 @@
     "isbn": "9784041026557",
     "asin": "4041026555",
     "readDate": "2025/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6557/9784041026557_1_12.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6557/9784041026557_1_12.jpg",
     "highlights": []
   },
   {
@@ -40,7 +40,7 @@
     "isbn": "9784087213485",
     "asin": "408721348X",
     "readDate": "2025/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3485/9784087213485_1_40.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3485/9784087213485_1_40.jpg",
     "highlights": [
       {
         "text": "債券の世界では、債券の投資から得られるリターンを「金利」や「利回り（イールド）」ということから、債券価格が上がれば、リターン（金利・利回り） は下がることになります。債券を勉強する際、金利が上がると価格は下がること、すなわち、金利と価格が逆の動きをすることを理解するのは難しいとされますが、高い値段で買うと、リターンが下がると考えれば当たり前に感じられるはずです。",
@@ -80,7 +80,7 @@
     "isbn": "9784094532425",
     "asin": "4094532420",
     "readDate": "2025/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2425/9784094532425_1_55.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2425/9784094532425_1_55.jpg",
     "highlights": []
   },
   {
@@ -91,7 +91,7 @@
     "isbn": "9784791704651",
     "asin": "4791704657",
     "readDate": "2025/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784791704651_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784791704651_1_3.jpg",
     "highlights": []
   },
   {
@@ -102,7 +102,7 @@
     "isbn": "9784062883382",
     "asin": "4062883384",
     "readDate": "2025/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3382/9784062883382.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3382/9784062883382.jpg",
     "highlights": [
       {
         "text": "１７４７年にリンドは、どの治療法が本当に有効であるのか調べるため、次のような試験を行なった。 12 人の壊血病患者を同じ場所に集め、毎日同じ食事を与えた。そして患者を２人ずつ６組に分け、それぞれにリンゴ果汁、硫酸塩溶液、酢、海水、ニンニクなどから作ったペースト、オレンジ２個とレモン１個を与えたのだ。また、症状を発したものの、通常の食事を続けた者もいたので、これも並行して観察を行なった。 結果は、わずか６日で出た。オレンジとレモンを与えられた兵士はほぼ完治、リンゴ果汁を飲んだ者はわずかに回復が見られたが、他の者は全く症状の改善が見られなかった。ここに、「柑橘類が壊血病の特効薬になる」という事実が、見事に証明されたのだ。 この実験は、現代の目からは当たり前にも映る。だが、他の条件をなるべく一定に揃え、比較対象群と共に実験を行なって、何が有効なのかをはっきりさせたリンドの手法は、全く画期的なものであった。現代の臨床試験はこの考え方を基礎としており、あらゆる医薬や医療器具などは、この試験をくぐったものだけが広く認められることになっている。 天才の着想というものは、その後一般に普及して当たり前になってしまい、後世から見るとその凄さがわからなくなることが少なくない。リンドの創出した「臨床試験」の考え方は、その典型的な例といえそうだ。",
@@ -118,7 +118,7 @@
     "isbn": "9784865284751",
     "asin": "4865284753",
     "readDate": "2025/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4751/9784865284751_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4751/9784865284751_1_2.jpg",
     "highlights": []
   },
   {
@@ -129,7 +129,7 @@
     "isbn": "9784167915827",
     "asin": "4167915820",
     "readDate": "2025/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5827/9784167915827_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5827/9784167915827_1_5.jpg",
     "highlights": [
       {
         "text": "「キューバ人の葉巻の吸い方を教えてやる」と言われ、「まず葉巻のお尻の部分を歯で嚙み切って吐き出せ！」と言われたのでやってみる。",
@@ -157,7 +157,7 @@
     "isbn": "9784166613281",
     "asin": "4166613286",
     "readDate": "2025/06/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3281/9784166613281_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3281/9784166613281_1_5.jpg",
     "highlights": []
   },
   {
@@ -168,7 +168,7 @@
     "isbn": "9784163917306",
     "asin": "4163917306",
     "readDate": "2025/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7306/9784163917306_1_23.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7306/9784163917306_1_23.jpg",
     "highlights": [
       {
         "text": "感情遮断弁があるからイーロン・マスクは冷淡だと言われるのだろう。だが、これがあるから積極的にリスクを取るイノベーターになれたとも言える。ジャスティンは次のようにも語っている。 「恐れも遮断できるんです。でも、恐れを遮断するには、喜びや共感などほかのものも一緒に遮断しないといけないのでしょう」 子ども時代のＰＴＳＤで、満たされるのを嫌うようになったのだろう。 「成功をかみしめるとか花の香りを楽しむとか、そういうのは、どうすればいいのかわかっていないのだと思います」 こう言うのは、グライムスという名前で活動する音楽家で、マスクの子ども３人の母親であるクレア・ブーシェイだ。 「人生は痛みの連続だと子ども時代にたたき込まれたのでしょう」 そのとおりだとマスクも同意している。 「私は苦しみが原点なのです。だから、ちょっとやそっとでは痛いと感じなくなりました」",
@@ -208,7 +208,7 @@
     "isbn": "9784778340186",
     "asin": "4778340183",
     "readDate": "2025/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0186/9784778340186_1_33.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0186/9784778340186_1_33.jpg",
     "highlights": []
   },
   {
@@ -219,7 +219,7 @@
     "isbn": "9784022736703",
     "asin": "4022736704",
     "readDate": "2025/06/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6703/9784022736703_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6703/9784022736703_1_2.jpg",
     "highlights": [
       {
         "text": "診断基準にはないものの、しばしばみられる特徴として、争いごとや感情的にぶつかるようなことを避けようとする傾向が挙げられる。不当な攻撃や非難であっても、やり返してさらに激しい争いになるくらいなら、引き下がって泣き寝入りする方を選ぶ。",
@@ -267,7 +267,7 @@
     "isbn": "9784488146238",
     "asin": "4488146236",
     "readDate": "2025/06/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6238/9784488146238.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6238/9784488146238.jpg",
     "highlights": []
   },
   {
@@ -278,7 +278,7 @@
     "isbn": "9784065363775",
     "asin": "4065363772",
     "readDate": "2025/06/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3775/9784065363775_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3775/9784065363775_1_2.jpg",
     "highlights": []
   },
   {
@@ -289,7 +289,7 @@
     "isbn": "9784150310608",
     "asin": "4150310602",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0608/9784150310608_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0608/9784150310608_1_2.jpg",
     "highlights": [
       {
         "text": "「で、結果は。ぼくの何が欠落していたのかな。ナルシシズムやユーモアとは言わせないよ」 キャロライン・シェパードはお義理の微笑を返し、そしてこう口を開いた。 意識、と。 「意識だって」 あまりにシュールな答えを受け、私は吹き出す。けれど彼女は沈黙し、沈痛な面持ちのまま私の瞳に視線をすえ続けていた。",
@@ -321,7 +321,7 @@
     "isbn": "9784150311032",
     "asin": "415031103X",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1032/9784150311032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1032/9784150311032.jpg",
     "highlights": []
   },
   {
@@ -332,7 +332,7 @@
     "isbn": "9784150310912",
     "asin": "4150310912",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0912/9784150310912.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0912/9784150310912.jpg",
     "highlights": [
       {
         "text": "ちなみに、この映画のラストシーン、映画がスタッフロールに行く直前の一瞬、フィンチャーの物凄い「悪意」が仕掛けてあります。わずか２フレーム（１／ 12 秒）程度の映像なので何が映っているか分からない人もいるかも知れませんが、映画の内容を考えればその映像が何かは明白。よく税関を通ったものです、この映画。税関や映倫委員に対する面当てであるうえ、我々観客に対する「あっかんべえ」でもあるこの一瞬は、映画史に刻み込まれるべきイタズラです。",
@@ -352,7 +352,7 @@
     "isbn": "9784422230450",
     "asin": "442223045X",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0450/9784422230450_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0450/9784422230450_1_3.jpg",
     "highlights": []
   },
   {
@@ -363,7 +363,7 @@
     "isbn": "9784150311872",
     "asin": "4150311870",
     "readDate": "2025/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1872/9784150311872.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1872/9784150311872.jpg",
     "highlights": []
   },
   {
@@ -374,7 +374,7 @@
     "isbn": "9784150311865",
     "asin": "4150311862",
     "readDate": "2025/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1865/9784150311865.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1865/9784150311865.jpg",
     "highlights": []
   },
   {
@@ -385,7 +385,7 @@
     "isbn": "9784087711677",
     "asin": "4087711676",
     "readDate": "2025/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1677/9784087711677.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1677/9784087711677.jpg",
     "highlights": []
   },
   {
@@ -396,7 +396,7 @@
     "isbn": "9784478116982",
     "asin": "4478116989",
     "readDate": "2025/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6982/9784478116982_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6982/9784478116982_1_8.jpg",
     "highlights": []
   },
   {
@@ -407,7 +407,7 @@
     "isbn": "9784479797036",
     "asin": "4479797033",
     "readDate": "2025/05/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7036/9784479797036.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7036/9784479797036.jpg",
     "highlights": [
       {
         "text": "このように、サブスクリプション型の大きな特徴は売り切り型と比べて圧倒的に乗り換えがしやすい（スイッチングコストが低い）ことです。乗り換えがしやすいということはインターネット以降のプロダクト・サービスの常識です。それは、収益性を保つ上で「一度買ってもらうこと」だけでなく、「長く使い続けてもらうこと」 が最優先課題になったということです。",
@@ -467,7 +467,7 @@
     "isbn": "9784163919096",
     "asin": "4163919090",
     "readDate": "2025/05/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9096/9784163919096_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9096/9784163919096_1_7.jpg",
     "highlights": [
       {
         "text": "日本は、ドイツ以上に二つ目の「西洋」、つまり「自由主義の伝統は持たないが近代的な西洋」に属している。しかし日本もまた危機に直面している。この点に関しては同様のことがロシアにも中国にも言えるが、非常に低い出生率がそれを示している。日本はドイツと同じく、ＮＡＴＯが崩壊することでアメリカの支配下から解放されるだろう。しかし日本はそれによって、韓国とともに、中国と独力で向き合わなければならなくなる。",
@@ -491,7 +491,7 @@
     "isbn": "9784839987800",
     "asin": "4839987807",
     "readDate": "2025/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7800/9784839987800_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7800/9784839987800_1_4.jpg",
     "highlights": []
   },
   {
@@ -502,7 +502,7 @@
     "isbn": "9784532356132",
     "asin": "453235613X",
     "readDate": "2025/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6132/9784532356132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6132/9784532356132.jpg",
     "highlights": [
       {
         "text": "偉大な文明の存続を脅かす要因としては、国境に押し寄せる異邦人よりも、その文明がみずから生み出した内部の 経済的 不均衡のほうが重大であることを示しており、これは古代ローマ帝国から現代ヨーロッパにいたるまでの歴史にも当てはまる。 たとえば、政治面での過剰な中央集権化は帝国の衰退の一般的な要因であり、通常はこうした集権化の実現から百年以降に衰退が始まる。",
@@ -558,7 +558,7 @@
     "isbn": "9784065020357",
     "asin": "4065020352",
     "readDate": "2025/04/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0357/9784065020357.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0357/9784065020357.jpg",
     "highlights": []
   },
   {
@@ -569,7 +569,7 @@
     "isbn": "9784492503409",
     "asin": "4492503404",
     "readDate": "2025/04/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3409/9784492503409_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3409/9784492503409_1_2.jpg",
     "highlights": [
       {
         "text": "各カンパニーは独立した法人とみなし、責任と権限を明確にしています。その裏返しとして、サイロ化しやすいのです。分厚いレンガで囲われていて中が見えない。まさに「壁」です。アウトプット（業績）はわかっても、その中身まではよく見えません。どこに問題があって目標が達成できなかったのか、その原因がわからなければ、対処法も解決策も考えられません。",
@@ -617,7 +617,7 @@
     "isbn": "9784781619835",
     "asin": "4781619835",
     "readDate": "2025/03/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9835/9784781619835_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9835/9784781619835_1_2.jpg",
     "highlights": [
       {
         "text": "「チヤホヤされているときは、自分が何者かを忘れていられる」点には、どうかお気をつけください。自分が何者でもないと悩んでいる人、とくに若い人が、チヤホヤされたりスポットライトを浴びたりして快感を覚え、悩みを忘れてしまった結果、「これこそが解決策」と早合点をしてしまうことがあります。",
@@ -665,7 +665,7 @@
     "isbn": "9784040824994",
     "asin": "4040824997",
     "readDate": "2025/03/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4994/9784040824994_1_12.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4994/9784040824994_1_12.jpg",
     "highlights": []
   },
   {
@@ -676,7 +676,7 @@
     "isbn": "9784101054315",
     "asin": "4101054312",
     "readDate": "2025/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4315/9784101054315_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4315/9784101054315_1_2.jpg",
     "highlights": [
       {
         "text": "① 一つの商品にたくさんの情報価値＝語りたくなる、伝えたくなる価値を盛り込む ② 発信しようとする情報を受け手の身になって考える、整理する ③ 時代を読む ④ 関与者を多く作る ⑤ 即効性のあるメディアほど情報感度は鈍い。雑誌→新聞→ラジオ・テレビの順番を意識する ⑥ 追い駆けるより追い駆けさせる構造を作る",
@@ -716,7 +716,7 @@
     "isbn": "9784142231652",
     "asin": "4142231650",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784142231652_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784142231652_1_3.jpg",
     "highlights": []
   },
   {
@@ -727,7 +727,7 @@
     "isbn": "9784002710808",
     "asin": "4002710807",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0808/9784002710808_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0808/9784002710808_1_2.jpg",
     "highlights": []
   },
   {
@@ -738,7 +738,7 @@
     "isbn": "9784569845999",
     "asin": "4569845991",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5999/9784569845999_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5999/9784569845999_1_2.jpg",
     "highlights": []
   },
   {
@@ -749,7 +749,7 @@
     "isbn": "9784101171319",
     "asin": "4101171319",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1319/9784101171319.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1319/9784101171319.jpg",
     "highlights": []
   },
   {
@@ -760,7 +760,7 @@
     "isbn": "9784094532012",
     "asin": "4094532013",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2012/9784094532012_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2012/9784094532012_1_4.jpg",
     "highlights": []
   },
   {
@@ -771,7 +771,7 @@
     "isbn": "9784778319663",
     "asin": "4778319664",
     "readDate": "2025/03/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9663/9784778319663_1_10.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9663/9784778319663_1_10.jpg",
     "highlights": [
       {
         "text": "邪神ちゃんマーケティングは弱者のためのメソッドです。 ご存じの方も多いと思いますが、マーケティング理論には ランチェスター戦略 という有名な考え方があります。これは「同じ武器を持った者同士が戦うと数が多い方が勝つ」 という当たり前のことを前提として「狭いところで大人数と少人数が１対１で戦うとどちらも同じ損害を受ける」「広いところで大人数と少人数が戦うと少人数の方が大きい損害を受ける」 という２つの法則を導きます。このことから少人数の時はなるべく局地戦で戦うべきだし、大人数の時はなるべく広域で戦うとよいということがわかります。",
@@ -811,7 +811,7 @@
     "isbn": "9784791776597",
     "asin": "4791776593",
     "readDate": "2025/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6597/9784791776597_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6597/9784791776597_1_3.jpg",
     "highlights": [
       {
         "text": "マーク・フィッシャーは著書『わが人生の亡霊たち』の序文にあたる文章の中で、「いずれにせよ、誰にとってであれ、自分自身であること（さらに言えば、自分自身を売り込むことを強いられること） ほど惨めなことはない。文化や文化に対する分析が価値を持つのは、それが自分自身からの逃走を可能にするかぎりでのことなのだ」と述べていた（３）。",
@@ -935,7 +935,7 @@
     "isbn": "9784153400375",
     "asin": "4153400378",
     "readDate": "2025/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0375/9784153400375_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0375/9784153400375_1_7.jpg",
     "highlights": [
       {
         "text": "ただ実際には、マーケットに売却せずに住み続けるのであれば、購入後の価格の変動は何の影響もない。 いくら価格が上昇しても、株式や債券と同様、売却して「益出し」をしない限り、果実を得ることはできないので、あくまでも「含み益」を 眺めているだけの状態にある。あるいは仮に売却して含み益を享受したとしても、次に住む家に買い替える必要が出てくる。不動産価格が上がっているということは、現在住んでいるレベルの家を買った当時の値段では 買えない ことを意味するので、同等の家に移り住むためには、場合によっては売却益以上の金銭負担がかかってくる。 下落している場合も同様で、住み続けられるのであれば、何か損するわけではない。結局、自分が所有している「資産」であるはずの家の値段が上がることに気分を良くする、あるいは下がることに対して良い気分になれないだけなのだ。",
@@ -987,7 +987,7 @@
     "isbn": "9784297143299",
     "asin": "4297143291",
     "readDate": "2025/02/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3299/9784297143299_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3299/9784297143299_1_4.jpg",
     "highlights": []
   },
   {
@@ -998,7 +998,7 @@
     "isbn": "9784763141880",
     "asin": "4763141880",
     "readDate": "2025/02/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1880/9784763141880_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1880/9784763141880_1_3.jpg",
     "highlights": [
       {
         "text": "モンゴル帝国は４０００㎞離れたロシアを征服できても、２００㎞の対馬海峡を越えて日本を征服することはできませんでした。ドイツは１５００㎞離れたロシアに２０００両の戦車を送れても、 30 ㎞のドーバー海峡の向こうのイギリスには１両の戦車も送れませんでした。そしてアメリカには、１機の飛行機さえ飛ばすことができませんでした。海を越えた侵略は、陸を越えた侵略よりもそれほど難しいのです。 海洋国家は防御有利、大陸国家は攻撃有利。この違いが、それぞれの行動原理を根本的に異なるものにします。",
@@ -1066,7 +1066,7 @@
     "isbn": "9784910511559",
     "asin": "4910511555",
     "readDate": "2025/02/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1559/9784910511559_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1559/9784910511559_1_2.jpg",
     "highlights": []
   },
   {
@@ -1077,7 +1077,7 @@
     "isbn": "9784314011167",
     "asin": "4314011165",
     "readDate": "2025/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1167/9784314011167.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1167/9784314011167.jpg",
     "highlights": []
   },
   {
@@ -1088,7 +1088,7 @@
     "isbn": "9784802512046",
     "asin": "480251204X",
     "readDate": "2025/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2046/9784802512046_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2046/9784802512046_1_3.jpg",
     "highlights": [
       {
         "text": "つまりデジタル化とは、無尽蔵に広がる人の想像と欲望に対して、それを満足させる資源供給方法の最適化である。そしてこれには必然性がある。私たちの想像と欲望にリミットはないが、地球のリソースにはリミットがあるためである。欲望を効率的、効果的に処理する方法が必要なのだ。",
@@ -1192,7 +1192,7 @@
     "isbn": "9784094531978",
     "asin": "4094531971",
     "readDate": "2025/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1978/9784094531978_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1978/9784094531978_1_4.jpg",
     "highlights": []
   },
   {
@@ -1203,7 +1203,7 @@
     "isbn": "9784094531640",
     "asin": "4094531645",
     "readDate": "2025/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1640/9784094531640_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1640/9784094531640_1_7.jpg",
     "highlights": []
   },
   {
@@ -1214,7 +1214,7 @@
     "isbn": "9784094531183",
     "asin": "4094531181",
     "readDate": "2025/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1183/9784094531183_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1183/9784094531183_1_5.jpg",
     "highlights": []
   },
   {
@@ -1225,7 +1225,7 @@
     "isbn": "9784094530940",
     "asin": "4094530940",
     "readDate": "2025/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/9784094530940_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/9784094530940_1_5.jpg",
     "highlights": []
   },
   {
@@ -1236,7 +1236,7 @@
     "isbn": "9784093891837",
     "asin": "4093891834",
     "readDate": "2025/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1837/9784093891837_1_59.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1837/9784093891837_1_59.jpg",
     "highlights": []
   },
   {
@@ -1247,7 +1247,7 @@
     "isbn": "9784802511193",
     "asin": "4802511191",
     "readDate": "2025/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784802511193.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784802511193.jpg",
     "highlights": [
       {
         "text": "本書で扱うテーマは大きく３つある。１つは、「アジャイルに作る」ことで直面する「不確実性」への適応について。「アジャイルに作る」とは、作ることを通じて学びを得る活動にほかならない。 得られた学びをプロダクトづくりの中でどのようにして受け止めるのか。受け止め損なうと、様々な背景や思惑を抱いて集まってきている関係者、チームの期待に応えられず、プロダクトづくりは破綻する。最初の昔話がその例だ。",
@@ -1343,7 +1343,7 @@
     "isbn": "9784799330838",
     "asin": "4799330837",
     "readDate": "2025/01/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0838/9784799330838_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0838/9784799330838_1_2.jpg",
     "highlights": []
   },
   {
@@ -1354,7 +1354,7 @@
     "isbn": "9784814400911",
     "asin": "4814400918",
     "readDate": "2025/01/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0911/9784814400911_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0911/9784814400911_1_2.jpg",
     "highlights": []
   },
   {
@@ -1365,7 +1365,7 @@
     "isbn": "9784777831180",
     "asin": "4777831183",
     "readDate": "2024/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1180/9784777831180_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1180/9784777831180_1_4.jpg",
     "highlights": []
   },
   {
@@ -1376,7 +1376,7 @@
     "isbn": "9784048977609",
     "asin": "4048977601",
     "readDate": "2024/12/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7609/9784048977609_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7609/9784048977609_1_8.jpg",
     "highlights": []
   },
   {
@@ -1387,7 +1387,7 @@
     "isbn": "9784314011365",
     "asin": "431401136X",
     "readDate": "2024/12/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1365/9784314011365.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1365/9784314011365.jpg",
     "highlights": []
   },
   {
@@ -1398,7 +1398,7 @@
     "isbn": "9784478115244",
     "asin": "4478115249",
     "readDate": "2024/12/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784478115244_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784478115244_1_2.jpg",
     "highlights": [
       {
         "text": "ＧＥでは最初に業績目標が決められ、どうやってそれを達成するかは二の次である。その目標を達成するために必要な数字が各事業に割り振られ、方法はどうであれ、数字を達成することが厳しく求められる。",
@@ -1438,7 +1438,7 @@
     "isbn": "9784065312629",
     "asin": "4065312620",
     "readDate": "2024/11/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2629/9784065312629_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2629/9784065312629_1_8.jpg",
     "highlights": [
       {
         "text": "「戦場ヶ原」 「何よ。まだ国家に 叛意 を？」 「いやいや、愛国心だよ。そして新婚旅行の行き先だ」 「？」 「戦場ヶ原に行こう。何でも知っている委員長に教えてもらったところによると、日本有数の、星の綺麗な湿原らしいぜ」",
@@ -1458,7 +1458,7 @@
     "isbn": "9784296202010",
     "asin": "4296202014",
     "readDate": "2024/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2010/9784296202010_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2010/9784296202010_1_4.jpg",
     "highlights": [
       {
         "text": "「思考が煮詰まったら、すぐに『行動』するんだ。誰かに相談したり、新たな情報を集めたりすることで、また思考できる状態に戻す」 「そういえば、お父さんって考えるのがめっちゃ速いよね。私は一度考え始めると、ずーっと時間を使っちゃうんだけど…。お父さんは淀みなく考えている感じがするっていうか、停滞していないというか…。考えがどんどん進んでいく感じがする！」 「ははは、いい表現だ。思考は単発の活動ではなく、流れなんだよ。状況を認知し、思考し、そして止まる。それを行動で打破し、また認知に戻ってくる。こうやってテンポよく、考え方の循環サイクルを回していく必要があるんだ」",
@@ -1526,7 +1526,7 @@
     "isbn": "9784022519979",
     "asin": "4022519975",
     "readDate": "2024/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9979/9784022519979_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9979/9784022519979_1_3.jpg",
     "highlights": [
       {
         "text": "全てはパターンに還元されてしまうけれど、それは概念の分解能を上げすぎなのだ。 映画を観ていると「この展開って、固有名詞が違うだけで前観たあの映画とほとんど同じじゃん」と気づくことがある。漫画を読んでいると「前読んだのと全く同じ種類のギャグ」に出会うことがある。そういうことに気づくと、白けるというかなんというか「結局はガワだけ取り替えた同じソフトウェアで機嫌を取られてるだけなんだなあ」という思いに支配されてしまいそうになる。けれどもむしろ、構造化してパターン分けすること自体が、個別のものごとに宿る豊穣さを見失う原因になっていないだろうか。「分析」による把握が、かえって理解を画一化してしまうのだ。だから、つまり、全ての作品が何らかの既存のパターンに依存しているとしても、その中で表現される個々のディテールやニュアンスはユニークであり、それ自体が価値を持っている。そう考えるべきなのだろう。",
@@ -1550,7 +1550,7 @@
     "isbn": "9784153400061",
     "asin": "4153400068",
     "readDate": "2024/10/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0061/9784153400061_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0061/9784153400061_1_2.jpg",
     "highlights": []
   },
   {
@@ -1561,7 +1561,7 @@
     "isbn": "9784775970379",
     "asin": "4775970372",
     "readDate": "2024/10/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7759/77597037.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7759/77597037.jpg",
     "highlights": [
       {
         "text": "ある者が違法な会社で結託し、 新たに株を発行し、度を超えた取引を奨励する。 魅力ある空虚な名前と雰囲気で、 まずは信用を高めておいて、後から底へと突き落とす。 そして無の実体を株に分け、 群衆の不和を引き起こす。 ――デフォー",
@@ -1581,7 +1581,7 @@
     "isbn": "9784094532036",
     "asin": "409453203X",
     "readDate": "2024/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2036/9784094532036_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2036/9784094532036_1_2.jpg",
     "highlights": []
   },
   {
@@ -1592,7 +1592,7 @@
     "isbn": "9784791704538",
     "asin": "4791704533",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4538/9784791704538_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4538/9784791704538_1_3.jpg",
     "highlights": []
   },
   {
@@ -1603,7 +1603,7 @@
     "isbn": "9784144072376",
     "asin": "4144072371",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2376/9784144072376.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2376/9784144072376.jpg",
     "highlights": [
       {
         "text": "そして、マスコミは中立であるべきだ、という一部の言説に対し、「中立なマスコミという幻想」をまず捨てなさいと警鐘を鳴らしています。特にリベラル層に多く見られる傾向ですが、私たちはあたかも中立で民主的でまっさらな情報を発信するマスコミが存在する、あるいはすべきだとどこかで思い込んでいる。その思い込み自体がステレオタイプなのです。これについてはフランスの思想家トクヴィル（＊ 19） が、『アメリカのデモクラシー』という著作の中で「民主制を終わらせるのはマスメディアだ」と指摘しているように、メディアはその成り立ち自体が持つ限界から、中立にはなりえません。この事実を受け入れた上で、受け手である私たちの中にあるステレオタイプの存在と、送り手であるメディアがそれを強化するという関係性を知ることが大切です。 メディアにはスポンサーという出資者がいて、そこでの制約があること。記者や制作スタッフやコメンテーターにもステレオタイプな主観があること。そして何よりも重要なことは、リップマンが言うように、そこで発信される情報イコール「真実」では決してなく、あくまでも切り取られた事実の一部にすぎないのだと、私たちが理解することなのです。",
@@ -1619,7 +1619,7 @@
     "isbn": "9784022952745",
     "asin": "4022952741",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2745/9784022952745_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2745/9784022952745_1_3.jpg",
     "highlights": [
       {
         "text": "日本以外の社会では、労働者が遂行すべき職務（job） が雇用契約に明確に規定されます。ところが、日本では、雇用契約に職務は明記されません。明記されるか、されないかというよりも、そもそも雇用契約上、職務が特定されていないのが普通です。どんな仕事をするか、職務に就くかというのは、使用者の命令によって定まります。いわば、日本の雇用契約は、その都度遂行すべき特定の職務が書き込まれる空白の石板なのです。ここから、日本における雇用の本質は職務（job） ではなく、所属（membership） にあると規定することができます。ジョブ型、メンバーシップ型という言葉の由来はここにあります。",
@@ -1667,7 +1667,7 @@
     "isbn": "9784569903880",
     "asin": "4569903886",
     "readDate": "2024/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784569903880_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784569903880_1_2.jpg",
     "highlights": [
       {
         "text": "議長席から見てジャコバン派が左側、ジロンド派が右側に着席したことから、前者を「左派」、後者を「右派」と呼ぶようになりました。 この場合の「右派」は、共同体（社会や家族） の伝統や秩序を重んじ、急激な変化を求めない考え方で、「保守主義」と言ってもいいでしょう。社会や家族を守ることが最高の価値であり、個人はその一員として頑張ろう、という立場です。 これに対して「左派」は、「共同体より個人。個人の権利と自由を制限するような伝統は、根本的につくり変えてしまえ」という考え方。改革や進歩を好み、言葉の本来の意味で「リベラル（自由主義者）」と呼ばれる人々です。",
@@ -1683,7 +1683,7 @@
     "isbn": "9784478114179",
     "asin": "447811417X",
     "readDate": "2024/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4179/9784478114179_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4179/9784478114179_1_2.jpg",
     "highlights": []
   },
   {
@@ -1694,7 +1694,7 @@
     "isbn": "9784591182253",
     "asin": "4591182258",
     "readDate": "2024/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2253/9784591182253_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2253/9784591182253_1_3.jpg",
     "highlights": []
   },
   {
@@ -1705,7 +1705,7 @@
     "isbn": "9784022952707",
     "asin": "4022952709",
     "readDate": "2024/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2707/9784022952707_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2707/9784022952707_1_3.jpg",
     "highlights": [
       {
         "text": "アメリカは、ユーラシアの歴史的帰結に影響をおよぼそうとして数千億ドルを費やしながらも、長い陸の国境を接する国で起こっているできごとを、不思議なほど静観している。しかも、その隣国は大混乱に 瀕 していて、イラクとアフガニスタンの合計の二倍近くの人口があるのだ。 もちろん、厳重な国境警備体制があれば、ナショナリズムを掲げ、健全に機能するアメリカが、部分的に無秩序状態で機能不全のメキシコと共存することはできる。しかしそんな状態は長くは続かない。",
@@ -1721,7 +1721,7 @@
     "isbn": "9784296103942",
     "asin": "4296103946",
     "readDate": "2024/09/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3942/9784296103942.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3942/9784296103942.jpg",
     "highlights": [
       {
         "text": "「いいかい。資料で大事なのは、図や文章じゃない。 伝えたいことがあるか、ないかだ。この資料にはそれがないんだよ」",
@@ -1833,7 +1833,7 @@
     "isbn": "9784062839006",
     "asin": "4062839008",
     "readDate": "2024/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9006/9784062839006.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9006/9784062839006.jpg",
     "highlights": [
       {
         "text": "「羽川。お前は何でも知ってるな」 「何でもは知らないわよ。知ってることだけ」 へらっと笑って、羽川はそう応じた。 昔のように──しかし、今の羽川は、こう付け加えた。 「知れば知るほど、知らないことが増えていく」 知ってる人も、いつか知らない人になる。",
@@ -1853,7 +1853,7 @@
     "isbn": "9784163918723",
     "asin": "4163918728",
     "readDate": "2024/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8723/9784163918723_1_21.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8723/9784163918723_1_21.jpg",
     "highlights": []
   },
   {
@@ -1864,7 +1864,7 @@
     "isbn": "9784065350355",
     "asin": "4065350352",
     "readDate": "2024/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0355/9784065350355_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0355/9784065350355_1_2.jpg",
     "highlights": [
       {
         "text": "あなた以外の人が全員正しく、あなた一人が大きな間違いを犯したとき、市場はあなたを罰しません。逆にその他の人が全員間違ってあなただけが正しかったときは大きく報います。 市場は、あなたの意見が少数意見である限りあなたの味方です。",
@@ -1932,7 +1932,7 @@
     "isbn": "9784822271787",
     "asin": "4822271781",
     "readDate": "2024/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1787/9784822271787.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1787/9784822271787.jpg",
     "highlights": [
       {
         "text": "「そうだ。会議は何かを決める場のはずだ。だから会議の終わりには必ず〝決まったこと〟と〝やるべきこと〟があるはずなんだ。定例会では、営業部門へ連絡するという〝やるべきこと〟が発生していたが、葵の先輩の片澤くんは分かっていなかった。もし会議の終わりに改めて確認していたら違ったと思わないか？」",
@@ -2028,7 +2028,7 @@
     "isbn": "9784167920258",
     "asin": "4167920255",
     "readDate": "2024/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784167920258_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784167920258_1_7.jpg",
     "highlights": [
       {
         "text": "「小さすぎる？」 「そこは東京 に じゃない。東京 をとすべきじゃないか、曾禰君。ひとつひとつの物件など、しょせん長い道のりの一里塚。私はつまり、最後には、東京そのものを建築する」",
@@ -2056,7 +2056,7 @@
     "isbn": "9784094530643",
     "asin": "4094530649",
     "readDate": "2024/08/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784094530643_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784094530643_1_3.jpg",
     "highlights": []
   },
   {
@@ -2067,7 +2067,7 @@
     "isbn": "9784094530414",
     "asin": "409453041X",
     "readDate": "2024/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0414/9784094530414_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0414/9784094530414_1_3.jpg",
     "highlights": []
   },
   {
@@ -2078,7 +2078,7 @@
     "isbn": "9784862760852",
     "asin": "4862760856",
     "readDate": "2024/08/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0852/9784862760852_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0852/9784862760852_1_3.jpg",
     "highlights": [
       {
         "text": "「悩む」＝「答えが出ない」という前提のもとに、「考えるフリ」をすること 「考える」＝「答えが出る」という前提のもとに、建設的に考えを組み立てること",
@@ -2126,7 +2126,7 @@
     "isbn": "9784802512480",
     "asin": "4802512481",
     "readDate": "2024/08/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2480/9784802512480_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2480/9784802512480_1_3.jpg",
     "highlights": [
       {
         "text": "「デザインシステム」は一般的に、「デザインの再現性を高め、一貫した製品体験を効率よく表現すること」を目的に導入される「ドキュメントやリソース群のこと」と説明されます。",
@@ -2354,7 +2354,7 @@
     "isbn": "9784163916873",
     "asin": "4163916873",
     "readDate": "2024/07/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784163916873_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784163916873_1_8.jpg",
     "highlights": [
       {
         "text": "近年、情報番組のコメンテーターは流行の職業だった。本業で少しでも実績があれば、それを肩書としてコメンテーターのポジションを得ることが出来る。大衆は権威に弱いため、一度テレビで顔が売れればさらに権威が増す。基本は井戸端会議なので、専門知識などなくても務まった。場の空気を読み、少し本音をまぶし、少し面白いことを言う。その 匙加減がうまい人間が生き残り、コメントで禄を 食む。要するに新手のテレビタレントなのである。",
@@ -2386,7 +2386,7 @@
     "isbn": "9784150506094",
     "asin": "4150506094",
     "readDate": "2024/07/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6094/9784150506094_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6094/9784150506094_1_2.jpg",
     "highlights": [
       {
         "text": "それを解決したのが、東南アジアのジャングルに生息するグッタペルカ（ガタパチャ）の木から採れる同名のゴム状の樹脂だ。グッタペルカの特質の１つは、常温では固いが温水に浸けると柔らかくなってどのようにでも変形できることだった。ヴィクトリア朝時代にはこれが現在のプラスチックのように使われていた。人形やチェスの駒、ラッパ形補聴器などはすべてこの材料で作られていた。それは高価ではあったが、ケーブルを絶縁するには理想的な材料だった。",
@@ -2414,7 +2414,7 @@
     "isbn": "9784798629704",
     "asin": "4798629707",
     "readDate": "2024/07/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784798629704_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784798629704_1_3.jpg",
     "highlights": []
   },
   {
@@ -2425,7 +2425,7 @@
     "isbn": "9784396344740",
     "asin": "4396344740",
     "readDate": "2024/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4740/9784396344740.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4740/9784396344740.jpg",
     "highlights": [
       {
         "text": "「やはり、 利根川じゃな」 どさりと 床几 に腰をおろした。野外で昼めしを食うつもりなのだ。 米を 炊くにおいがして、従者が竹皮のつつみを持ってきた。つつみをひらくと、大きなにぎりめしが六個。うなぎの なれ ずし が 添えられている。ぶつ切りにしたうなぎを酒にひたして塩漬けしたものだが、やわらかいから、忠次は骨まで食べてしまう。 「うん。やはり野外で食うめしはうまい」 五分ほどでぺろりと平らげてしまうと、 「父上」 となりの床几でちょこんと膝をそろえ、忠次とおなじ大きさのにぎりめしを手にしつつ、八歳の長男・熊蔵が、 「なぜ利根川なのですか。この関東には、ほかに無数の川がありますのに」 「利根川こそが、江戸の地を水びたしにしている元凶なのだ」 「なぜです」 「流量が多く、江戸 湊（東京湾）にそそぐ河口が広すぎるからだ」 忠次は、説明した。 そもそも利根川は上野国の北部、 水上（群馬県利根郡みなかみ町）の山ふかくを水源としている。はじめ南東へ、やがて南へ流れて江戸湊にそそぐ、というのが大ざっぱな流路だった。くりかえすが、 東京湾 に そそいでいる。二十一世紀の現在とはまったくちがう。 「河口は江戸城の北東方、 関屋（ 足立区 千住 関屋町付近）にある。周囲はいちめん湿地となり、海の水とまじりあい、人のあゆみを 拒んでいる。米も、みのらぬ。畑にもならぬ。江戸で雨がふらずとも、北関東でふれば手のつけられぬ水が押し寄せる。この問題を解決せねば、江戸は永遠に未開のままじゃ」 「ならば、河口を移せばいい」",
@@ -2457,7 +2457,7 @@
     "isbn": "9784040752518",
     "asin": "4040752511",
     "readDate": "2024/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784040752518_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784040752518_1_3.jpg",
     "highlights": []
   },
   {
@@ -2468,7 +2468,7 @@
     "isbn": "9784153400269",
     "asin": "4153400262",
     "readDate": "2024/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0269/9784153400269_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0269/9784153400269_1_3.jpg",
     "highlights": [
       {
         "text": "また、グーグルのデータセンターにおいては、通常のデータセンターで用いられるような高価なサーバを用いない。データセンターで使われることを想定したサーバは主要な部品の質が高く、二重化などがされているため、壊れにくい。その分値段が高い。グーグルでは、サーバは壊れるものと割り切り、低品質のサーバを大量に調達し、次々と入れ替えていくという方法をとってコストを抑えているという。これはしかし、一部のサーバが壊れても全体が稼働し続けるというシステムを作り上げる技術力が可能にした、発想の転換である。",
@@ -2500,7 +2500,7 @@
     "isbn": "9784153400153",
     "asin": "4153400157",
     "readDate": "2024/07/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0153/9784153400153_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0153/9784153400153_1_2.jpg",
     "highlights": []
   },
   {
@@ -2511,7 +2511,7 @@
     "isbn": "9784296001866",
     "asin": "4296001868",
     "readDate": "2024/07/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1866/9784296001866_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1866/9784296001866_1_2.jpg",
     "highlights": [
       {
         "text": "「私は人が生きていくうえで最も大切なことは使命感を持つことだと思います。そのためにはまず、自分は何者なのか、そのことを深く考える必要があると思います」 「自分にとって何が最も大切なことなのか、絶対に譲ることができないものはなんなのか、そこを突き詰めて自らの強みを発見し、生かす。自分にしかできない、自分の人生を思いっきり生きてほしい。明確な意識があるのとないのとでは、同じ人生を送っても成果は１００倍、１０００倍あるいは１万倍も違うのではないかと私は思います」",
@@ -2579,7 +2579,7 @@
     "isbn": "9784822255077",
     "asin": "4822255077",
     "readDate": "2024/07/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5077/9784822255077.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5077/9784822255077.jpg",
     "highlights": []
   },
   {
@@ -2590,7 +2590,7 @@
     "isbn": "9784873118888",
     "asin": "4873118883",
     "readDate": "2024/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8888/9784873118888.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8888/9784873118888.jpg",
     "highlights": []
   },
   {
@@ -2601,7 +2601,7 @@
     "isbn": "9784065227381",
     "asin": "4065227380",
     "readDate": "2024/07/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7381/9784065227381.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7381/9784065227381.jpg",
     "highlights": [
       {
         "text": "モンテヴェルディ自身は「和音」や「属七」といった用語をまったく使ってはいないが、この「属七の和音／ドミナント・セブンス」の特別な扱いを可能にしたのが、実は今から400年前のモンテヴェルディであった。",
@@ -2669,7 +2669,7 @@
     "isbn": "9784153400191",
     "asin": "415340019X",
     "readDate": "2024/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0191/9784153400191_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0191/9784153400191_1_2.jpg",
     "highlights": [
       {
         "text": "文明社会がますます進み、あれもこれも障害特性とみなされ、〝人間の標準規格〟の基準が厳しくなった未来にはもっと多くの人が治療や支援を必要とするでしょう。そうした果てに、誰もが能力向上のための服薬を求めるようになり、子どもが不適応を起こさないよう遺伝子操作が行われるのが当然の未来が到来したとして……それは肯定して構わないものでしょうか。",
@@ -2725,7 +2725,7 @@
     "isbn": "9784065309506",
     "asin": "4065309506",
     "readDate": "2024/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9506/9784065309506_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9506/9784065309506_1_2.jpg",
     "highlights": []
   },
   {
@@ -2736,7 +2736,7 @@
     "isbn": "9784492047354",
     "asin": "4492047352",
     "readDate": "2024/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7354/9784492047354_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7354/9784492047354_1_7.jpg",
     "highlights": [
       {
         "text": "みんなを等しく便利にした会社の創業者が、結果的に大金持ちになったんや」 ボスの説明に、七海がため息をつく。 「そういうことでしたか。格差を縮めるサービスを提供しているのに、お金持ちだという事実だけが切り出されていたんですね」 「もちろん、金銭的な格差も小さいほうがええで。せやけど、その中身を見ないでむやみに批判するのはあかん。自分の立場を利用してずるくもうけるお金持ちと、みんなの 抱える問題を解決してくれたお金持ちとでは意味が違うんや」",
@@ -2760,7 +2760,7 @@
     "isbn": "9784839976156",
     "asin": "4839976155",
     "readDate": "2024/06/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6156/9784839976156_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6156/9784839976156_1_4.jpg",
     "highlights": []
   },
   {
@@ -2771,7 +2771,7 @@
     "isbn": "9784815618667",
     "asin": "4815618666",
     "readDate": "2024/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8667/9784815618667_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8667/9784815618667_1_3.jpg",
     "highlights": []
   },
   {
@@ -2782,7 +2782,7 @@
     "isbn": "9784153400238",
     "asin": "4153400238",
     "readDate": "2024/05/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0238/9784153400238_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0238/9784153400238_1_2.jpg",
     "highlights": [
       {
         "text": "また考え方として最も影響を受けたのは、スタニスワフ・レムの『ソラリス』や『砂漠の惑星』です。一つひとつは非力で小さな虫みたいなロボットが、集まることで全体として大きな力をもつ、あるいは海が知性をもってしまうといった概念には、非常にアンチヒューマノイド的なところがあって。たとえばアシモフの『われはロボット』は完全にヒューマノイド的な機械の世界ですが、『ソラリス』がそれとは全く異なる世界を提示していることに衝撃を受けた。人間以外の知性体がいるという世界観には非常に影響を受けましたね。",
@@ -2838,7 +2838,7 @@
     "isbn": "9784334039899",
     "asin": "4334039898",
     "readDate": "2024/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9899/9784334039899.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9899/9784334039899.jpg",
     "highlights": [
       {
         "text": "ちなみに、バッタとイナゴは相変異を示すか示さないかで区別されている。相変異を示すものがバッタ（ust）、示さないものがイナゴ（Grasshopper）と呼ばれる。日本では、オンブバッタやショウリョウバッタなどと呼ばれるが、厳密にはイナゴの仲間である。ustの由来はラテン語の「焼野原」だ。彼らが過ぎ去った後は、緑という緑が全て消えることからきている。",
@@ -2862,7 +2862,7 @@
     "isbn": "9784274229497",
     "asin": "4274229491",
     "readDate": "2024/05/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9497/9784274229497_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9497/9784274229497_1_3.jpg",
     "highlights": []
   },
   {
@@ -2873,7 +2873,7 @@
     "isbn": "9784087213126",
     "asin": "4087213129",
     "readDate": "2024/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3126/9784087213126_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3126/9784087213126_1_8.jpg",
     "highlights": [
       {
         "text": "『痴人の愛』は、元はといえば「大阪朝日新聞」の連載小説である。当時の新聞の主なターゲットは、新中間層、つまりは毎日通勤するサラリーマンだった（山本武利『近代日本の新聞読者層』）。だとすれば、「田舎から出てきた真面目なサラリーマンが、カフェで働く美少女を引き取る」というあらすじは、まさに谷崎潤一郎がサラリーマンに向けて書いた妄想物語そのものだったのではないだろうか。",
@@ -2941,7 +2941,7 @@
     "isbn": "9784296070787",
     "asin": "4296070789",
     "readDate": "2024/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0787/9784296070787_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0787/9784296070787_1_2.jpg",
     "highlights": []
   },
   {
@@ -2952,7 +2952,7 @@
     "isbn": "9784061498075",
     "asin": "406149807X",
     "readDate": "2024/04/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8075/9784061498075.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8075/9784061498075.jpg",
     "highlights": []
   },
   {
@@ -2963,7 +2963,7 @@
     "isbn": "9784826902434",
     "asin": "4826902433",
     "readDate": "2024/04/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2434/9784826902434_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2434/9784826902434_1_2.jpg",
     "highlights": []
   },
   {
@@ -2974,7 +2974,7 @@
     "isbn": "9784049155983",
     "asin": "4049155982",
     "readDate": "2024/04/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5983/9784049155983_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5983/9784049155983_1_4.jpg",
     "highlights": []
   },
   {
@@ -2985,7 +2985,7 @@
     "isbn": "9784062883184",
     "asin": "406288318X",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3184/9784062883184.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3184/9784062883184.jpg",
     "highlights": [
       {
         "text": "主語が一人称で書かれているのは、ドイツ文学によく見られる「教養小説」（主人公の自己形成の過程を描いた小説） のスタイルだ。カリスマ的指導者にふさわしくない過去は書き換えられているため、実際はかなり優柔不断で自堕落でもあったヒトラーの実像は伝わってこない。反対に、早くから政治意識に目覚め、生来の弁舌の才をもって政治家への道を歩む、偽りのヒトラー像が提示される。現代の読者がこの本をひもとくときは、そのことに注意する必要があるだろう。",
@@ -3033,7 +3033,7 @@
     "isbn": "9784103145363",
     "asin": "4103145366",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784103145363_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784103145363_1_2.jpg",
     "highlights": [
       {
         "text": "さても読者の皆様方よ。コロナを 巫山戯 て書きました。お怒りでしたらお詫びをしますが、作者の言い分申し上げます。そもそもわれわれ日本人、生真面目過ぎていけません。苦しむ人の多いなか、コロナで冗談言うとは何ごと、不謹慎も甚だしいと、眼を三角にするお方、これぞまことの日本人、ほんとにほんとにご苦労さん、言い返す気は御座いませんが、これはあくまで世間の常識一般人の考えで、文学者まで追随し、コロナに関する生真面目さ、こりゃまあ一体なんたるコロナ、小説家としてだらしない。あくまでわたしの考えですが、文学やるなら常識捨てて、世間の糾弾身に引き受けて、何でも書くのがまともな作家、ここは良識退けて、不真面目さをこそ追究せねば、なぜになったか文学者、純文学誌もなさけない、コロナとなれば及び腰、先生これはやめましょう。なんの小生平気の平左、言われりゃまだ書く反骨精神、笑って続けるコロちゃんづくし。コロナ、コロナ、どうしてあなたはコロナなの。コロナ切なや、遣る瀬なや。コロナ、コロナ、コロナ苦いかしょっぱいか。コロナ、コロナで半年暮らす、後の半年ゃ寝て暮らす。コロナ居良いか住み良いか。",
@@ -3053,7 +3053,7 @@
     "isbn": "9784820729631",
     "asin": "4820729632",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9631/9784820729631_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9631/9784820729631_1_2.jpg",
     "highlights": []
   },
   {
@@ -3064,7 +3064,7 @@
     "isbn": "9784569692920",
     "asin": "4569692923",
     "readDate": "2024/04/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5696/56969292.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5696/56969292.jpg",
     "highlights": []
   },
   {
@@ -3075,7 +3075,7 @@
     "isbn": "9784822233488",
     "asin": "4822233480",
     "readDate": "2024/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3488/9784822233488.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3488/9784822233488.jpg",
     "highlights": []
   },
   {
@@ -3086,7 +3086,7 @@
     "isbn": "9784049153491",
     "asin": "4049153491",
     "readDate": "2024/03/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3491/9784049153491_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3491/9784049153491_1_3.jpg",
     "highlights": []
   },
   {
@@ -3097,7 +3097,7 @@
     "isbn": "9784163917689",
     "asin": "4163917683",
     "readDate": "2024/03/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7689/9784163917689_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7689/9784163917689_1_5.jpg",
     "highlights": [
       {
         "text": "ソフトウェア開発に限らず、世界から日本を見ると「生産性の悪さ」で〝大損〟している分野が非常に多い。それは単にＤＸ（デジタルトランスフォーメーション） 化が遅れているといった次元の話ではなく、生産性の要となるマインドセット、チームビルディングにまだまだ大きな改善の余地があるのだ。",
@@ -3193,7 +3193,7 @@
     "isbn": "9784065348253",
     "asin": "4065348250",
     "readDate": "2024/03/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8253/9784065348253_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8253/9784065348253_1_2.jpg",
     "highlights": []
   },
   {
@@ -3204,7 +3204,7 @@
     "isbn": "9784480823830",
     "asin": "4480823832",
     "readDate": "2024/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3830/9784480823830_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3830/9784480823830_1_3.jpg",
     "highlights": []
   },
   {
@@ -3215,7 +3215,7 @@
     "isbn": "9784309412443",
     "asin": "4309412440",
     "readDate": "2024/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2443/9784309412443_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2443/9784309412443_1_3.jpg",
     "highlights": []
   },
   {
@@ -3226,7 +3226,7 @@
     "isbn": "9784791704415",
     "asin": "479170441X",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784791704415_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784791704415_1_2.jpg",
     "highlights": []
   },
   {
@@ -3237,7 +3237,7 @@
     "isbn": "9784480094254",
     "asin": "4480094253",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4254/9784480094254.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4254/9784480094254.jpg",
     "highlights": []
   },
   {
@@ -3248,7 +3248,7 @@
     "isbn": "9784480097187",
     "asin": "448009718X",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7187/9784480097187.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7187/9784480097187.jpg",
     "highlights": []
   },
   {
@@ -3259,7 +3259,7 @@
     "isbn": "9784054069756",
     "asin": "4054069754",
     "readDate": "2024/02/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9756/9784054069756_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9756/9784054069756_1_5.jpg",
     "highlights": [
       {
         "text": "そもそも、不動産投資が、「大丈夫」なものでも「有利」なものでもないことは、不動産業者が自ら物件を保有するのではなく、客を探して売っている状況が雄弁に物語っている。「サラリーマンでも大家さん」「不動産投資で不労所得」といった甘言に乗るのは賢くないから、気をつけろ。",
@@ -3327,7 +3327,7 @@
     "isbn": "9784022952523",
     "asin": "4022952520",
     "readDate": "2024/02/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2523/9784022952523_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2523/9784022952523_1_3.jpg",
     "highlights": []
   },
   {
@@ -3338,7 +3338,7 @@
     "isbn": "9784798179421",
     "asin": "4798179426",
     "readDate": "2024/01/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9421/9784798179421_1_133.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9421/9784798179421_1_133.jpg",
     "highlights": [
       {
         "text": "会員特典データのご案内 本書の読者特典として、「用語集」をご提供致します。本書の理解にご活用ください。 会員特典データは、以下のサイトからダウンロードして入手いただけます。 https://www.shoeisha.co.jp/book/present/9784798179421 ※会員特典データのファイルは圧縮されています。ダウンロードしたファイルをダブルクリックすると、ファイルが解凍され、利用いただけます。 ※会員特典データのダウンロードには、SHOEISHA iD（翔泳社が運営する無料の会員制度）への会員登録が必要です。詳しくは、Webサイトをご覧ください。 ※会員特典データに関する権利は著者および株式会社翔泳社が所有しています。許可なく配布したり、Webサイトに転載したりすることはできません。 ※会員特典データの提供は予告なく終了することがあります。予めご了承ください。 ※会員特典データの提供にあたっては正確な記述につとめましたが、著者や出版社などのいずれも、その内容に対してなんらかの保証をするものではなく、内容やサンプルに基づくいかなる運用結果に関してもいっさいの責任を負いません。",
@@ -3366,7 +3366,7 @@
     "isbn": "9784101035413",
     "asin": "4101035415",
     "readDate": "2024/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5413/9784101035413_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5413/9784101035413_1_2.jpg",
     "highlights": [
       {
         "text": "我々は妥協を重ねながら生きている。 何かやりたいことをあきらめたり、何かやるべきことから眼を 背けているだけではない。 どういうことなのか。なぜこうなってしまうのか。何か違う、いや、そうじゃないんだ……。そのように感じられる何ごとかについて、「まぁ、いいか」と自分に言い聞かせながら、あるいはむしろ、自分にそう言い聞かせるよう 心がけながら 生きている。 この本は、そうした妥協に 抗いながら書かれた。自分が感じてきた、 曖昧 な、ボンヤリとした何かに姿形を与えるには、それが必要だった。",
@@ -3506,7 +3506,7 @@
     "isbn": "9784799320235",
     "asin": "4799320238",
     "readDate": "2023/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0235/9784799320235_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0235/9784799320235_1_2.jpg",
     "highlights": []
   },
   {
@@ -3517,7 +3517,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2023/12/18",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2367992/3f526908-04c9-4594-831d-d6d875b57a32.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2367992/3f526908-04c9-4594-831d-d6d875b57a32.png",
     "highlights": []
   },
   {
@@ -3528,7 +3528,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2023/12/13",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368019/c9f43e45-c909-4424-a625-c8c4e9b25130.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368019/c9f43e45-c909-4424-a625-c8c4e9b25130.png",
     "highlights": []
   },
   {
@@ -3539,7 +3539,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2023/11/15",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368045/ae67fc6e-8f77-4024-bf8a-3e9867c85409.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368045/ae67fc6e-8f77-4024-bf8a-3e9867c85409.png",
     "highlights": []
   },
   {
@@ -3550,7 +3550,7 @@
     "isbn": "9784047376915",
     "asin": "4047376914",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6915/9784047376915_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6915/9784047376915_1_2.jpg",
     "highlights": []
   },
   {
@@ -3561,7 +3561,7 @@
     "isbn": "9784047373112",
     "asin": "4047373117",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3112/9784047373112_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3112/9784047373112_1_3.jpg",
     "highlights": []
   },
   {
@@ -3572,7 +3572,7 @@
     "isbn": "9784047358782",
     "asin": "4047358789",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8782/9784047358782.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8782/9784047358782.jpg",
     "highlights": []
   },
   {
@@ -3583,7 +3583,7 @@
     "isbn": "9784153400146",
     "asin": "4153400149",
     "readDate": "2023/10/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0146/9784153400146_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0146/9784153400146_1_2.jpg",
     "highlights": []
   },
   {
@@ -3594,7 +3594,7 @@
     "isbn": "9784153400092",
     "asin": "4153400092",
     "readDate": "2023/10/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784153400092_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784153400092_1_2.jpg",
     "highlights": []
   },
   {
@@ -3605,7 +3605,7 @@
     "isbn": "9784480432933",
     "asin": "4480432930",
     "readDate": "2023/10/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2933/9784480432933.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2933/9784480432933.jpg",
     "highlights": []
   },
   {
@@ -3616,7 +3616,7 @@
     "isbn": "9784041141861",
     "asin": "4041141869",
     "readDate": "2023/10/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1861/9784041141861_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1861/9784041141861_1_3.jpg",
     "highlights": []
   },
   {
@@ -3627,7 +3627,7 @@
     "isbn": "9784582766721",
     "asin": "4582766722",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6721/9784582766721.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6721/9784582766721.jpg",
     "highlights": []
   },
   {
@@ -3638,7 +3638,7 @@
     "isbn": "9784022518378",
     "asin": "4022518375",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8378/9784022518378_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8378/9784022518378_1_7.jpg",
     "highlights": [
       {
         "text": "答えがわからない。押したのはいいけれど思い出せない。問題文の先を予測してみたが見当違いだった。そんなことは頻繁にある。でも僕は恥ずかしがらず、堂々と誤答を口にした。学校のテストで空欄を作ることがもったいないように、クイズをしているのに何も答えないのはもったいない。間違っていると思っていても、とりあえず口に出してみる。間違っているのは誤答することではなく、恥ずかしがって何も答えないことだ。 気がつくと、クイズの外でも「恥ずかしい」と思うことがあまりなくなっていた。クイズも現実世界も同じだ。なんでもやってみるに越したことはない。誰かに笑われたって構わない。恥ずかしいという気持ちのせいで自分の可能性を閉ざしてしまうことの方がもったいない。",
@@ -3658,7 +3658,7 @@
     "isbn": "9784087520279",
     "asin": "4087520277",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0875/08752027.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0875/08752027.jpg",
     "highlights": [
       {
         "text": "これは哲学者のマッグの書いた「 阿呆 の言葉」の中の何章かです。―― × 阿呆はいつも彼以外のものを阿呆であると信じている。 × 我々の自然を愛するのは自然は我々を憎んだり 嫉妬 したりしないためもないことはない。 × もっとも賢い生活は一時代の習慣を 軽蔑 しながら、しかもそのまた習慣を少しも破らないように暮らすことである。 × 我々のもっとも誇りたいものは我々の持っていないものだけである。 × 何びとも偶像を破壊することに異存を持っているものはない。同時にまた何びとも偶像になることに異存を持っているものはない。しかし偶像の台座の上に安んじてすわっていられるものはもっとも神々に恵まれたもの、――阿呆か、悪人か、英雄かである。（クラバックはこの章の上へ 爪 の 痕 をつけていました。） × 我々の生活に必要な思想は三千年 前 に尽きたかもしれない。我々はただ古い 薪 に新しい炎を加えるだけであろう。 × 我々の特色は我々自身の意識を超越するのを常としている。 × 幸福は苦痛を伴い、平和は 倦怠 を伴うとすれば、――？ × 自己を弁護することは他人を弁護することよりも困難である。疑うものは弁護士を見よ。 × 矜誇［＃ルビの「きょうか」はママ］、愛欲、疑惑――あらゆる罪は三千年来、この三者から発している。同時にまたおそらくはあらゆる徳も。 × 物質的欲望を減ずることは必ずしも平和をもたらさない。我々は平和を得るためには精神的欲望も減じなければならぬ。（クラバックはこの章の上にも 爪 の 痕 を残していました。） × 我々は人間よりも不幸である。人間は 河童 ほど進化… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -3674,7 +3674,7 @@
     "isbn": "9784798068169",
     "asin": "4798068160",
     "readDate": "2023/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8169/9784798068169_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8169/9784798068169_1_4.jpg",
     "highlights": []
   },
   {
@@ -3685,7 +3685,7 @@
     "isbn": "9784569820934",
     "asin": "456982093X",
     "readDate": "2023/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0934/9784569820934_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0934/9784569820934_1_2.jpg",
     "highlights": [
       {
         "text": "多くの人は「感情的な自分」を「自分自身」だと思い込んでいますが、それは「ゴミが散らかった部屋」を「普通」だと思い込んでいる汚部屋の住人と同じ心理に陥っています。その状態では、なかなか自分が感情的になっている、ということに気づくことができないでしょう。「怒っていること」が当たり前の状態で何年も、何十年も過ごして来た人は、自分が怒っているということに気づくことができなくなるのです。 これが、「心の基準点」を明るく、静かな状態に保っておいたほうがいい理由です。そして、「体質改善を目指す行」というのは、この「心の基準点」をできるだけ高いところに保つために行うものです。明るく、爽やかで、深い呼吸をして心が落ち着いた状態にある自分を「基準」にしておく。そうすれば日常の中で、小さな怒り、小さなイライラ、小さな不安が生じたときにすぐ気づくことができるし、小さい段階で見つけることによって、容易に払えるようになるのです。",
@@ -3705,7 +3705,7 @@
     "isbn": "9784150506025",
     "asin": "4150506027",
     "readDate": "2023/10/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6025/9784150506025_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6025/9784150506025_1_3.jpg",
     "highlights": [
       {
         "text": "不平等な社会で頂点に立つ人びとは、自分の成功は道徳的に正当なものだと思い込みたがる。能力主義の社会において、これは次のことを意味する。つまり、勝者は自らの才能と努力によって成功を勝ち取ったと信じなければならないということだ。 逆説的だが、これこそ不正に手を染める親が子供に与えたかった贈り物だ。彼らの本当の気がかりが、子供を裕福に暮らせるようにしてやることに尽きるとすれば、子供に信託ファンドを与えておけばよかったはずだ。だが、彼らはほかの何かを望んでいた。それは、名門大学への入学が与えてくれる能力主義の威信である。",
@@ -3729,7 +3729,7 @@
     "isbn": "9784569673820",
     "asin": "4569673821",
     "readDate": "2023/09/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3820/9784569673820.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3820/9784569673820.jpg",
     "highlights": [
       {
         "text": "当たり前の議論が通らなくなるのは、どこかで皆さんが遠慮するからです。社会が一つの方向に漂流してしまうときこそ、それをくい止めるのが宗教の役割なんです",
@@ -3765,7 +3765,7 @@
     "isbn": "9784152102133",
     "asin": "4152102136",
     "readDate": "2023/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2133/9784152102133_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2133/9784152102133_1_2.jpg",
     "highlights": []
   },
   {
@@ -3776,7 +3776,7 @@
     "isbn": "9784150315375",
     "asin": "415031537X",
     "readDate": "2023/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5375/9784150315375_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5375/9784150315375_1_3.jpg",
     "highlights": [
       {
         "text": "信仰とは 生 への不安感を解消し安寧を得るための手段であり、なかでも他者を推す＝祀るロールは人生をやり過ごす効果的な酩酊ツールです。その感情が酩酊であると分かっていても、全ての信仰を棄教して生きるには人生はあまりに長く、全てに醒めて生きるメリットはあまりに少ない。人間は多かれ少なかれ何らかの存在に酩酊して生きており、それはアイドルのような信仰される側の存在であっても同じである場合が多いです。",
@@ -3792,7 +3792,7 @@
     "isbn": "9784866995076",
     "asin": "4866995076",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5076/9784866995076_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5076/9784866995076_1_2.jpg",
     "highlights": []
   },
   {
@@ -3803,7 +3803,7 @@
     "isbn": "9784866993997",
     "asin": "4866993995",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3997/9784866993997_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3997/9784866993997_1_2.jpg",
     "highlights": []
   },
   {
@@ -3814,7 +3814,7 @@
     "isbn": "9784866992150",
     "asin": "4866992158",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2150/9784866992150.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2150/9784866992150.jpg",
     "highlights": []
   },
   {
@@ -3825,7 +3825,7 @@
     "isbn": "9784864727327",
     "asin": "4864727325",
     "readDate": "2023/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7327/9784864727327.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7327/9784864727327.jpg",
     "highlights": []
   },
   {
@@ -3836,7 +3836,7 @@
     "isbn": "9784049148671",
     "asin": "4049148676",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8671/9784049148671_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8671/9784049148671_1_2.jpg",
     "highlights": []
   },
   {
@@ -3847,7 +3847,7 @@
     "isbn": "9784049139365",
     "asin": "4049139367",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9365/9784049139365_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9365/9784049139365_1_2.jpg",
     "highlights": []
   },
   {
@@ -3858,7 +3858,7 @@
     "isbn": "9784094531268",
     "asin": "4094531262",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1268/9784094531268_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1268/9784094531268_1_3.jpg",
     "highlights": []
   },
   {
@@ -3869,7 +3869,7 @@
     "isbn": "9784049150148",
     "asin": "404915014X",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0148/9784049150148_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0148/9784049150148_1_2.jpg",
     "highlights": []
   },
   {
@@ -3880,7 +3880,7 @@
     "isbn": "9784049144963",
     "asin": "4049144964",
     "readDate": "2023/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4963/9784049144963_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4963/9784049144963_1_6.jpg",
     "highlights": []
   },
   {
@@ -3891,7 +3891,7 @@
     "isbn": "9784049144956",
     "asin": "4049144956",
     "readDate": "2023/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4956/9784049144956_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4956/9784049144956_1_4.jpg",
     "highlights": [
       {
         "text": "改めて振り返って。この『あした、 裸足 でこい。』４巻は、自分の中でもちょっと特別な、チャレンジもある巻だったなと思います。 ついに 坂本 自身が自分の生き方に向き合う。新たな小惑星を探す。 外側だけを見れば、シリーズ後半にふさわしいイベントが目白押しです。 自分でも、書いていてとても楽しかった。 けれど多分、僕がこの巻で一番 描きたかったのは、 二 斗 と 坂本 の関係の変化だったんだろうなと思います。 持っている能力ゆえに、孤独に戦っていた 二 斗。 凡人である 坂本 が、本当の意味でその隣に立つまでが、この４巻のテーマだったかなと。 内容について多くは触れませんが、そこを 描きつつ皆さんにも楽しんでもらえそうな話にする、というのが、今回僕にとって大きな挑戦だったように思う。 どうでしたかね？ 楽しんでもらえたかな、伝わったかな。 挑戦の結果やいかに……。 僕自身としては、このうえなく 良い形で描けたんじゃないかと自負しています。 そうそう、今回執筆中にキャラが勝手に動きまくったのもうれしかったですね。 もちろん、原稿作業前にプロットは立てますし、大枠でストーリーは決めています。 ただこの４巻では 坂本 も 二 斗 も 真琴 も、ゲストキャラの 七森 さえも、いきなりプロットと違う形で感情を発露させまくってきたんだよな。 笑ったり怒ったりバチバチしたり。 こういうの、予想外でびっくりしますし本当に楽しいんです。 特に大きかったのは 真琴 ですね。 読んでくれた方は分かると思いますが、面接シーン。 あそこ、あんな風にするつもり全然なかったんです。もっと普通に色々匂わせる程度のつもりだったのに、 真琴 が勝手に超ストレートに言ってしまった。ああいうの、小説家 冥利 に尽きる瞬間です。 ということで、『あした、 裸足 でこい… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -3911,7 +3911,7 @@
     "isbn": "9784152102157",
     "asin": "4152102152",
     "readDate": "2023/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2157/9784152102157_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2157/9784152102157_1_2.jpg",
     "highlights": [
       {
         "text": "ジラールは、私たちが欲しがるもののほとんどは、 模倣 によるものであって、内在するものではないとした。人間は──真似ることを通して──ほかの人が欲しがるものと同じものを 欲しがることを学ぶ。同じ言語を話し、同じ文化的規範によって行動することを学ぶのと同じである。真似は、社会において人々が 公 に認める以上に大きな役割を果たしている。",
@@ -3979,7 +3979,7 @@
     "isbn": "9784845921423",
     "asin": "4845921421",
     "readDate": "2023/08/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1423/9784845921423_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1423/9784845921423_1_3.jpg",
     "highlights": []
   },
   {
@@ -3990,7 +3990,7 @@
     "isbn": "9784845637966",
     "asin": "4845637960",
     "readDate": "2023/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7966/9784845637966_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7966/9784845637966_1_5.jpg",
     "highlights": []
   },
   {
@@ -4001,7 +4001,7 @@
     "isbn": "9784003315811",
     "asin": "4003315812",
     "readDate": "2023/08/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5811/9784003315811_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5811/9784003315811_1_3.jpg",
     "highlights": [
       {
         "text": "英雄とか偉人とかいわれている人々の中で、本当に尊敬が出来るのは、人類の進歩に役立った人だけだ。そして、彼らの非凡な事業のうち、真に値打のあるものは、ただこの流れに沿って行われた事業だけだ。（",
@@ -4017,7 +4017,7 @@
     "isbn": "9784065241271",
     "asin": "4065241278",
     "readDate": "2023/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1271/9784065241271_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1271/9784065241271_1_2.jpg",
     "highlights": []
   },
   {
@@ -4028,7 +4028,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2023/07/29",
-    "thumnailImage": "https://m.media-amazon.com/images/I/514RatodeeL._AC_SL1500_.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/514RatodeeL._AC_SL1500_.jpg",
     "highlights": [
       {
         "text": "特別な才能がある 素敵な音楽を作ったり、人を感動させる物語が書けたり、生活に役立つ発明が出来たり、容姿端麗で写真を撮るだけでお金になったりという、そんな銀のスプーンを最初からくわえて生まれてきた、とんでもなくラッキーな方は、その才能によってリッチになれます。",
@@ -4052,7 +4052,7 @@
     "isbn": "9784811808505",
     "asin": "4811808509",
     "readDate": "2023/07/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784811808505_1_77.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784811808505_1_77.jpg",
     "highlights": []
   },
   {
@@ -4063,7 +4063,7 @@
     "isbn": "9784046058683",
     "asin": "4046058684",
     "readDate": "2023/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8683/9784046058683_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8683/9784046058683_1_2.jpg",
     "highlights": []
   },
   {
@@ -4074,7 +4074,7 @@
     "isbn": "9784087212686",
     "asin": "4087212688",
     "readDate": "2023/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2686/9784087212686_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2686/9784087212686_1_7.jpg",
     "highlights": [
       {
         "text": "タイアップの話が進む中で、電通は『ラピュタ』に関するキャラクターや映像の使用について、細かな条件をリストアップした契約書を用意してきた。しかし高畑は、この契約書の記載項目をほぼすべて却下。許可するのは、『天空の城ラピュタ』というロゴのみとし、そのほかのキャラクターの絵や映像については、都度協議して使用を検討することを条件とした。高畑がこのような厳しい条件を提示した背景には、企業とタイアップをすることによって、それまで商業主義に侵されなかった映画の自由が失われることへの危惧、そして、『ラピュタ』をその第一号作品にするべきではないという考えがあったという。",
@@ -4106,7 +4106,7 @@
     "isbn": "9784001140125",
     "asin": "4001140128",
     "readDate": "2023/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0125/9784001140125.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0125/9784001140125.jpg",
     "highlights": [
       {
         "text": "「ああわたくしもそれをもとめている。おまえはおまえの 切符 をしっかりもっておいで。そして一しんに 勉強 しなけぁいけない。おまえは 化学 をならったろう、水は 酸素 と 水素 からできているということを知っている。いまはたれだってそれを 疑 やしない。 実験 してみるとほんとうにそうなんだから。けれども 昔 はそれを 水銀 と 塩 でできていると 言ったり、 水銀 と 硫黄 でできていると 言ったりいろいろ 議論 したのだ。みんながめいめいじぶんの 神さまがほんとうの神さまだというだろう、けれどもお互いほかの 神さまを 信ずる人たちのしたことでも 涙 がこぼれるだろう。それからぼくたちの心がいいとかわるいとか 議論 するだろう。そして 勝負 がつかないだろう。けれども、もしおまえがほんとうに 勉強 して 実験 でちゃんとほんとうの考えと、うその考えとを分けてしまえば、その 実験 の 方法 さえきまれば、もう 信仰 も 化学 と同じようになる。けれども、ね、ちょっとこの本をごらん、いいかい、これは 地理 と 歴史 の 辞典 だよ。",
@@ -4122,7 +4122,7 @@
     "isbn": "9784063765786",
     "asin": "4063765784",
     "readDate": "2023/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784063765786.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784063765786.jpg",
     "highlights": []
   },
   {
@@ -4133,7 +4133,7 @@
     "isbn": "9784334034252",
     "asin": "433403425X",
     "readDate": "2023/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403425.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403425.jpg",
     "highlights": []
   },
   {
@@ -4144,7 +4144,7 @@
     "isbn": "9784046055477",
     "asin": "4046055472",
     "readDate": "2023/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5477/9784046055477_1_10.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5477/9784046055477_1_10.jpg",
     "highlights": []
   },
   {
@@ -4155,7 +4155,7 @@
     "isbn": "9784144072260",
     "asin": "4144072266",
     "readDate": "2023/07/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2260/9784144072260.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2260/9784144072260.jpg",
     "highlights": []
   },
   {
@@ -4166,7 +4166,7 @@
     "isbn": "9784198654825",
     "asin": "4198654824",
     "readDate": "2023/07/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4825/9784198654825_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4825/9784198654825_1_3.jpg",
     "highlights": [
       {
         "text": "日々の運動習慣に加えて、予防医療も重要だ。日本はこの予防医療の考えがかなり遅れている。大半の病気は、事前の対処次第でいくらでも回避できるのだ。 たとえば日本人に多い胃がん。日本人がかかる胃がんのうち、 98％はピロリ菌感染によるものだ。このピロリ菌は薬を飲めば簡単に除去できる。ちょっとした手間と出費だけで胃がんリスクは激減するのだが、まだまだみんなのピロリ菌に対する認識が低い。 「万病の元」と言われている歯周病もそうだ。海外に比べて日本人は歯周病を軽視しすぎだ。歯周病は口臭の原因になるだけではない。心筋梗塞や脳梗塞など血管系疾患に直結する。だから海外ではデンタルケアに対する意識が高く、幼いころから徹底的に教育されている。 ところが日本はどうだろう。定期的に歯科医に行き、歯石などをクリーニングしている人はどれだけいるだろうか。歯周病になってから、いざ事態が深刻になってから、あわてて手間と治療費を注ぎ込むなんて馬鹿げている。 残念ながら、生命保険や医療保険は、災いを避けてくれる魔除けのお守りではない。 山崎さんが言うように、いざというときは公的医療保険制度が使えるのだからそっちはそれで十分だ。それより習慣的な運動や予防医療にお金を使うべきだ。",
@@ -4198,7 +4198,7 @@
     "isbn": "9784198627058",
     "asin": "4198627053",
     "readDate": "2023/06/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7058/9784198627058.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7058/9784198627058.jpg",
     "highlights": []
   },
   {
@@ -4209,7 +4209,7 @@
     "isbn": "9784478107041",
     "asin": "4478107041",
     "readDate": "2023/06/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784478107041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784478107041.jpg",
     "highlights": []
   },
   {
@@ -4220,7 +4220,7 @@
     "isbn": "9784620326122",
     "asin": "4620326127",
     "readDate": "2023/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6122/9784620326122.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6122/9784620326122.jpg",
     "highlights": []
   },
   {
@@ -4231,7 +4231,7 @@
     "isbn": "9784041061763",
     "asin": "4041061768",
     "readDate": "2023/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1763/9784041061763.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1763/9784041061763.jpg",
     "highlights": []
   },
   {
@@ -4242,7 +4242,7 @@
     "isbn": "9784334046002",
     "asin": "4334046002",
     "readDate": "2023/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6002/9784334046002_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6002/9784334046002_1_3.jpg",
     "highlights": [
       {
         "text": "大学生の彼らは趣味や娯楽について、てっとり早く、短時間で、「何かをモノにしたい」「何かのエキスパートになりたい」と思っている。彼らはオタクに〝憧れている〟のだそうだ。 ところが、彼らは",
@@ -4286,7 +4286,7 @@
     "isbn": "9784087212334",
     "asin": "4087212335",
     "readDate": "2023/05/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2334/9784087212334_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2334/9784087212334_1_4.jpg",
     "highlights": [
       {
         "text": "彼らの行動の裏側にあるのは、個人として培った上昇志向だけではないように思える。そこに潜んでいるのは、ビジネスパーソンの中に「新自由主義」が内面化され、絶えずＳＮＳなどで周囲との比較を強いられて、なおかつ社会の中で生き残るために「うまくやる」ことが求められた結果として、終わりなき成長に駆り立てられる……という時代精神ではないだろうか。",
@@ -4330,7 +4330,7 @@
     "isbn": "9784086314800",
     "asin": "4086314800",
     "readDate": "2023/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784086314800_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784086314800_1_5.jpg",
     "highlights": []
   },
   {
@@ -4341,7 +4341,7 @@
     "isbn": "9784798627601",
     "asin": "4798627607",
     "readDate": "2023/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7601/9784798627601_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7601/9784798627601_1_4.jpg",
     "highlights": []
   },
   {
@@ -4352,7 +4352,7 @@
     "isbn": "9784569534077",
     "asin": "4569534074",
     "readDate": "2023/03/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4077/9784569534077.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4077/9784569534077.jpg",
     "highlights": []
   },
   {
@@ -4363,7 +4363,7 @@
     "isbn": "9784061385498",
     "asin": "4061385496",
     "readDate": "2023/02/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5498/9784061385498.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5498/9784061385498.jpg",
     "highlights": []
   },
   {
@@ -4374,7 +4374,7 @@
     "isbn": "9784763140142",
     "asin": "4763140140",
     "readDate": "2023/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784763140142_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784763140142_1_2.jpg",
     "highlights": []
   },
   {
@@ -4385,7 +4385,7 @@
     "isbn": "9784798068534",
     "asin": "4798068535",
     "readDate": "2023/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8534/9784798068534_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8534/9784798068534_1_5.jpg",
     "highlights": []
   },
   {
@@ -4396,7 +4396,7 @@
     "isbn": "9784062176200",
     "asin": "4062176203",
     "readDate": "2023/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6200/9784062176200.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6200/9784062176200.jpg",
     "highlights": [
       {
         "text": "私が研究者からマッキンゼーへと転職して、初めてのプロジェクトを担当してから現在にいたるまで、チームづくりにおいて非常に役立っているコンセプトがある。 それこそが「チームアプローチによる問題解決」だ（以下、「チームアプローチ」と記す）。「チームアプローチ」とは端的にいえば、「よいチーム」を継続的に、システマチックに何度でも再現するために考え出された組織づくりの概念である。 この「チームアプローチ」に関しては、マッキンゼーのパートナーであったジョン・Ｒ・カッツェンバックとダグラス・Ｋ・スミスが、『「高業績チーム」の知恵─企業を革新する自己実現型組織』（ダイヤモンド社刊） に詳しく記している。 カッツェンバックらは、さまざまなプロジェクトのケーススタディを通じて、「まあまあ」よい成果ではなく、「抜きんでた」成果をあげたチームには、共通の特徴があることを発見した。 「よいチーム」はたいていの場合、 1 少人数である 2 メンバーが互いに補完的なスキルを有する 3 共通の目的とその達成に責任を持つ 4 問題解決のためのアプローチの方法を共有している 5 メンバーの相互責任がある という５つの大きな共通点を持つことを見出した。 この５つの共通する特徴を、チームづくりに活かすというのがチームアプローチの基本的な考え方である。",
@@ -4416,7 +4416,7 @@
     "isbn": "9784094530612",
     "asin": "4094530614",
     "readDate": "2023/02/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0612/9784094530612_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0612/9784094530612_1_3.jpg",
     "highlights": []
   },
   {
@@ -4427,7 +4427,7 @@
     "isbn": "9784065296028",
     "asin": "4065296021",
     "readDate": "2023/02/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6028/9784065296028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6028/9784065296028.jpg",
     "highlights": [
       {
         "text": "「運命がカードを切り、わたしたちが勝負する」──。ショーペンハウアーによれば、人生はいつも思いどおりにはならず、ぎりぎりの勝負の連続である（『幸福について』第五章第四八節、邦訳三二八頁）。",
@@ -4463,7 +4463,7 @@
     "isbn": "9784837928447",
     "asin": "4837928447",
     "readDate": "2023/02/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8447/9784837928447.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8447/9784837928447.jpg",
     "highlights": [
       {
         "text": "独学が長続きしないのも成果が出にくいのも、要するに「計画どおりに進まない」からです。 そして多くの場合、その原因は、じつは「計画を立てる」段階ですでに問題があり、その問題が放置されたことにあります。要するに、 「計画どおりに進まないのは、計画そのものが予定どおりに進むような設計になっていないから」",
@@ -4503,7 +4503,7 @@
     "isbn": "9784046043672",
     "asin": "4046043679",
     "readDate": "2023/02/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3672/9784046043672_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3672/9784046043672_1_7.jpg",
     "highlights": []
   },
   {
@@ -4514,7 +4514,7 @@
     "isbn": "9784873116303",
     "asin": "4873116309",
     "readDate": "2023/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6303/9784873116303.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6303/9784873116303.jpg",
     "highlights": []
   },
   {
@@ -4525,7 +4525,7 @@
     "isbn": "9784000614139",
     "asin": "4000614134",
     "readDate": "2023/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4139/9784000614139.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4139/9784000614139.jpg",
     "highlights": []
   },
   {
@@ -4536,7 +4536,7 @@
     "isbn": "9784046050298",
     "asin": "4046050292",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0298/9784046050298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0298/9784046050298.jpg",
     "highlights": []
   },
   {
@@ -4547,7 +4547,7 @@
     "isbn": "9784046053770",
     "asin": "4046053771",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3770/9784046053770_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3770/9784046053770_1_4.jpg",
     "highlights": []
   },
   {
@@ -4558,7 +4558,7 @@
     "isbn": "9784845636846",
     "asin": "4845636840",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784845636846_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784845636846_1_3.jpg",
     "highlights": []
   },
   {
@@ -4569,7 +4569,7 @@
     "isbn": "9784048932714",
     "asin": "4048932713",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2714/9784048932714.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2714/9784048932714.jpg",
     "highlights": []
   },
   {
@@ -4580,7 +4580,7 @@
     "isbn": "9784484212333",
     "asin": "4484212331",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2333/9784484212333_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2333/9784484212333_1_3.jpg",
     "highlights": [
       {
         "text": "お金を持っていない人や会社を相手にしてお金儲けをする場合には、以下のどちらかの条件をクリアしている必要がある。注意しておこう。 ①トラブルのリスクを補って余りあるほど利益率が高い ②相手の数が極めて多く、販売が極めて簡単",
@@ -4596,7 +4596,7 @@
     "isbn": "9784480075284",
     "asin": "4480075283",
     "readDate": "2023/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5284/9784480075284_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5284/9784480075284_1_3.jpg",
     "highlights": []
   },
   {
@@ -4607,7 +4607,7 @@
     "isbn": "9784022518095",
     "asin": "402251809X",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8095/9784022518095_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8095/9784022518095_1_2.jpg",
     "highlights": [
       {
         "text": "当時のTwitterには「Twitterの有名人」がいた。ユーザーが少ないので、活発にツイートしてる人たちの名前とアイコンはみんなの共通認識になっていた。といっても、Twitter有名人のみんながみんな面白ツイートをしているわけでもなかった。いまTwitterで有名になろうと思ったら一芸に秀でなければいけないが、当時は「なんとなくいい感じの人」というだけで知られている人々がいたのである。あれなんだったんだろう。 できたてのプラットフォーム特有の「せまい」感じが好きだ。Twitterはもう自己顕示欲と悪口と 怨嗟 と転載猫動画が広がる汚染された果てなき荒野でしかないけど、１０年くらい前はなんとなく「果て」が感じられた。ああ、これくらいの広さなんだな、というのが、タイムラインを見ているだけで体感できたのだ。",
@@ -4683,7 +4683,7 @@
     "isbn": "9784049143362",
     "asin": "4049143364",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3362/9784049143362_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3362/9784049143362_1_3.jpg",
     "highlights": []
   },
   {
@@ -4694,7 +4694,7 @@
     "isbn": "9784049134469",
     "asin": "4049134462",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4469/9784049134469_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4469/9784049134469_1_4.jpg",
     "highlights": []
   },
   {
@@ -4705,7 +4705,7 @@
     "isbn": "9784040744070",
     "asin": "4040744071",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4070/9784040744070_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4070/9784040744070_1_3.jpg",
     "highlights": []
   },
   {
@@ -4716,7 +4716,7 @@
     "isbn": "9784040738628",
     "asin": "4040738624",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8628/9784040738628.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8628/9784040738628.jpg",
     "highlights": []
   },
   {
@@ -4727,7 +4727,7 @@
     "isbn": "9784040736426",
     "asin": "4040736427",
     "readDate": "2023/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6426/9784040736426.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6426/9784040736426.jpg",
     "highlights": []
   },
   {
@@ -4738,7 +4738,7 @@
     "isbn": "9784040733791",
     "asin": "4040733797",
     "readDate": "2023/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784040733791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784040733791.jpg",
     "highlights": []
   },
   {
@@ -4749,7 +4749,7 @@
     "isbn": "9784040731728",
     "asin": "4040731727",
     "readDate": "2023/01/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1728/9784040731728.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1728/9784040731728.jpg",
     "highlights": []
   },
   {
@@ -4760,7 +4760,7 @@
     "isbn": "9784065267141",
     "asin": "4065267145",
     "readDate": "2023/01/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7141/9784065267141_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7141/9784065267141_1_2.jpg",
     "highlights": []
   },
   {
@@ -4771,7 +4771,7 @@
     "isbn": "9784065294383",
     "asin": "406529438X",
     "readDate": "2022/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4383/9784065294383.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4383/9784065294383.jpg",
     "highlights": [
       {
         "text": "ところが実際に経済が再開してみると、経済学者たちの予想に反して生産が回復してきません。生産がニーズに追いつかない、つまり需要が供給を上まわるというアンバランスが経済のあちこちで生じてしまい、それが物価上昇を引き起こしてしまったのです。",
@@ -4795,7 +4795,7 @@
     "isbn": "9784621066089",
     "asin": "4621066080",
     "readDate": "2022/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6089/9784621066089.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6089/9784621066089.jpg",
     "highlights": []
   },
   {
@@ -4806,7 +4806,7 @@
     "isbn": "9784910413006",
     "asin": "4910413006",
     "readDate": "2022/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3006/9784910413006.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3006/9784910413006.jpg",
     "highlights": []
   },
   {
@@ -4817,7 +4817,7 @@
     "isbn": "9784061385436",
     "asin": "4061385437",
     "readDate": "2022/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5436/9784061385436.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5436/9784061385436.jpg",
     "highlights": [
       {
         "text": "そもそも物語の文法の一番の基本は二つある、と考えて下さい。 一つは「欠落したものが回復する」というパターン。もう一つは「行って帰る」というパターンです。",
@@ -4873,7 +4873,7 @@
     "isbn": "9784040659930",
     "asin": "4040659937",
     "readDate": "2022/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9930/9784040659930_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9930/9784040659930_1_6.jpg",
     "highlights": []
   },
   {
@@ -4884,7 +4884,7 @@
     "isbn": "9784061385153",
     "asin": "4061385151",
     "readDate": "2022/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5153/9784061385153.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5153/9784061385153.jpg",
     "highlights": [
       {
         "text": "知識や情報の確認テストでいくら良い点数をとっても、いまの時代にはほとんど無意味でしょう。漢字の読み書きが典型ですが、 いまやネットで検索すれば漢字検定一級の問題であっても、誰でも 10 秒で答えが出せます。 「誰でもできること」に価値はありません。そして、「誰でもできること」しかできない人材は、いまの時代、確実に買い叩かれる運命にあります。 だから、思考力や 洞察 力、想像力を 育むかたちに大学教育も変えていかなければなりません。若手教員のあいだで双方向の授業への流れが生まれているのは、時代の変化を反映させてのことなのです。",
@@ -4960,7 +4960,7 @@
     "isbn": "9784041125786",
     "asin": "4041125782",
     "readDate": "2022/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784041125786_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784041125786_1_7.jpg",
     "highlights": []
   },
   {
@@ -4971,7 +4971,7 @@
     "isbn": "9784798625577",
     "asin": "4798625574",
     "readDate": "2022/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5577/9784798625577_1_22.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5577/9784798625577_1_22.jpg",
     "highlights": []
   },
   {
@@ -4982,7 +4982,7 @@
     "isbn": "9784065212899",
     "asin": "4065212898",
     "readDate": "2022/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2899/9784065212899.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2899/9784065212899.jpg",
     "highlights": [
       {
         "text": "日本における製作委員会が悪く機能してしまったときの事例と似ているように僕は思える。製作委員会というシステム自体は決して悪い存在ではない。おもちゃやグッズなどを作って、それらを売ることに特化していればいいのだが、それが考えなくストーリーのクリエイティブに混ざってしまったら、悪い化学変化を起こすことはないともいえない。両方のメリットである最大公約数を探していかないといけないのだが、「どちらを取るのか」というような、片方のことしか考えない発想になるのは、作品に悪い影響を及ぼしがちだ。僕は現場クリエイターとしての立場の人間だが、おもちゃやグッズの売上げなんて関係ないと思っているクリエイターなどほとんどいないと思っている。重要なのは、どちらかに偏りすぎると、すごく歪なものになっていくということだ。プロデューサーがそのバランスを取ることは、とても大事なことだろう。",
@@ -5002,7 +5002,7 @@
     "isbn": "9784094530872",
     "asin": "4094530878",
     "readDate": "2022/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0872/9784094530872_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0872/9784094530872_1_3.jpg",
     "highlights": [
       {
         "text": "「知識型マウントね！ 普通は知らない専門知識をあたかも一般常識のように語り『え？ 知らないの（笑）』とマウントを取ったあと『仕方ないな。説明するとだな──』とドヤ顔で説明してくる隠密タイプよ。他にも『 立ち上げる』『 最初から』『 論理的』『 優先順位』『 余裕』『 証拠』など面倒な横文字を使って有能アピールをするマウンティングも知識型にはあるわ。耐性のない相手をイラつかせて冷静さを奪うデバフ効果があって、ベンチャー企業に憧れる学生や自称フリーランスエンジニアの人間に多い。 因みにこの手の人の口癖は『生産性が悪い』よ！」",
@@ -5018,7 +5018,7 @@
     "isbn": "9784061385016",
     "asin": "4061385011",
     "readDate": "2022/09/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5016/9784061385016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5016/9784061385016.jpg",
     "highlights": [
       {
         "text": "世の中を変えるためには、知識を持っているだけではダメです。もちろん、知識すら持っていないのは論外。 日頃から、知識を判断、判断を行動につなげる意識を強く持ってください。",
@@ -5078,7 +5078,7 @@
     "isbn": "9784061385207",
     "asin": "4061385208",
     "readDate": "2022/08/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5207/9784061385207.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5207/9784061385207.jpg",
     "highlights": []
   },
   {
@@ -5089,7 +5089,7 @@
     "isbn": "9784065228098",
     "asin": "4065228093",
     "readDate": "2022/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8098/9784065228098.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8098/9784065228098.jpg",
     "highlights": []
   },
   {
@@ -5100,7 +5100,7 @@
     "isbn": "9784865280968",
     "asin": "4865280960",
     "readDate": "2022/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0968/9784865280968_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0968/9784865280968_1_2.jpg",
     "highlights": [
       {
         "text": "今日「インターセクショナリティ」という語は、Twitter上でのおぞましい言い争いを、つまり人々がたがいに喧嘩しているだけの、あるいはそんな感じのどうしようもないことを意味するだけになりました。これは物事が適切に「 交差」していないことを示しています。すなわち、集団意識の統合が強まるというよりも、各集団間でのアイデンティティ闘争があるだけなのです。",
@@ -5140,7 +5140,7 @@
     "isbn": "9784049144611",
     "asin": "4049144611",
     "readDate": "2022/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4611/9784049144611_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4611/9784049144611_1_4.jpg",
     "highlights": []
   },
   {
@@ -5151,7 +5151,7 @@
     "isbn": "9784049141405",
     "asin": "404914140X",
     "readDate": "2022/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1405/9784049141405_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1405/9784049141405_1_4.jpg",
     "highlights": []
   },
   {
@@ -5162,7 +5162,7 @@
     "isbn": "9784049139419",
     "asin": "4049139413",
     "readDate": "2022/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9419/9784049139419_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9419/9784049139419_1_6.jpg",
     "highlights": []
   },
   {
@@ -5173,7 +5173,7 @@
     "isbn": "9784049137323",
     "asin": "4049137321",
     "readDate": "2022/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784049137323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784049137323.jpg",
     "highlights": []
   },
   {
@@ -5184,7 +5184,7 @@
     "isbn": "9784803009224",
     "asin": "4803009228",
     "readDate": "2022/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9224/9784803009224.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9224/9784803009224.jpg",
     "highlights": []
   },
   {
@@ -5195,7 +5195,7 @@
     "isbn": "9784152099679",
     "asin": "4152099674",
     "readDate": "2022/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9679/9784152099679.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9679/9784152099679.jpg",
     "highlights": [
       {
         "text": "科学者は超オタクだと思われることが多いのですが、科学の哲学的基盤は実際、まったくのパンクロック的無秩序です。具体的には、それは次のようなものからなっています。決して権威を尊重するな。誰のどんな言葉も決してうのみにするな。そして、自分が知っていると思うものすべてを、自分で正しいと確認するか、間違っていると否定するために検証せよ。",
@@ -5227,7 +5227,7 @@
     "isbn": "9784094530858",
     "asin": "4094530851",
     "readDate": "2022/08/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0858/9784094530858_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0858/9784094530858_1_3.jpg",
     "highlights": []
   },
   {
@@ -5238,7 +5238,7 @@
     "isbn": "9784575244670",
     "asin": "4575244678",
     "readDate": "2022/08/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4670/9784575244670_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4670/9784575244670_1_3.jpg",
     "highlights": []
   },
   {
@@ -5249,7 +5249,7 @@
     "isbn": "9784041119327",
     "asin": "4041119324",
     "readDate": "2022/08/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9327/9784041119327_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9327/9784041119327_1_3.jpg",
     "highlights": []
   },
   {
@@ -5260,7 +5260,7 @@
     "isbn": "9784198653880",
     "asin": "4198653887",
     "readDate": "2022/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784198653880_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784198653880_1_3.jpg",
     "highlights": []
   },
   {
@@ -5271,7 +5271,7 @@
     "isbn": "9784023318786",
     "asin": "4023318787",
     "readDate": "2022/08/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8786/9784023318786_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8786/9784023318786_1_3.jpg",
     "highlights": []
   },
   {
@@ -5282,7 +5282,7 @@
     "isbn": "9784065244555",
     "asin": "4065244552",
     "readDate": "2022/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4555/9784065244555_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4555/9784065244555_1_2.jpg",
     "highlights": [
       {
         "text": "「なんなら俺のオンラインサロンにチャンネル登録しろ」 「貝木さん、オンラインサロンを開催してるの？ チャンネル登録されてるの？」 「ああ。詐欺師志望の有望な若者が多く集まってくるので、そういう奴らから金を巻き上げるという善行をおこなっている」",
@@ -5306,7 +5306,7 @@
     "isbn": "9784065244548",
     "asin": "4065244544",
     "readDate": "2022/08/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4548/9784065244548_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4548/9784065244548_1_2.jpg",
     "highlights": [
       {
         "text": "「コロナ禍を物語に取り入れるかどうかっていうのは意見の分かれるところだよね。現実が舞台である以上、あたかもコロナウイルスが存在しないがごとく描くのはともすると欺瞞であるかのようだけれど、読む人によっては、パンデミックが小説にまで侵食してきたと、暗い気持ちになることもあるだろう。読書を楽しんでいるときくらい、自粛ではなく自由でありたいと思うのは当然だ。そんなかたにお勧めなのが下巻だよ」",
@@ -5322,7 +5322,7 @@
     "isbn": "9784815610159",
     "asin": "4815610150",
     "readDate": "2022/08/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0159/9784815610159_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0159/9784815610159_1_2.jpg",
     "highlights": []
   },
   {
@@ -5333,7 +5333,7 @@
     "isbn": "9784815609252",
     "asin": "481560925X",
     "readDate": "2022/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9252/9784815609252_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9252/9784815609252_1_2.jpg",
     "highlights": [
       {
         "text": "「人間関係ってのは面倒で、一人でいるぼっちは楽だ。これは絶対的な真理。でも、面倒なことをひたすら回避して生きていても、どこにも行けない気がするんだよな。うまく言えないけど、面倒なことも人生に必要だっていうか、この面倒くささもどこかにつながってるっていうか。花見辻と過ごしてて、そんな風に思った」",
@@ -5349,7 +5349,7 @@
     "isbn": "9784065211588",
     "asin": "4065211581",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1588/9784065211588.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1588/9784065211588.jpg",
     "highlights": [
       {
         "text": "「関係性の放棄ですからね。自分のための、己のための自己犠牲でもあるのです。己への献身であり、献心ですよ。お前とまともに話すつもりはないと、宣言しているようなものです。前向きに検討しますとか善処しますとか、そんな言い逃れと同じですよ。謝ってるんだからもういいだろめんどくせえという本音が透けて見えます」",
@@ -5369,7 +5369,7 @@
     "isbn": "9784063650389",
     "asin": "4063650383",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0389/9784063650389.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0389/9784063650389.jpg",
     "highlights": []
   },
   {
@@ -5380,7 +5380,7 @@
     "isbn": "9784063650228",
     "asin": "4063650227",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0228/9784063650228.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0228/9784063650228.jpg",
     "highlights": []
   },
   {
@@ -5391,7 +5391,7 @@
     "isbn": "9784150505257",
     "asin": "415050525X",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5257/9784150505257.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5257/9784150505257.jpg",
     "highlights": [
       {
         "text": "いくら自分探しをしたところで、単一の真の自己などというものは存在しない。自分自身の内にも、ほかの人の内にもない。心理学者であり哲学者であったウィリアム・ジェームズ（一八四二～一九一〇）はかつて、〝人は、自分を知る人の数と同じだけの社会的自己をもつ〟と書いた。驚くほど孔子的な意見だ。人にはそれぞれ無数の役割があり、役割同士が対立することも多いうえ、それをあやつる手綱さばきを教えてくれる規範もない。礼の実践だけが手綱さばきを身につける助けになる。",
@@ -5423,7 +5423,7 @@
     "isbn": "9784797341379",
     "asin": "4797341378",
     "readDate": "2022/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1379/9784797341379.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1379/9784797341379.jpg",
     "highlights": []
   },
   {
@@ -5434,7 +5434,7 @@
     "isbn": "9784046049872",
     "asin": "4046049871",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9872/9784046049872.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9872/9784046049872.jpg",
     "highlights": []
   },
   {
@@ -5445,7 +5445,7 @@
     "isbn": "9784535574755",
     "asin": "4535574758",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -5456,7 +5456,7 @@
     "isbn": "9784822286583",
     "asin": "4822286584",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6583/9784822286583.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6583/9784822286583.jpg",
     "highlights": []
   },
   {
@@ -5467,7 +5467,7 @@
     "isbn": "9784098253111",
     "asin": "4098253119",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3111/9784098253111.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3111/9784098253111.jpg",
     "highlights": [
       {
         "text": "僕らの心は一瞬で変わり続けているため、真実を正しく映し出せていない可能性が高い。だとすれば、心に生じた感情が「本物」ではない可能性もまた大きい、ということになります。僕らはしばしば、心のなかに生じた「怒り」や「妬み」といった感情を、実体として、かなりのリアリティをもってとらえてしまいがちです。しかし、もし心が「一瞬で変わる」のであれば、それらはすべて実体のない、幻にすぎないものだということになります。",
@@ -5523,7 +5523,7 @@
     "isbn": "9784048930659",
     "asin": "4048930656",
     "readDate": "2022/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0659/9784048930659.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0659/9784048930659.jpg",
     "highlights": [
       {
         "text": "巨大な課題管理システムにある膨大な要件文書を扱いながら、システムを「動かす」ために 死に物狂い になっている。彼らが作り出すコードは、きれいではないかもしれないが、それでも動く。何かを「一度だけ」動かすのは、それほど難しいことではないからだ。",
@@ -5599,7 +5599,7 @@
     "isbn": "9784094530728",
     "asin": "409453072X",
     "readDate": "2022/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0728/9784094530728_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0728/9784094530728_1_3.jpg",
     "highlights": []
   },
   {
@@ -5610,7 +5610,7 @@
     "isbn": "9784761275457",
     "asin": "4761275456",
     "readDate": "2022/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784761275457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784761275457.jpg",
     "highlights": []
   },
   {
@@ -5621,7 +5621,7 @@
     "isbn": "9784478109687",
     "asin": "4478109680",
     "readDate": "2022/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9687/9784478109687.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9687/9784478109687.jpg",
     "highlights": [
       {
         "text": "金を無駄にするのを恐れて機会を逃がすのはナンセンスだ。 金を浪費することより、人生を無駄にしてしまうことのほうが、はるかに大きな問題ではないだろうか。",
@@ -5677,7 +5677,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2022/07/16",
-    "thumnailImage": "https://m.media-amazon.com/images/I/518NDBA1+SL.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/518NDBA1+SL.jpg",
     "highlights": []
   },
   {
@@ -5688,7 +5688,7 @@
     "isbn": "9784152101334",
     "asin": "4152101334",
     "readDate": "2022/07/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1334/9784152101334.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1334/9784152101334.jpg",
     "highlights": []
   },
   {
@@ -5699,7 +5699,7 @@
     "isbn": "9784074143511",
     "asin": "4074143518",
     "readDate": "2022/07/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784074143511.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784074143511.jpg",
     "highlights": []
   },
   {
@@ -5710,7 +5710,7 @@
     "isbn": "9784334032913",
     "asin": "4334032915",
     "readDate": "2022/06/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2913/9784334032913.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2913/9784334032913.jpg",
     "highlights": []
   },
   {
@@ -5721,7 +5721,7 @@
     "isbn": "9784297127831",
     "asin": "4297127830",
     "readDate": "2022/06/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7831/9784297127831_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7831/9784297127831_1_3.jpg",
     "highlights": [
       {
         "text": "コンストラクタでは、 0 ～ 999 の範囲外は不正な値として弾くロジックになっています。不正な値が紛れ込まないようにしかけをしておくと、バグ化しない頑強なクラス構造になります。",
@@ -5949,7 +5949,7 @@
     "isbn": "9784121006240",
     "asin": "4121006240",
     "readDate": "2022/06/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6240/9784121006240.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6240/9784121006240.jpg",
     "highlights": [
       {
         "text": "いったい読者はこの文書に何を期待しているはずかと，一瞬，反省してみることを勧める．",
@@ -5989,7 +5989,7 @@
     "isbn": "9784167105587",
     "asin": "4167105586",
     "readDate": "2022/05/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16710558.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16710558.jpg",
     "highlights": []
   },
   {
@@ -6000,7 +6000,7 @@
     "isbn": "9784798046143",
     "asin": "4798046140",
     "readDate": "2022/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6143/9784798046143.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6143/9784798046143.jpg",
     "highlights": [
       {
         "text": "ソフトウェアにおいて、その選択の多様性を受容します。 ソフトウェアに関わるすべての場面において、「唯一の正しい方法」というのは存在しません。「唯一の正しい方法がある」とする、すべての主張を信用してはいけません。",
@@ -6024,7 +6024,7 @@
     "isbn": "9784797390575",
     "asin": "4797390573",
     "readDate": "2022/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0575/9784797390575.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0575/9784797390575.jpg",
     "highlights": []
   },
   {
@@ -6035,7 +6035,7 @@
     "isbn": "9784815610258",
     "asin": "4815610258",
     "readDate": "2022/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784815610258_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784815610258_1_3.jpg",
     "highlights": []
   },
   {
@@ -6046,7 +6046,7 @@
     "isbn": "9784094530605",
     "asin": "4094530606",
     "readDate": "2022/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0605/9784094530605_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0605/9784094530605_1_3.jpg",
     "highlights": []
   },
   {
@@ -6057,7 +6057,7 @@
     "isbn": "9784094530223",
     "asin": "4094530223",
     "readDate": "2022/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0223/9784094530223_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0223/9784094530223_1_3.jpg",
     "highlights": []
   },
   {
@@ -6068,7 +6068,7 @@
     "isbn": "9784094518993",
     "asin": "4094518991",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784094518993.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784094518993.jpg",
     "highlights": []
   },
   {
@@ -6079,7 +6079,7 @@
     "isbn": "9784094518665",
     "asin": "4094518665",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8665/9784094518665.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8665/9784094518665.jpg",
     "highlights": []
   },
   {
@@ -6090,7 +6090,7 @@
     "isbn": "9784094518412",
     "asin": "409451841X",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784094518412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784094518412.jpg",
     "highlights": []
   },
   {
@@ -6101,7 +6101,7 @@
     "isbn": "9784094518160",
     "asin": "4094518169",
     "readDate": "2022/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8160/9784094518160.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8160/9784094518160.jpg",
     "highlights": []
   },
   {
@@ -6112,7 +6112,7 @@
     "isbn": "9784094517965",
     "asin": "4094517960",
     "readDate": "2022/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7965/9784094517965.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7965/9784094517965.jpg",
     "highlights": [
       {
         "text": "「手を 繫 いだら、停滞してしまうから」 だからもしも、と顔を上げて、 「もしもこんな時間がずっと続けばいいと願っているのなら」 切っ先を向けるように言い放つ。 「──そんなのは偽物の恋だと思います」",
@@ -6140,7 +6140,7 @@
     "isbn": "9784046813619",
     "asin": "404681361X",
     "readDate": "2022/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3619/9784046813619_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3619/9784046813619_1_3.jpg",
     "highlights": []
   },
   {
@@ -6151,7 +6151,7 @@
     "isbn": "9784046810014",
     "asin": "4046810017",
     "readDate": "2022/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0014/9784046810014_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0014/9784046810014_1_3.jpg",
     "highlights": []
   },
   {
@@ -6162,7 +6162,7 @@
     "isbn": "9784062817400",
     "asin": "4062817403",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7400/9784062817400.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7400/9784062817400.jpg",
     "highlights": []
   },
   {
@@ -6173,7 +6173,7 @@
     "isbn": "9784046806079",
     "asin": "4046806079",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784046806079_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784046806079_1_5.jpg",
     "highlights": []
   },
   {
@@ -6184,7 +6184,7 @@
     "isbn": "9784046803269",
     "asin": "4046803266",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3269/9784046803269.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3269/9784046803269.jpg",
     "highlights": []
   },
   {
@@ -6195,7 +6195,7 @@
     "isbn": "9784040647265",
     "asin": "4040647262",
     "readDate": "2022/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7265/9784040647265.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7265/9784040647265.jpg",
     "highlights": []
   },
   {
@@ -6206,7 +6206,7 @@
     "isbn": "9784873119823",
     "asin": "4873119820",
     "readDate": "2022/04/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9823/9784873119823_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9823/9784873119823_1_3.jpg",
     "highlights": []
   },
   {
@@ -6217,7 +6217,7 @@
     "isbn": "9784344984028",
     "asin": "4344984021",
     "readDate": "2022/04/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784344984028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784344984028.jpg",
     "highlights": []
   },
   {
@@ -6228,7 +6228,7 @@
     "isbn": "9784094530100",
     "asin": "409453010X",
     "readDate": "2022/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0100/9784094530100_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0100/9784094530100_1_2.jpg",
     "highlights": []
   },
   {
@@ -6239,7 +6239,7 @@
     "isbn": "9784094518870",
     "asin": "4094518878",
     "readDate": "2022/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8870/9784094518870.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8870/9784094518870.jpg",
     "highlights": []
   },
   {
@@ -6250,7 +6250,7 @@
     "isbn": "9784101024028",
     "asin": "4101024022",
     "readDate": "2022/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784101024028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784101024028.jpg",
     "highlights": []
   },
   {
@@ -6261,7 +6261,7 @@
     "isbn": "9784408551227",
     "asin": "4408551228",
     "readDate": "2022/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1227/9784408551227.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1227/9784408551227.jpg",
     "highlights": []
   },
   {
@@ -6272,7 +6272,7 @@
     "isbn": "9784799315323",
     "asin": "4799315323",
     "readDate": "2022/02/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5323/9784799315323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5323/9784799315323.jpg",
     "highlights": [
       {
         "text": "次に、議事録で必ず盛り込むべき項目を挙げましょう。 ・日時 ・場所 ・参加者 ・本日のアジェンダ（論点・議題） 以上は当たり前ですね。重要なのは、次の４つです。 ・決まったこと ・決まらなかったこと（次に持ち越したこと） ・確認が必要なこと ・次回に向けてのＴＯＤＯ（誰がいつまでに）",
@@ -6288,7 +6288,7 @@
     "isbn": "9784761275075",
     "asin": "4761275073",
     "readDate": "2022/02/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5075/9784761275075.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5075/9784761275075.jpg",
     "highlights": [
       {
         "text": "取引や投資をするときは記録を取る。これは私がファンドで働き始めたとき、先輩にアドバイスされたことです。 たとえば、新たに株式を購入したら、購入した理由を書きます。それと同時に、前もって売る理由も書いておきます。「こうなったら売る」というルールを記しておくのです。 あるいは「こうなったら、自分の判断が間違っていたので売る」と損切りのルールも書いておきます。 これがないと、 自分が間違えても「自分は正しい」と都合よく解釈してしまいます。 そう、自分に嘘をついてしまうのです。結果、失敗から学ぶことができないので何度も同じ間違いをしてしまいますし、感情のコントロールもできなくなります。 書く方法は手書きである必要はありません。私はPCで管理していて、定期的に見返すようにしています。過去の自分と対話するといまの自分を客観視できるので、次の判断にも生かすことができます。",
@@ -6308,7 +6308,7 @@
     "isbn": "9784479393818",
     "asin": "4479393811",
     "readDate": "2022/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3818/9784479393818_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3818/9784479393818_1_2.jpg",
     "highlights": []
   },
   {
@@ -6319,7 +6319,7 @@
     "isbn": "9784798150727",
     "asin": "479815072X",
     "readDate": "2022/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg",
     "highlights": []
   },
   {
@@ -6330,7 +6330,7 @@
     "isbn": "9784775972304",
     "asin": "4775972308",
     "readDate": "2022/01/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2304/9784775972304.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2304/9784775972304.jpg",
     "highlights": [
       {
         "text": "１．私はこの事業を理解しているか。 ２．企業を守る経営上の堀があるおかげで、今後五年から一〇年間、同じか類似した製品を売り続けることができるか。 ３．この業界は変化が激しいか。 ４．この企業には多様な顧客基盤があるか。 ５．固定資産が少ない事業か。 ６．景気循環に大きく影響される業界か。 ７．この企業にはまだ成長の余地があるか。 ８．過去一〇年間、好景気のときも不景気のときも常に利益を出し続けてきたか。 ９．営業利益率は安定して二桁を維持しているか。 10．利益率は競合他社よりも高いか。 11．一五％以上のＲＯＩＣ（投下資本利益率）を過去一〇年にわたって維持しているか。 12．一貫して二桁の成長率で、売上高と利益を伸ばしてきたか。 13．財務基盤がしっかりしているか。 14．経営陣は自社株をかなり保有しているか。 15．経営陣の収入は似た規模の他社と比べてどうか。 16．インサイダーはこの企業の株式を買っているか。 17．内在価値やＰＥＲ（株価収益率）で測った株価は妥当か。 18．歴史的に見て、現在のバリュエーションはどうか。 19．これまでの不況期に株価はどうだったか。 20．自分の調査にどれくらいの自信があるか。",
@@ -6350,7 +6350,7 @@
     "isbn": "9784106105760",
     "asin": "4106105764",
     "readDate": "2021/12/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5760/9784106105760_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5760/9784106105760_1_3.jpg",
     "highlights": []
   },
   {
@@ -6361,7 +6361,7 @@
     "isbn": "9784106101496",
     "asin": "4106101491",
     "readDate": "2021/12/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1496/9784106101496_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1496/9784106101496_1_2.jpg",
     "highlights": []
   },
   {
@@ -6372,7 +6372,7 @@
     "isbn": "9784046051578",
     "asin": "4046051574",
     "readDate": "2021/12/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1578/9784046051578_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1578/9784046051578_1_3.jpg",
     "highlights": []
   },
   {
@@ -6383,7 +6383,7 @@
     "isbn": "9784106100611",
     "asin": "4106100614",
     "readDate": "2021/12/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0611/9784106100611_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0611/9784106100611_1_2.jpg",
     "highlights": [
       {
         "text": "反権力を声高に言っている者は、つまり俺に権力をよこせと言っているに過ぎない。決して体制そのものに異を唱えているわけではない。反権力と反体制とは別ものです。 全共闘が反体制と言っていた時は、「これは反体制じゃない、反権力だ」と私は思っていました。あいつらが勝ったら結局、「体制側」と同じことをするんじゃないかと思っていたのです。もっと平たく言えば、「俺に金を寄越せ」と言っているだけなんじゃないかと思ったのです。",
@@ -6403,7 +6403,7 @@
     "isbn": "9784152100719",
     "asin": "4152100710",
     "readDate": "2021/12/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0719/9784152100719_1_17.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0719/9784152100719_1_17.jpg",
     "highlights": []
   },
   {
@@ -6414,7 +6414,7 @@
     "isbn": "9784798149493",
     "asin": "4798149497",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9493/9784798149493.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9493/9784798149493.jpg",
     "highlights": []
   },
   {
@@ -6425,7 +6425,7 @@
     "isbn": "9784140883853",
     "asin": "4140883855",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3853/9784140883853.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3853/9784140883853.jpg",
     "highlights": []
   },
   {
@@ -6436,7 +6436,7 @@
     "isbn": "9784152100702",
     "asin": "4152100702",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0702/9784152100702_1_15.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0702/9784152100702_1_15.jpg",
     "highlights": []
   },
   {
@@ -6447,7 +6447,7 @@
     "isbn": "9784344985148",
     "asin": "4344985141",
     "readDate": "2021/11/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5148/9784344985148.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5148/9784344985148.jpg",
     "highlights": [
       {
         "text": "①何を言ってもいい。 ②人の言うことに対して否定的な態度をとらない。 ③発言せず、ただ聞いているだけでもいい。 ④お互いに問いかけるようにする。 ⑤知識ではなく、自分の経験にそくして話す。 ⑥話がまとまらなくてもいい。 ⑦意見が変わってもいい。 ⑧分からなくなってもいい。",
@@ -6467,7 +6467,7 @@
     "isbn": "9784297111731",
     "asin": "429711173X",
     "readDate": "2021/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1731/9784297111731.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1731/9784297111731.jpg",
     "highlights": []
   },
   {
@@ -6478,7 +6478,7 @@
     "isbn": "9784144071997",
     "asin": "4144071995",
     "readDate": "2021/11/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1997/9784144071997.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1997/9784144071997.jpg",
     "highlights": []
   },
   {
@@ -6489,7 +6489,7 @@
     "isbn": "9784757433151",
     "asin": "4757433158",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3151/9784757433151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3151/9784757433151.jpg",
     "highlights": []
   },
   {
@@ -6500,7 +6500,7 @@
     "isbn": "9784492533659",
     "asin": "4492533656",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3659/9784492533659.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3659/9784492533659.jpg",
     "highlights": [
       {
         "text": "経験より現金をもらうほうがうれしいと言っていたはずなのに、実験群のほうが満足度は高かったのだ。実際、かなり高かった。現金をもらうより楽しさが 28% 増しになり、記憶に 28% 強く残り、じっくり考える機会が 15% 増えた。これはディズニーランド旅行（大人の心は今も子どものままだ）でも個人で使うバウチャーでも同じだった。",
@@ -6524,7 +6524,7 @@
     "isbn": "9784487811892",
     "asin": "4487811899",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1892/9784487811892.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1892/9784487811892.jpg",
     "highlights": []
   },
   {
@@ -6535,7 +6535,7 @@
     "isbn": "9784344985612",
     "asin": "4344985613",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5612/9784344985612.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5612/9784344985612.jpg",
     "highlights": [
       {
         "text": "日本が欧米に追いつくことを目指していた時代には、情報を輸入することに大きな価値が置かれていたのも無理はなかったかもしれません。 しかし日本が先進国化した今、海外から情報を輸入して再現することの価値は低下しています。 それどころか、日本は他の多くの国と比べても少子化や高齢化、地域の過疎化といった問題の進行が速く、「課題先進国」とさえいわれているのです。従来のように海外をモデルとし、その成功事例を模倣するというやり方では、こうした課題に対する望ましい解決策にはたどり着けないでしょう。 この点、何か新たな問題が発生し議論が生じたとき、すぐに「海外ではどう対応しているのか」「他国でいい成功事例はないのか」などと考えてしまいがちな人は注意が必要かもしれません。 日本はさまざまな課題に関して、好むと好まざるとにかかわらずフロントランナーにならざるをえない状況にあるのです。日本企業や日本人が直接、課題に向き合う必要性が高まっていることを認識する必要があるでしょう。",
@@ -6575,7 +6575,7 @@
     "isbn": "9784844378785",
     "asin": "4844378783",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8785/9784844378785.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8785/9784844378785.jpg",
     "highlights": []
   },
   {
@@ -6586,7 +6586,7 @@
     "isbn": "9784344841253",
     "asin": "4344841255",
     "readDate": "2021/11/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1253/9784344841253.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1253/9784344841253.jpg",
     "highlights": []
   },
   {
@@ -6597,7 +6597,7 @@
     "isbn": "9784822280536",
     "asin": "4822280535",
     "readDate": "2021/11/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82228053.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82228053.jpg",
     "highlights": [
       {
         "text": "安全と変更 ● 変更は、あらゆるプロジェクトの成功のために（ほかのたいていの物事においても）必要不可欠である。 ● 人は安全だとわからないと変更を受け入れない。安全が保証されていないと、リスクを避けようとする。 ● リスクを避けることは、それに伴う利益をも逃すことになるため、致命的である。 ● 人は、面と向かって脅されたときはもちろん、自分に対して不当に権力が行使されるかもしれないと思ったときにも、安全ではないと感じるようになる。",
@@ -6693,7 +6693,7 @@
     "isbn": "9784163914411",
     "asin": "4163914412",
     "readDate": "2021/11/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4411/9784163914411_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4411/9784163914411_1_5.jpg",
     "highlights": []
   },
   {
@@ -6704,7 +6704,7 @@
     "isbn": "9784150300142",
     "asin": "4150300143",
     "readDate": "2021/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784150300142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784150300142.jpg",
     "highlights": []
   },
   {
@@ -6715,7 +6715,7 @@
     "isbn": "9784086314398",
     "asin": "4086314398",
     "readDate": "2021/10/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4398/9784086314398_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4398/9784086314398_1_4.jpg",
     "highlights": []
   },
   {
@@ -6726,7 +6726,7 @@
     "isbn": "9784094530315",
     "asin": "4094530312",
     "readDate": "2021/09/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0315/9784094530315_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0315/9784094530315_1_3.jpg",
     "highlights": []
   },
   {
@@ -6737,7 +6737,7 @@
     "isbn": "9784152100436",
     "asin": "4152100435",
     "readDate": "2021/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784152100436_1_23.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784152100436_1_23.jpg",
     "highlights": [
       {
         "text": "１ 気候大災害を防ぐには、ゼロを達成しなければならない。 ２ 太陽光や風力といったすでにある手段を、もっと早く効果的に展開する必要がある。 ３ 目標達成を可能にするブレークスルーを生み出し展開しなければならない。",
@@ -6765,7 +6765,7 @@
     "isbn": "9784797395457",
     "asin": "4797395451",
     "readDate": "2021/09/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784797395457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784797395457.jpg",
     "highlights": []
   },
   {
@@ -6776,7 +6776,7 @@
     "isbn": "9784049133721",
     "asin": "4049133725",
     "readDate": "2021/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3721/9784049133721.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3721/9784049133721.jpg",
     "highlights": []
   },
   {
@@ -6787,7 +6787,7 @@
     "isbn": "9784062920278",
     "asin": "4062920271",
     "readDate": "2021/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0278/9784062920278.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0278/9784062920278.jpg",
     "highlights": [
       {
         "text": "戦争とは、要するに「暴力的手段による政治運動の一形態」にすぎない、とマハンは強調しているが、それはプロイセンの偉大な軍人・軍政家クラウゼヴィッツの古典『戦争論』の有名な命題──「戦争とは形を変えた政治である」──を思わせるテーゼである。",
@@ -6819,7 +6819,7 @@
     "isbn": "9784122022874",
     "asin": "4122022878",
     "readDate": "2021/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2874/9784122022874.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2874/9784122022874.jpg",
     "highlights": [
       {
         "text": "苦しみは忘れていく。楽しみはその時限りのもの。そして失ったものもまた、忘れていく。残ったものにだけすがりつき、残余の命を保っていこうとする。まるで現実そのものではないか。",
@@ -6835,7 +6835,7 @@
     "isbn": "9784795403604",
     "asin": "4795403600",
     "readDate": "2021/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3604/9784795403604.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3604/9784795403604.jpg",
     "highlights": []
   },
   {
@@ -6846,7 +6846,7 @@
     "isbn": "9784873119380",
     "asin": "4873119383",
     "readDate": "2021/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9380/9784873119380_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9380/9784873119380_1_2.jpg",
     "highlights": []
   },
   {
@@ -6857,7 +6857,7 @@
     "isbn": "9784781620046",
     "asin": "4781620043",
     "readDate": "2021/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0046/9784781620046_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0046/9784781620046_1_4.jpg",
     "highlights": []
   },
   {
@@ -6868,7 +6868,7 @@
     "isbn": "9784864108454",
     "asin": "4864108455",
     "readDate": "2021/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8454/9784864108454_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8454/9784864108454_1_2.jpg",
     "highlights": []
   },
   {
@@ -6879,7 +6879,7 @@
     "isbn": "9784151843518",
     "asin": "4151843515",
     "readDate": "2021/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3518/9784151843518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3518/9784151843518.jpg",
     "highlights": [
       {
         "text": "記号化された人物、人物の行動が構成する命題、その命題からなる公理系、そこにいくつかの推論規則が加わって──それが推理小説──にして形式体系──にしてメタ数学だよ！」",
@@ -6911,7 +6911,7 @@
     "isbn": "9784152095428",
     "asin": "4152095423",
     "readDate": "2021/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5428/9784152095428.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5428/9784152095428.jpg",
     "highlights": []
   },
   {
@@ -6922,7 +6922,7 @@
     "isbn": "9784152095244",
     "asin": "4152095245",
     "readDate": "2021/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784152095244.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784152095244.jpg",
     "highlights": []
   },
   {
@@ -6933,7 +6933,7 @@
     "isbn": "9784596551450",
     "asin": "4596551456",
     "readDate": "2021/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1450/9784596551450.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1450/9784596551450.jpg",
     "highlights": [
       {
         "text": "不便は「無消費」の表れであることが多い。無消費とはすなわち、潜在的な消費者が生活のなかのある部分を進歩させたいと切望しながら、それに応えるプロダクトを買うだけの余裕がない、あるいは、存在を知らなかったり、入手する方法がなかったりする状況を指す。",
@@ -6965,7 +6965,7 @@
     "isbn": "9784800010834",
     "asin": "4800010837",
     "readDate": "2021/06/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0834/9784800010834.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0834/9784800010834.jpg",
     "highlights": []
   },
   {
@@ -6976,7 +6976,7 @@
     "isbn": "9784065195031",
     "asin": "4065195039",
     "readDate": "2021/06/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5031/9784065195031.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5031/9784065195031.jpg",
     "highlights": [
       {
         "text": "成長を続けなければならないというのは、資本主義というシステムが必然的に持たざるを得ない一つの宿命だからである。 そしてそれゆえにこそ、温暖化問題なども抜本的な解決がなされないのである。 ではどうしてそんなことになってしまうのだろうか。その最も直接的な理由をずばりと言えば、それは「金利」というものがあるからである。",
@@ -7016,7 +7016,7 @@
     "isbn": "9784405071940",
     "asin": "4405071942",
     "readDate": "2021/05/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1940/9784405071940.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1940/9784405071940.jpg",
     "highlights": []
   },
   {
@@ -7027,7 +7027,7 @@
     "isbn": "9784094518566",
     "asin": "4094518568",
     "readDate": "2021/05/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8566/9784094518566.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8566/9784094518566.jpg",
     "highlights": [
       {
         "text": "まったく、髪型をころころ変えていいのは 冴えないあの御方だけだぞ、 不遜 な奴め。",
@@ -7043,7 +7043,7 @@
     "isbn": "9784797365818",
     "asin": "4797365811",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5818/9784797365818.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5818/9784797365818.jpg",
     "highlights": []
   },
   {
@@ -7054,7 +7054,7 @@
     "isbn": "9784799214671",
     "asin": "4799214675",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4671/9784799214671.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4671/9784799214671.jpg",
     "highlights": []
   },
   {
@@ -7065,7 +7065,7 @@
     "isbn": "9784094060843",
     "asin": "4094060847",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0843/9784094060843.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0843/9784094060843.jpg",
     "highlights": []
   },
   {
@@ -7076,7 +7076,7 @@
     "isbn": "9784152100214",
     "asin": "4152100214",
     "readDate": "2021/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0214/9784152100214.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0214/9784152100214.jpg",
     "highlights": []
   },
   {
@@ -7087,7 +7087,7 @@
     "isbn": "9784152100207",
     "asin": "4152100206",
     "readDate": "2021/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0207/9784152100207.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0207/9784152100207.jpg",
     "highlights": []
   },
   {
@@ -7098,7 +7098,7 @@
     "isbn": "9784065224403",
     "asin": "4065224403",
     "readDate": "2021/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4403/9784065224403.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4403/9784065224403.jpg",
     "highlights": []
   },
   {
@@ -7109,7 +7109,7 @@
     "isbn": "9784086314121",
     "asin": "4086314126",
     "readDate": "2021/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4121/9784086314121.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4121/9784086314121.jpg",
     "highlights": []
   },
   {
@@ -7120,7 +7120,7 @@
     "isbn": "9784086313797",
     "asin": "4086313790",
     "readDate": "2021/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3797/9784086313797.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3797/9784086313797.jpg",
     "highlights": []
   },
   {
@@ -7131,7 +7131,7 @@
     "isbn": "9784086313568",
     "asin": "4086313561",
     "readDate": "2021/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3568/9784086313568.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3568/9784086313568.jpg",
     "highlights": []
   },
   {
@@ -7142,7 +7142,7 @@
     "isbn": "9784775930793",
     "asin": "4775930796",
     "readDate": "2021/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0793/9784775930793.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0793/9784775930793.jpg",
     "highlights": []
   },
   {
@@ -7153,7 +7153,7 @@
     "isbn": "9784866732008",
     "asin": "4866732008",
     "readDate": "2021/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2008/9784866732008.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2008/9784866732008.jpg",
     "highlights": []
   },
   {
@@ -7164,7 +7164,7 @@
     "isbn": "9784334752019",
     "asin": "4334752012",
     "readDate": "2021/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2019/9784334752019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2019/9784334752019.jpg",
     "highlights": []
   },
   {
@@ -7175,7 +7175,7 @@
     "isbn": "9784800010643",
     "asin": "4800010640",
     "readDate": "2021/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784800010643.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784800010643.jpg",
     "highlights": []
   },
   {
@@ -7186,7 +7186,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2021/04/25",
-    "thumnailImage": "https://tshop.r10s.jp/book/cabinet/0611/4910019750611.jpg",
+    "thumbnailImage": "https://tshop.r10s.jp/book/cabinet/0611/4910019750611.jpg",
     "highlights": []
   },
   {
@@ -7197,7 +7197,7 @@
     "isbn": "9784582766714",
     "asin": "4582766714",
     "readDate": "2021/04/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6714/9784582766714.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6714/9784582766714.jpg",
     "highlights": []
   },
   {
@@ -7208,7 +7208,7 @@
     "isbn": "9784094530049",
     "asin": "4094530045",
     "readDate": "2021/04/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0049/9784094530049.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0049/9784094530049.jpg",
     "highlights": []
   },
   {
@@ -7219,7 +7219,7 @@
     "isbn": "9784150314811",
     "asin": "4150314810",
     "readDate": "2021/04/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4811/9784150314811.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4811/9784150314811.jpg",
     "highlights": []
   },
   {
@@ -7230,7 +7230,7 @@
     "isbn": "9784798163680",
     "asin": "4798163686",
     "readDate": "2021/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784798163680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784798163680.jpg",
     "highlights": [
       {
         "text": "最初に、プロダクトオーナーが今回のスプリントで達成したい目的を明らかにします。次に、今回のスプリントでそれを達成するために完成させるプロダクトバックログ項目を選びます。選択する項目は並べ替えてあるプロダクトバックログの上位の項目になるのが一般的です。選択するプロダクトバックログの個数は、それぞれの項目の見積りのサイズや開発チームの過去の実績（これをベロシティと呼びます）、今回のスプリントで作業に使える時間（キャパシティと呼びます）などを踏まえて仮決定します。 また、検討した内容を踏まえて今回のスプリントの目標を簡潔にまとめておきます。これを スプリントゴール と呼び、開発チームがなぜここで選択したプロダクトバックログの項目を開発するのかを理解しやすくなります。",
@@ -7250,7 +7250,7 @@
     "isbn": "9784775972021",
     "asin": "4775972022",
     "readDate": "2021/04/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2021/9784775972021.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2021/9784775972021.jpg",
     "highlights": [
       {
         "text": "人ができる最高のことは、ほかの人がより多くを知る手助けをすることです。 ――チャーリー・マンガー（二〇一〇年のバークシャー・ハサウェイ株主総会）",
@@ -7306,7 +7306,7 @@
     "isbn": "9784845910564",
     "asin": "484591056X",
     "readDate": "2021/04/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0564/9784845910564.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0564/9784845910564.jpg",
     "highlights": []
   },
   {
@@ -7317,7 +7317,7 @@
     "isbn": "9784862807939",
     "asin": "4862807933",
     "readDate": "2021/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7939/9784862807939.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7939/9784862807939.jpg",
     "highlights": []
   },
   {
@@ -7328,7 +7328,7 @@
     "isbn": "9784103145349",
     "asin": "410314534X",
     "readDate": "2021/04/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5349/9784103145349.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5349/9784103145349.jpg",
     "highlights": [
       {
         "text": "フレドリック・ブラウンの「電獣ヴァヴェリ」は星新一が翻訳して「ＳＦマガジン」に掲載した。地球にやってきた電気を食べる電波生物ヴァヴェリのためにすべての電気製品が使えなくなった世界。電気がなくなればヴァヴェリはいなくなるのだが、油断して電気を使うと彼らはすぐにやってきてその僅かな電気を食べてしまう。かくて社会は原始時代に戻る。輸送手段は蒸気機関車と馬車にとって代り、テレビも映画もない世界で演劇とコンサートが主流となり、燃料としてはガスが使われ、活字は手で組まれて植字機と印刷機は蒸気機関を使うことになる。そして主人公が雨の夜に稲妻を恋しがっている場面で小説は終る。こいつはまるで新型コロナではないか。感染者が一人になっても彼らはそこにいるのだ。われわれもまた、パーティや大宴会を恋しがりながら残りの生を終えるのであろうか。このコロナ騒動が終ったあとの世界はいったいどんな世界なのか。以前の世界に戻るのだろうか。あるいはそれは今までわれわれが想像もしなかったような未知の世界なのだろうか。",
@@ -7344,7 +7344,7 @@
     "isbn": "9784140841419",
     "asin": "4140841419",
     "readDate": "2021/04/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1408/14084141.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1408/14084141.jpg",
     "highlights": []
   },
   {
@@ -7355,7 +7355,7 @@
     "isbn": "9784480688767",
     "asin": "4480688765",
     "readDate": "2021/03/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8767/9784480688767.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8767/9784480688767.jpg",
     "highlights": [
       {
         "text": "重要なことは、先ほどのふたつの作品には一二〇〇年以上もの時間的隔たりがあることと、描かれた地域も技法もなにもかも異なる点です。しかしそれでもなお、描かれた人物の容貌と服装、そしてなにより鍵という特徴的なアイテムによって、彼がペテロであることを観る者は理解できるのです。こうした、固体認識のための「属性」、あるいはそれを示す要素を「アトリビュート」と呼びます。仏教用語から来た「 持物」と訳されることもあります。",
@@ -7371,7 +7371,7 @@
     "isbn": "9784908655142",
     "asin": "4908655146",
     "readDate": "2021/03/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5142/9784908655142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5142/9784908655142.jpg",
     "highlights": []
   },
   {
@@ -7382,7 +7382,7 @@
     "isbn": "9784908655074",
     "asin": "4908655073",
     "readDate": "2021/03/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5074/9784908655074.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5074/9784908655074.jpg",
     "highlights": []
   },
   {
@@ -7393,7 +7393,7 @@
     "isbn": "9784151300080",
     "asin": "4151300082",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130008.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130008.jpg",
     "highlights": []
   },
   {
@@ -7404,7 +7404,7 @@
     "isbn": "9784142231140",
     "asin": "4142231146",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1140/9784142231140.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1140/9784142231140.jpg",
     "highlights": [
       {
         "text": "私は、人それぞれの答えでよい領域と、「だれもがこう考えるしかない」という意味で共有できる領域とがあると考えています。 たとえば、「私はどうやって生きるべきか、どんな人生でありたいか」という生き方の問いはどうでしょうか。これについては、最終的に「人それぞれ」で決めていくしかありません。答えがひとつに決められたら、自由がなくなってしまいますから。",
@@ -7440,7 +7440,7 @@
     "isbn": "9784862762580",
     "asin": "4862762581",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2580/9784862762580.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2580/9784862762580.jpg",
     "highlights": [
       {
         "text": "学習とはつまり理解のプロセス、メソッド、体系なのである。学習とは一つのことへの集中と計画性と内省をともなう活動であり、学習の方法がわかれば習得の度合いと効果は大きく上がる。",
@@ -7476,7 +7476,7 @@
     "isbn": "9784862464019",
     "asin": "4862464017",
     "readDate": "2021/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784862464019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784862464019.jpg",
     "highlights": []
   },
   {
@@ -7487,7 +7487,7 @@
     "isbn": "9784314001472",
     "asin": "431400147X",
     "readDate": "2021/03/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1472/9784314001472.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1472/9784314001472.jpg",
     "highlights": []
   },
   {
@@ -7498,7 +7498,7 @@
     "isbn": "9784336070999",
     "asin": "4336070997",
     "readDate": "2021/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0999/9784336070999.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0999/9784336070999.jpg",
     "highlights": []
   },
   {
@@ -7509,7 +7509,7 @@
     "isbn": "9784049129021",
     "asin": "4049129027",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9021/9784049129021.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9021/9784049129021.jpg",
     "highlights": []
   },
   {
@@ -7520,7 +7520,7 @@
     "isbn": "9784798124704",
     "asin": "4798124702",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4704/9784798124704.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4704/9784798124704.jpg",
     "highlights": [
       {
         "text": "ビューの使用は、原則として1段にとどめておくようにしましょう。システムの世界には、「過度に複雑な作りはシステムをダメにする」という思想があります。この思想を表現するスローガンを「 KISSの原則」と言います。それは次のようなものです。 勘どころ 58 Keep It Simple, Stupid.（単純にしておけ、このバカ）",
@@ -7536,7 +7536,7 @@
     "isbn": "9784041003053",
     "asin": "4041003059",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3053/9784041003053.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3053/9784041003053.jpg",
     "highlights": []
   },
   {
@@ -7547,7 +7547,7 @@
     "isbn": "9784041002636",
     "asin": "404100263X",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2636/9784041002636.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2636/9784041002636.jpg",
     "highlights": []
   },
   {
@@ -7558,7 +7558,7 @@
     "isbn": "9784750516509",
     "asin": "4750516503",
     "readDate": "2021/02/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6509/9784750516509.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6509/9784750516509.jpg",
     "highlights": []
   },
   {
@@ -7569,7 +7569,7 @@
     "isbn": "9784041001431",
     "asin": "4041001439",
     "readDate": "2021/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1431/9784041001431.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1431/9784041001431.jpg",
     "highlights": []
   },
   {
@@ -7580,7 +7580,7 @@
     "isbn": "9784044748531",
     "asin": "4044748535",
     "readDate": "2021/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8531/9784044748531.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8531/9784044748531.jpg",
     "highlights": []
   },
   {
@@ -7591,7 +7591,7 @@
     "isbn": "9784044748456",
     "asin": "4044748454",
     "readDate": "2021/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8456/9784044748456.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8456/9784044748456.jpg",
     "highlights": []
   },
   {
@@ -7602,7 +7602,7 @@
     "isbn": "9784040732718",
     "asin": "4040732715",
     "readDate": "2021/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2718/9784040732718.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2718/9784040732718.jpg",
     "highlights": []
   },
   {
@@ -7613,7 +7613,7 @@
     "isbn": "9784152099099",
     "asin": "4152099097",
     "readDate": "2021/02/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9099/9784152099099.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9099/9784152099099.jpg",
     "highlights": [
       {
         "text": "だが、この状況は、スマホのおかげでがらりと変わりつつある。というのも、スマホのカメラはこれまでの50mmレンズよりもはるかに広い画角を持っているからだ。 たとえばiPhoneXは水平方向の画角が65度で、ユーザーは後ろにさがらなくても、広い範囲を写真に収めることができる（しかしこれでもまだ、ある人気撮影テーマを撮るには広さが足りない。それが虹だ。虹は空に83度にわたって広がっているので〔虹の広がりの角度は太陽光線に対してプリズムとして働く水滴の屈折率から、色の違いによる広がりはあるが、半径約42度と決まっているため、全体を見渡したときの画角は約83～84度〕、iPhoneのフレームに収まるにはほんの少し広すぎる）。 このような広角レンズは、今後ますます普及するのではないだろうか。というのも、スマホのユーザーたちは、生活のさまざまな場面を自然に見えるように撮影したり、大勢が一度に写るような自撮りをしたいと思っているからだ。従来の50mmレンズのカメラを腕を伸ばして持った状態で自撮りをするのは難しい。そしてスマホでは撮影したあとで画像を簡単にクロップする（写真の不要な部分を切り取ること。従来トリミングと言われていたことに近い） ことができるので、スマホカメラの設計としてはやや「広すぎる」ぐらいにしておいて、ユーザーにズームなりクロップなりで好きな範囲の画像に加工してもらおうという考え方は理に 適っている。",
@@ -7629,7 +7629,7 @@
     "isbn": "9784775971949",
     "asin": "4775971948",
     "readDate": "2021/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1949/9784775971949.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1949/9784775971949.jpg",
     "highlights": [
       {
         "text": "●コストはできるだけ抑えることが大事。これは、リスク調整済み超過リターン（アルファ）を稼ぐ最も簡単な方法。 ●同じような特徴の異なる名前の銘柄を選ぶのではなく、企業の大きさ、投資スタイル、産業の集中度などに基づいて広範にわたって分散化することが重要。 ●市場を打ち負かすのは簡単ではない。これをやれる投資家はほとんどいない。したがって、市場ポートフォリオを複製するのは良い方法かもしれない。",
@@ -7681,7 +7681,7 @@
     "isbn": "9784151300813",
     "asin": "4151300813",
     "readDate": "2021/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130081.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130081.jpg",
     "highlights": [
       {
         "text": "ブランチは少し軽い口調でいった。 「人間なんて、まあ、そんなものよね。しがみついてた方がいいのに、投げだしちまったり、ほっとけばいいのに、引き受けたり。人生が本当と思えないくらい、美しく感じられて、うっとりしているかと思うと――たちまち地獄の苦しみと惨めさを経験する。物事がうまくいってるときは、そのままの状態がいつまでも続くような気がするけれど、そんなことは長続きしたためしがないんだし。どん底に沈みこんで、もういっぺん浮かびあがって息をつくことなんて、できそうにないと思っていると、そうでもない――人生ってそんなものじゃないの？」",
@@ -7701,7 +7701,7 @@
     "isbn": "9784142231164",
     "asin": "4142231162",
     "readDate": "2021/02/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1164/9784142231164.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1164/9784142231164.jpg",
     "highlights": [
       {
         "text": "ローマ時代のサルスティウス（＊４） は神話について「これらのことは決して起こったことがないが、いつも存在している」という有名な言葉を残していますが、昔話もこれと同じです。つまり昔話は、決して起こったことがないけれども、常に存在しているリアリティを持った物語なのです。だからこそ昔話はいつ読んでもおもしろいのです。",
@@ -7725,7 +7725,7 @@
     "isbn": "9784791703968",
     "asin": "4791703960",
     "readDate": "2021/02/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3968/9784791703968.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3968/9784791703968.jpg",
     "highlights": []
   },
   {
@@ -7736,7 +7736,7 @@
     "isbn": "9784142231096",
     "asin": "414223109X",
     "readDate": "2021/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1096/9784142231096.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1096/9784142231096.jpg",
     "highlights": []
   },
   {
@@ -7747,7 +7747,7 @@
     "isbn": "9784094082746",
     "asin": "4094082743",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2746/9784094082746.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2746/9784094082746.jpg",
     "highlights": []
   },
   {
@@ -7758,7 +7758,7 @@
     "isbn": "9784094082753",
     "asin": "4094082751",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2753/9784094082753.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2753/9784094082753.jpg",
     "highlights": []
   },
   {
@@ -7769,7 +7769,7 @@
     "isbn": "9784480020475",
     "asin": "4480020470",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0475/9784480020475.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0475/9784480020475.jpg",
     "highlights": [
       {
         "text": "新しいことを考えるのに、すべて自分の頭から絞り出せると思ってはならない。無から有を生ずるような思考などめったにおこるものではない。すでに存在するものを結びつけることによって、新しいものが生れる。",
@@ -7813,7 +7813,7 @@
     "isbn": "9784150307684",
     "asin": "4150307687",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1503/15030768.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1503/15030768.jpg",
     "highlights": [
       {
         "text": "宇宙へ出ること、別の星に住まうこと。それは人類でなくなること、宇宙に咀嚼されていくことなのかもしれない。",
@@ -7829,7 +7829,7 @@
     "isbn": "9784142231201",
     "asin": "4142231200",
     "readDate": "2021/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784142231201.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784142231201.jpg",
     "highlights": []
   },
   {
@@ -7840,7 +7840,7 @@
     "isbn": "9784142231133",
     "asin": "4142231138",
     "readDate": "2021/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1133/9784142231133.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1133/9784142231133.jpg",
     "highlights": []
   },
   {
@@ -7851,7 +7851,7 @@
     "isbn": "9784309207520",
     "asin": "4309207529",
     "readDate": "2021/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7520/9784309207520.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7520/9784309207520.jpg",
     "highlights": []
   },
   {
@@ -7862,7 +7862,7 @@
     "isbn": "9784197203284",
     "asin": "4197203284",
     "readDate": "2021/01/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3284/9784197203284.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3284/9784197203284.jpg",
     "highlights": []
   },
   {
@@ -7873,7 +7873,7 @@
     "isbn": "9784003750117",
     "asin": "400375011X",
     "readDate": "2021/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0037/00375011.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0037/00375011.jpg",
     "highlights": []
   },
   {
@@ -7884,7 +7884,7 @@
     "isbn": "9784309464992",
     "asin": "4309464998",
     "readDate": "2021/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4992/9784309464992.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4992/9784309464992.jpg",
     "highlights": [
       {
         "text": "三つの巨大企業は「三位一体・運命の全能の仕掛け人」というものを作り出していた。こうして、コンピュータのプログラムが「運命の書」となり、政党も天候も仕組まれたものとなった。さらに、エド・ハンマー三世がこの世に生を享けたこと自体も、特定の注文の結果なのである。そして、その特定の注文とは、また別の注文の結果に他ならない。もはや誰も自発的に生まれることもできなければ、死ぬこともできない。同様に、一人で、独力で、最後まで何かを経験するなどということも、もはや誰にもできないのだ。なぜならば、人間の思考、恐怖、努力、痛み──このどれ一つをとっても、コンピュータによる代数計算の連鎖の小さな一コマだからである。完全に「仕組まれた」生活からは取引の対象とならない価値が排除されてしまう以上、罪と罰、道徳的責任、善と悪といった概念はもはや空疎なものに過ぎない。人間のあらゆる特徴を百パーセント利用し、それを確かなシステムの中に組み入れることによって作り出されたこのコンピュータ天国。ここに何か問題があるとすれば、それはただ一つ、この世界がまさにそんな風に仕組まれていることを住民たちが知らないということだろう。",
@@ -7904,7 +7904,7 @@
     "isbn": "9784480064424",
     "asin": "4480064427",
     "readDate": "2020/12/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4424/9784480064424.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4424/9784480064424.jpg",
     "highlights": []
   },
   {
@@ -7915,7 +7915,7 @@
     "isbn": "9784041098516",
     "asin": "4041098513",
     "readDate": "2020/12/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8516/9784041098516.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8516/9784041098516.jpg",
     "highlights": []
   },
   {
@@ -7926,7 +7926,7 @@
     "isbn": "9784532357856",
     "asin": "4532357853",
     "readDate": "2020/12/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7856/9784532357856.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7856/9784532357856.jpg",
     "highlights": []
   },
   {
@@ -7937,7 +7937,7 @@
     "isbn": "9784791703944",
     "asin": "4791703944",
     "readDate": "2020/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3944/9784791703944.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3944/9784791703944.jpg",
     "highlights": []
   },
   {
@@ -7948,7 +7948,7 @@
     "isbn": "9784873118161",
     "asin": "4873118166",
     "readDate": "2020/11/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8161/9784873118161.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8161/9784873118161.jpg",
     "highlights": []
   },
   {
@@ -7959,7 +7959,7 @@
     "isbn": "9784815602505",
     "asin": "4815602506",
     "readDate": "2020/11/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2505/9784815602505.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2505/9784815602505.jpg",
     "highlights": []
   },
   {
@@ -7970,7 +7970,7 @@
     "isbn": "9784296105359",
     "asin": "4296105353",
     "readDate": "2020/10/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5359/9784296105359.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5359/9784296105359.jpg",
     "highlights": [
       {
         "text": "みずほＦＧの経営トップは勘定系システムの刷新を現場任せにして、情報システムのことを理解せず、必要な資金や人員を投入する決断ができなかった。情報システムの開発に際して業務部門が情報システム部門に全面的に協力したり、関係各所の利害を調整したりできるようリーダーシップを発揮することも怠った。経営陣のＩＴ軽視、ＩＴ理解不足が、大規模システム障害の根本的な原因だった。",
@@ -7994,7 +7994,7 @@
     "isbn": "9784106108204",
     "asin": "4106108208",
     "readDate": "2020/10/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8204/9784106108204.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8204/9784106108204.jpg",
     "highlights": [
       {
         "text": "ここに述べた実際の声は、大きく次の二つにまとめられるかと思います。一つは自己への気づきであり、もう一つは自己評価の向上です。",
@@ -8018,7 +8018,7 @@
     "isbn": "9784140886298",
     "asin": "4140886293",
     "readDate": "2020/10/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6298/9784140886298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6298/9784140886298.jpg",
     "highlights": []
   },
   {
@@ -8029,7 +8029,7 @@
     "isbn": "9784122069299",
     "asin": "4122069297",
     "readDate": "2020/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9299/9784122069299.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9299/9784122069299.jpg",
     "highlights": [
       {
         "text": "現代の世界にすでに存在する膨大な悪意の量をさらにふやしたければ、ユダヤ人対アラブ人、ドイツ人対チェコ人、インド人対イギリス人、ロシア人対ポーランド人、イタリア人対ユーゴスラヴィア人対抗の、一連のサッカーの試合をおこない、どの試合もさまざまな人種のまじった十万の観客に見せるのが一番だろう。むろん、スポーツが国際的対立の大きな原因の一つだなどと言うつもりはない。大規模なスポーツは、それ自体で、ナショナリズムを生んだ諸原因の一つの結果にすぎないと思うまでだ。それでも、全国代表のレッテルを貼った十一人のチームを派遣して他国のチームと戦わせ、どこの国にも、負けたほうの国は「面目を失う」という気持ちを抱かせておいたのでは、事態がますます悪化することは確実である。",
@@ -8065,7 +8065,7 @@
     "isbn": "9784150118266",
     "asin": "4150118264",
     "readDate": "2020/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8266/9784150118266.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8266/9784150118266.jpg",
     "highlights": []
   },
   {
@@ -8076,7 +8076,7 @@
     "isbn": "9784003246016",
     "asin": "4003246012",
     "readDate": "2020/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784003246016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784003246016.jpg",
     "highlights": []
   },
   {
@@ -8087,7 +8087,7 @@
     "isbn": "9784297111533",
     "asin": "4297111535",
     "readDate": "2020/09/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1533/9784297111533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1533/9784297111533.jpg",
     "highlights": [
       {
         "text": "本を読んで「よかった」「よくなかった」だけでなく、本が自分にどのように変化を及ぼしたかを考え抜く。そして、それを言葉にしてアウトプットする。そうすることで、ほかの人が受けた変化に敏感になれる。その変化を軸に、自分が築いてきた壁や井戸を乗り越え、より広く遠いところまで行ける先達を見つけることができるのだ。 わたしが書評を続けているのは、だれかに読んでもらうためでもあるのはもちろんだが、それはむしろ副次的なものなのかもしれない。ほかのだれよりも、まず自分が読み、自分がどう変化したかに自覚的になるために書いているのだ。",
@@ -8115,7 +8115,7 @@
     "isbn": "9784086310857",
     "asin": "4086310856",
     "readDate": "2020/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0857/9784086310857.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0857/9784086310857.jpg",
     "highlights": []
   },
   {
@@ -8126,7 +8126,7 @@
     "isbn": "9784065138243",
     "asin": "4065138248",
     "readDate": "2020/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8243/9784065138243.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8243/9784065138243.jpg",
     "highlights": []
   },
   {
@@ -8137,7 +8137,7 @@
     "isbn": "9784065175361",
     "asin": "4065175364",
     "readDate": "2020/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5361/9784065175361.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5361/9784065175361.jpg",
     "highlights": []
   },
   {
@@ -8148,7 +8148,7 @@
     "isbn": "9784641164048",
     "asin": "4641164045",
     "readDate": "2020/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4048/9784641164048.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4048/9784641164048.jpg",
     "highlights": []
   },
   {
@@ -8159,7 +8159,7 @@
     "isbn": "9784041308257",
     "asin": "4041308259",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "人々は、やたらに未来に 薔薇色 の幻影を描く。だが、未来には 混沌 と崩壊しかないと悟った時、 過去に達成されたもの の中にこそ、 完璧 の域にまでみがき上げられた、たしかな法悦がある事に気づくだろう。──私のように……",
@@ -8175,7 +8175,7 @@
     "isbn": "9784860112608",
     "asin": "4860112601",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2608/9784860112608.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2608/9784860112608.jpg",
     "highlights": []
   },
   {
@@ -8186,7 +8186,7 @@
     "isbn": "9784480067241",
     "asin": "4480067248",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7241/9784480067241.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7241/9784480067241.jpg",
     "highlights": []
   },
   {
@@ -8197,7 +8197,7 @@
     "isbn": "9784041065815",
     "asin": "404106581X",
     "readDate": "2020/08/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5815/9784041065815.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5815/9784041065815.jpg",
     "highlights": [
       {
         "text": "「これからの世界は、いったいどうなって行くんでしょうね？」 「さあ……」田口三佐は、ふいに妙な質問を出されて、ちょっと言葉につまった。 「どうなるって──あまりかわらんだろうね。もう戦争も大恐慌もなく……」 そういいかけて、彼はふとおどろいた。なるほど！──もう ずいぶん長い間、なにごともなくすごして来たのだ。何度か危機が叫ばれ、何度も寸前で回避された。大国の経済破綻が、世界市場をくつがえすかと思われた瞬間さえあったが、それも結局はやや長期にわたる不景気という形で回避された。──噂だけだが、アメリカの経済危機を、国際経済の舞台裏で、ソ連がすくってやったという話さえある。船でいえば「復元性」というやつが、世界全体に強くなってきつつあるみたいだ。これから先……。 「まあ、多少の振幅はあっても、わずかずつ、ゆっくりと、文明全体が進んで行くだろうね──それがどうしたんだい？」",
@@ -8257,7 +8257,7 @@
     "isbn": "9784150314439",
     "asin": "4150314438",
     "readDate": "2020/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4439/9784150314439.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4439/9784150314439.jpg",
     "highlights": []
   },
   {
@@ -8268,7 +8268,7 @@
     "isbn": "9784775941652",
     "asin": "4775941658",
     "readDate": "2020/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784775941652.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784775941652.jpg",
     "highlights": [
       {
         "text": "富の集中はごく自然な避けようのないことで、暴力的、あるいは平和的再配分によってときどき緩和される。この視点からとらえると、経済史とは、富の集中と強制的再配分という収縮・弛緩を繰り返す社会的有機体のゆっくりとした心臓の鼓動であるといえよう。",
@@ -8296,7 +8296,7 @@
     "isbn": "9784094518474",
     "asin": "4094518479",
     "readDate": "2020/08/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8474/9784094518474.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8474/9784094518474.jpg",
     "highlights": []
   },
   {
@@ -8307,7 +8307,7 @@
     "isbn": "9784094518252",
     "asin": "4094518258",
     "readDate": "2020/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784094518252.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784094518252.jpg",
     "highlights": []
   },
   {
@@ -8318,7 +8318,7 @@
     "isbn": "9784102114032",
     "asin": "4102114033",
     "readDate": "2020/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4032/9784102114032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4032/9784102114032.jpg",
     "highlights": [
       {
         "text": "天災というものは、事実、ざらにあることであるが、しかし、そいつがこっちの頭上に降りかかってきたときは、容易に天災とは信じられない。この世には、戦争と同じくらいの数のペストがあった。しかも、ペストや戦争がやってきたとき、人々はいつも同じくらい無用意な状態にあっ",
@@ -8362,7 +8362,7 @@
     "isbn": "9784622089230",
     "asin": "4622089238",
     "readDate": "2020/08/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9230/9784622089230.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9230/9784622089230.jpg",
     "highlights": []
   },
   {
@@ -8373,7 +8373,7 @@
     "isbn": "9784480065292",
     "asin": "4480065296",
     "readDate": "2020/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5292/9784480065292.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5292/9784480065292.jpg",
     "highlights": []
   },
   {
@@ -8384,7 +8384,7 @@
     "isbn": "9784001141276",
     "asin": "4001141272",
     "readDate": "2020/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1276/9784001141276.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1276/9784001141276.jpg",
     "highlights": [
       {
         "text": "ローマ時代のサルスティウス（＊４） は神話について「これらのことは決して起こったことがないが、いつも存在している」という有名な言葉を残していますが、昔話もこれと同じです。つまり昔話は、決して起こったことがないけれども、常に存在しているリアリティを持った物語なのです。だからこそ昔話はいつ読んでもおもしろいのです。",
@@ -8424,7 +8424,7 @@
     "isbn": "9784801923508",
     "asin": "480192350X",
     "readDate": "2020/08/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3508/9784801923508.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3508/9784801923508.jpg",
     "highlights": []
   },
   {
@@ -8435,7 +8435,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2020/07/26",
-    "thumnailImage": "https://m.media-amazon.com/images/I/511Dckd-UKL.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/511Dckd-UKL.jpg",
     "highlights": []
   },
   {
@@ -8446,7 +8446,7 @@
     "isbn": "9784049125184",
     "asin": "4049125188",
     "readDate": "2020/07/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5184/9784049125184.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5184/9784049125184.jpg",
     "highlights": [
       {
         "text": "「昔がどうだからって今が否定されるわけじゃないし……逆に今がいいから、昔がなかったことになるわけでもないんだけどさ。 繫 がりなんてあるようでないから、今こうしてるのが全部だし。今 綺麗 なら、今は好きなんだ。そう言うしかない」",
@@ -8462,7 +8462,7 @@
     "isbn": "9784040732688",
     "asin": "4040732685",
     "readDate": "2020/07/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2688/9784040732688.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2688/9784040732688.jpg",
     "highlights": []
   },
   {
@@ -8473,7 +8473,7 @@
     "isbn": "9784150314064",
     "asin": "4150314063",
     "readDate": "2020/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4064/9784150314064.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4064/9784150314064.jpg",
     "highlights": [
       {
         "text": "「『人生』という名前のゲームだ」と彼は答えた。「あるいは、『ゲーム』という名の人生だ」",
@@ -8509,7 +8509,7 @@
     "isbn": "9784150314057",
     "asin": "4150314055",
     "readDate": "2020/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4057/9784150314057.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4057/9784150314057.jpg",
     "highlights": [
       {
         "text": "なかった。サルはこの壮大な茶番を通じて、ある重要な真理を強く認識した。結局のところ、権力を握った者がすべてのルールを決めるのだ。サッカーの試合をしていたら、審判が「ゴールを決めるな」と命令してくる。審判に反抗してゴールを決めた選手は退場させられ、ゴールは無効にされる。結果的に、誰もゴールを決めようとはしなくなる。試合終了。五対〇、シハヌークの勝ち。いったいどうすればいい？ 答えは簡単だ。自分たちがルールを支配すればいい。選挙の顛末を受けて、カンボジア共産党は即座に合法部門の撤廃を決めた。権力者の定めたルールに従ってフェアプレイを行っても絶対に勝つことはできない。相手がルールを変更することで勝利を盤石にしようとするならば、自分たちもルールを逸脱してそれに応じなければならない。そのために手段を選んでいる場合ではない。残念ながら、革命が闘争であるという格言は正しい。驚くほど正しい。",
@@ -8541,7 +8541,7 @@
     "isbn": "9784065194287",
     "asin": "4065194288",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4287/9784065194287.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4287/9784065194287.jpg",
     "highlights": []
   },
   {
@@ -8552,7 +8552,7 @@
     "isbn": "9784150314415",
     "asin": "4150314411",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784150314415.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784150314415.jpg",
     "highlights": []
   },
   {
@@ -8563,7 +8563,7 @@
     "isbn": "9784150314408",
     "asin": "4150314403",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784150314408.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784150314408.jpg",
     "highlights": []
   },
   {
@@ -8574,7 +8574,7 @@
     "isbn": "9784122018334",
     "asin": "4122018331",
     "readDate": "2020/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8334/9784122018334.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8334/9784122018334.jpg",
     "highlights": [
       {
         "text": "大東亜戦争における諸作戦の失敗を、組織としての日本軍の失敗ととらえ直し、これを現代の組織にとっての教訓、あるいは反面教師として活用することが、本書の最も大きなねらいである。",
@@ -8622,7 +8622,7 @@
     "isbn": "9784041085219",
     "asin": "4041085217",
     "readDate": "2020/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5219/9784041085219.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5219/9784041085219.jpg",
     "highlights": []
   },
   {
@@ -8633,7 +8633,7 @@
     "isbn": "9784003278512",
     "asin": "4003278518",
     "readDate": "2020/06/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8512/9784003278512.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8512/9784003278512.jpg",
     "highlights": []
   },
   {
@@ -8644,7 +8644,7 @@
     "isbn": "9784049128963",
     "asin": "4049128969",
     "readDate": "2020/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8963/9784049128963.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8963/9784049128963.jpg",
     "highlights": []
   },
   {
@@ -8655,7 +8655,7 @@
     "isbn": "9784108310032",
     "asin": "4108310039",
     "readDate": "2020/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/9784108310032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/9784108310032.jpg",
     "highlights": []
   },
   {
@@ -8666,7 +8666,7 @@
     "isbn": "9784065197035",
     "asin": "4065197031",
     "readDate": "2020/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7035/9784065197035.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7035/9784065197035.jpg",
     "highlights": []
   },
   {
@@ -8677,7 +8677,7 @@
     "isbn": "9784094518467",
     "asin": "4094518460",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8467/9784094518467.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8467/9784094518467.jpg",
     "highlights": []
   },
   {
@@ -8688,7 +8688,7 @@
     "isbn": "9784094518450",
     "asin": "4094518452",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8450/9784094518450.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8450/9784094518450.jpg",
     "highlights": []
   },
   {
@@ -8699,7 +8699,7 @@
     "isbn": "9784094518368",
     "asin": "4094518363",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8368/9784094518368.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8368/9784094518368.jpg",
     "highlights": []
   },
   {
@@ -8710,7 +8710,7 @@
     "isbn": "9784041095430",
     "asin": "4041095433",
     "readDate": "2020/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5430/9784041095430.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5430/9784041095430.jpg",
     "highlights": []
   },
   {
@@ -8721,7 +8721,7 @@
     "isbn": "9784094518351",
     "asin": "4094518355",
     "readDate": "2020/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8351/9784094518351.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8351/9784094518351.jpg",
     "highlights": []
   },
   {
@@ -8732,7 +8732,7 @@
     "isbn": "9784044003678",
     "asin": "404400367X",
     "readDate": "2020/03/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9784044003678.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9784044003678.jpg",
     "highlights": [
       {
         "text": "蚊にとっておあつらえ向きの増殖環境も増やしてしまった。舗装の穴、植木鉢の受け皿、詰まった雨どい、よどんだドブなど身辺で水たまりは多い。ヒトスジシマカは、大さじ一杯ほどの水でも卵を産むことができる。昔の人は墓参りのときに、花入れに一〇円玉を入れて帰った。こうすると水の中に銅のイオンが溶け出して、ボウフラが生きられないからだ。こうした先人の知恵も継承されなくなった。",
@@ -8756,7 +8756,7 @@
     "isbn": "9784480683540",
     "asin": "4480683542",
     "readDate": "2020/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3540/9784480683540.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3540/9784480683540.jpg",
     "highlights": []
   },
   {
@@ -8767,7 +8767,7 @@
     "isbn": "9784087816846",
     "asin": "4087816842",
     "readDate": "2020/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784087816846.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784087816846.jpg",
     "highlights": []
   },
   {
@@ -8778,7 +8778,7 @@
     "isbn": "9784150314156",
     "asin": "4150314152",
     "readDate": "2020/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4156/9784150314156.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4156/9784150314156.jpg",
     "highlights": []
   },
   {
@@ -8789,7 +8789,7 @@
     "isbn": "9784049128505",
     "asin": "4049128500",
     "readDate": "2020/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784049128505.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784049128505.jpg",
     "highlights": []
   },
   {
@@ -8800,7 +8800,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2020/02/08",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51w2s0SQ%2BgL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51w2s0SQ%2BgL.jpg",
     "highlights": []
   },
   {
@@ -8811,7 +8811,7 @@
     "isbn": "9784062919357",
     "asin": "4062919354",
     "readDate": "2020/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9357/9784062919357.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9357/9784062919357.jpg",
     "highlights": []
   },
   {
@@ -8822,7 +8822,7 @@
     "isbn": "9784939103407",
     "asin": "4939103404",
     "readDate": "2020/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9391/93910340.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9391/93910340.jpg",
     "highlights": [
       {
         "text": "まず最初に言っておきたいのは、一つのトレード・アイデアに対しては常に資金の五パーセント以下の金しか使わないということだね。そうすれば二〇回君が間違ったとしても大丈夫だし、全部やられるまでには随分時間が稼げる。強調したいのは一つのアイデアに五パーセントということだよ。だからもし君が二つの穀物の商品でそれぞれロングしていても、その二つの商品に相関関係があるのであれば一つのアイデアと考えるべきだ。",
@@ -8854,7 +8854,7 @@
     "isbn": "9784041032190",
     "asin": "4041032199",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2190/9784041032190.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2190/9784041032190.gif",
     "highlights": []
   },
   {
@@ -8865,7 +8865,7 @@
     "isbn": "9784040822587",
     "asin": "4040822587",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2587/9784040822587.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2587/9784040822587.jpg",
     "highlights": []
   },
   {
@@ -8876,7 +8876,7 @@
     "isbn": "9784094516876",
     "asin": "4094516875",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6876/9784094516876.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6876/9784094516876.jpg",
     "highlights": []
   },
   {
@@ -8887,7 +8887,7 @@
     "isbn": "9784065124987",
     "asin": "4065124980",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4987/9784065124987.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4987/9784065124987.jpg",
     "highlights": []
   },
   {
@@ -8898,7 +8898,7 @@
     "isbn": "9784040731025",
     "asin": "4040731026",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1025/9784040731025.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1025/9784040731025.jpg",
     "highlights": [
       {
         "text": "誰に臆することなく自分の意見を述べられる＝自己中、空気読めない 他人の意見を柔軟に受け入れられる＝どうでもいい、人に興味がない",
@@ -8918,7 +8918,7 @@
     "isbn": "9784061497658",
     "asin": "4061497650",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0614/06149765.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0614/06149765.jpg",
     "highlights": []
   },
   {
@@ -8929,7 +8929,7 @@
     "isbn": "9784094517149",
     "asin": "4094517146",
     "readDate": "2020/01/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7149/9784094517149.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7149/9784094517149.jpg",
     "highlights": []
   },
   {
@@ -8940,7 +8940,7 @@
     "isbn": "9784775949061",
     "asin": "4775949063",
     "readDate": "2020/01/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9061/9784775949061.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9061/9784775949061.jpg",
     "highlights": [
       {
         "text": "１．ポーカーのさまざまな現実を理解し受け入れる ２．長期的視野でプレイする ３．金を儲けることよりも正しい決断を下すことを優先させる ４．金への執着を捨てる ５．自尊心を持ち込まない ６．あらゆる感情を決断から排除する ７．分析と改善のサイクルを継続的に繰り返す 上記",
@@ -8956,7 +8956,7 @@
     "isbn": "9784798615202",
     "asin": "479861520X",
     "readDate": "2020/01/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784798615202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784798615202.jpg",
     "highlights": []
   },
   {
@@ -8967,7 +8967,7 @@
     "isbn": "9784065151624",
     "asin": "4065151627",
     "readDate": "2020/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1624/9784065151624.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1624/9784065151624.jpg",
     "highlights": []
   },
   {
@@ -8978,7 +8978,7 @@
     "isbn": "9784866470863",
     "asin": "4866470860",
     "readDate": "2019/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0863/9784866470863.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0863/9784866470863.jpg",
     "highlights": []
   },
   {
@@ -8989,7 +8989,7 @@
     "isbn": "9784309464084",
     "asin": "4309464084",
     "readDate": "2019/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4084/9784309464084.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4084/9784309464084.jpg",
     "highlights": [
       {
         "text": "本書のタイトルからすれば皇子ハムレット、点、線、平面、ｎ次元の多平面と多容積、あらゆる総称語、そしておそらくわれわれ個々の人間や神を入れることが正当化されるだろう。要するに──一切の事柄の総計、宇宙である。しかしながらわれわれは、《想像の存在》という言葉が即座に喚起するものにのみ限ることとした。時と空間を通して人間の想像力によって考えられた奇妙な創造物の小冊子を編んだのである。",
@@ -9025,7 +9025,7 @@
     "isbn": "9784873118864",
     "asin": "4873118867",
     "readDate": "2019/12/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8864/9784873118864.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8864/9784873118864.jpg",
     "highlights": []
   },
   {
@@ -9036,7 +9036,7 @@
     "isbn": "9784102159743",
     "asin": "4102159746",
     "readDate": "2019/12/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9743/9784102159743.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9743/9784102159743.jpg",
     "highlights": []
   },
   {
@@ -9047,7 +9047,7 @@
     "isbn": "9784044090012",
     "asin": "4044090017",
     "readDate": "2019/12/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0012/9784044090012.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0012/9784044090012.jpg",
     "highlights": [
       {
         "text": "道徳なき商業における拝金主義と、空理空論の道徳論者の商業 蔑視 と、この両者に引き裂かれている実情に対して、渋沢は〈現実社会において生きることのできる道徳に基づいた商業〉をめざしたのである。それを可能とする接着剤、商業と道徳との接着剤として、渋沢が選んだのが儒教であった。",
@@ -9075,7 +9075,7 @@
     "isbn": "9784062880701",
     "asin": "4062880709",
     "readDate": "2019/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0701/9784062880701.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0701/9784062880701.jpg",
     "highlights": []
   },
   {
@@ -9086,7 +9086,7 @@
     "isbn": "9784894563810",
     "asin": "4894563819",
     "readDate": "2019/12/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3810/9784894563810.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3810/9784894563810.jpg",
     "highlights": [
       {
         "text": "かつての目標 ──長い長い間人類の目標だったものが、突然達成されはじめ出したら……じゃいったい、その時期にうまれてきた世代は、今度は 何を 目標にしたらいいんだ？ こいつは大問題だと思わないかい？──ねえ、ミナ、ぼくたちは、時間というエスカレーターにのっけられて、自動的にこの時代の中に押し上げられて行く。ところが、この華やかで上に行くほどすばらしい栄光で光り輝いているエスカレーターの、 金色 燦然 たる頂上のむこうには──何もないんだ。 光と喜びにみちた虚無があるだけなんだ！」 「すると、あとはまっさかさまってわけ？」ミナは、かすかに苦笑するように小首をかしげて、その深い、 菫色の眼を、ぼくにむけた。 「ちがうよ、ミナ。君は虚無ってものの性質をとりちがえているよ。虚無というやつは── おちて行くべき奈落 さえないんだ。すべてがあり、そしてささえるものはなにもない……」 「私は、別にいまが〝黄金時代のはじまり〟だなんて、思っちゃいないのよ」ミナは、ベンチの傍でたちどまった。「すわりましょうよ、タツヤ」 ぼくたちは、ペンキがほとんどはげおちたベンチに腰をおろした。 木肌 が 陽ざしをすってあたたかかった。 あたたかく、 満ち足りた金色の虚無……。",
@@ -9110,7 +9110,7 @@
     "isbn": "9784041417034",
     "asin": "4041417031",
     "readDate": "2019/12/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7034/9784041417034.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7034/9784041417034.jpg",
     "highlights": []
   },
   {
@@ -9121,7 +9121,7 @@
     "isbn": "9784046043931",
     "asin": "4046043938",
     "readDate": "2019/12/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3931/9784046043931.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3931/9784046043931.jpg",
     "highlights": [
       {
         "text": "まずは新渡戸稲造の談話からです。新渡戸が展開した野球批判はおおよそ次のようなものでした。 ・野球は 賤技 なり剛勇の気なし。 ・相手を常にペテンにかけよう、計略に陥れよう、 塁 を盗もうなど、眼を四方八面に配り神経を鋭くしてやる遊びである。 ・ゆえに米人には適するが英人やドイツ人には決して出来ない。 ・英国の国技たる 蹴球※７ のように鼻が曲がっても顎骨が歪んでもボールに嚙り付いているような勇剛な遊びは米人には出来ない。 ※７ ここではラグビーを指す。 ・日本の野球選手は礼儀を知らない。過日の軽井沢で行われた外国人との試合において不調法な野次を飛ばして試合が中止になったという。 ・海外では「スポーツマンライク」と言って非常に礼儀正しいことであるが、これを日本語に訳して「運動家らしい」と言うとなんというか礼儀も知らぬ 破落漢 の様に聞こえるのも日本の運動家の品性下劣から来ている。",
@@ -9145,7 +9145,7 @@
     "isbn": "9784800293671",
     "asin": "4800293677",
     "readDate": "2019/12/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3671/9784800293671.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3671/9784800293671.jpg",
     "highlights": []
   },
   {
@@ -9156,7 +9156,7 @@
     "isbn": "9784152098993",
     "asin": "4152098996",
     "readDate": "2019/12/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784152098993.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784152098993.jpg",
     "highlights": []
   },
   {
@@ -9167,7 +9167,7 @@
     "isbn": "9784150505424",
     "asin": "415050542X",
     "readDate": "2019/12/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5424/9784150505424.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5424/9784150505424.jpg",
     "highlights": [
       {
         "text": "定期的に運動を始めると、それがたとえ週に１回といった少ない回数でも、他の運動とは関係のない部分も、知らないうちに変わってくる。代表的なのが、運動を始めると食生活が向上し、さらに職場での生産性も上がるという現象だ。喫煙量が減り、同僚や家族に対しても寛大になる。クレジットカードを使う回数が減り、ストレスも軽減する。",
@@ -9187,7 +9187,7 @@
     "isbn": "9784791713882",
     "asin": "4791713885",
     "readDate": "2019/11/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3882/9784791713882.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3882/9784791713882.jpg",
     "highlights": []
   },
   {
@@ -9198,7 +9198,7 @@
     "isbn": "9784152093974",
     "asin": "4152093978",
     "readDate": "2019/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3974/9784152093974.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3974/9784152093974.jpg",
     "highlights": [
       {
         "text": "株価が正規分布になるのではなく、 収益率 が正規分布になっているのだ（＊",
@@ -9238,7 +9238,7 @@
     "isbn": "9784791703791",
     "asin": "4791703790",
     "readDate": "2019/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784791703791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784791703791.jpg",
     "highlights": []
   },
   {
@@ -9249,7 +9249,7 @@
     "isbn": "9784873115658",
     "asin": "4873115655",
     "readDate": "2019/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5658/9784873115658.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5658/9784873115658.jpg",
     "highlights": []
   },
   {
@@ -9260,7 +9260,7 @@
     "isbn": "9784150116699",
     "asin": "4150116695",
     "readDate": "2019/11/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6699/9784150116699.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6699/9784150116699.jpg",
     "highlights": [
       {
         "text": "今日まで記憶される彼の唯一の作品は『シリンダーの救世主』 The Messiah of the Cylinder（一九一七）で、Ｈ・Ｇ・ウエルズの『睡眠者が目ざめる時』 When the Sleeper Wakes に応えて書いたアンチユートピア小説である（本文の中で、ウエルズの名が何度も言及される）。これには『一九八四年』の非常に印象的な予測がいくつも含まれているから、ジョージ・オーウェルがルッソー（・エマニュエル）の小説を読んだことは、まずまちがいないと思われる（このテーマは、きっと彼にアピールしたのだろう（ １））。",
@@ -9300,7 +9300,7 @@
     "isbn": "9784040724577",
     "asin": "4040724577",
     "readDate": "2019/11/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4577/9784040724577.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4577/9784040724577.jpg",
     "highlights": []
   },
   {
@@ -9311,7 +9311,7 @@
     "isbn": "9784041305263",
     "asin": "4041305268",
     "readDate": "2019/11/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130526.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130526.jpg",
     "highlights": []
   },
   {
@@ -9322,7 +9322,7 @@
     "isbn": "9784783725121",
     "asin": "4783725128",
     "readDate": "2019/11/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7837/78372512.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7837/78372512.jpg",
     "highlights": []
   },
   {
@@ -9333,7 +9333,7 @@
     "isbn": "9784040734026",
     "asin": "4040734025",
     "readDate": "2019/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4026/9784040734026.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4026/9784040734026.jpg",
     "highlights": []
   },
   {
@@ -9344,7 +9344,7 @@
     "isbn": "9784094517811",
     "asin": "4094517812",
     "readDate": "2019/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7811/9784094517811.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7811/9784094517811.jpg",
     "highlights": []
   },
   {
@@ -9355,7 +9355,7 @@
     "isbn": "9784166602513",
     "asin": "4166602519",
     "readDate": "2019/11/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2513/9784166602513.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2513/9784166602513.jpg",
     "highlights": [
       {
         "text": "よい入門書は、まず最初に「私たちは何を知らないのか」を問います。「私たちはなぜそのことを知らないままで今日まで済ませてこられたのか」を問います。 これは実にラディカルな問いかけです。 なぜ、私たちはあることを「知らない」のでしょう？ なぜ今日までそれを「知らずに」きたのでしょう。単に面倒くさかっただけなのでしょうか？ それは違います。私たちがあることを知らない理由はたいていの場合一つしかありません。 「知りたくない」からです。 より厳密に言えば「自分があることを『知りたくない』と思っていることを知りたくない」からです。 無知というのはたんなる知識の欠如ではありません。「知らずにいたい」というひたむきな努力の成果です。無知は怠惰の結果ではなく、勤勉の結果なのです。 噓だと思ったら、親が説教くさいことを言い始めた瞬間にふいと遠い目をする子どもの様子を思い出して下さい。",
@@ -9379,7 +9379,7 @@
     "isbn": "9784061490178",
     "asin": "4061490176",
     "readDate": "2019/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0178/9784061490178.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0178/9784061490178.jpg",
     "highlights": []
   },
   {
@@ -9390,7 +9390,7 @@
     "isbn": "9784822242978",
     "asin": "4822242978",
     "readDate": "2019/11/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224297.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224297.jpg",
     "highlights": [
       {
         "text": "幼年期の成長の効率を最大化するために最適な方法は、トレーディング日誌をつけることである。すべての取引内容を記録するだけでなく、そのトレーディングに関する見解、アイデア、その取引の結果を記録しなければならない。学んだ教訓を日誌に記録することによって、その教訓を決して無駄にしないようにしなければならない。この日誌は自分を映す鏡、また、自分がどこへ向かおうとしているかを示す地図となるのである。すべての経験、感情、思考を記録する習慣を身につけることによって、最終的には、壮年期に至る恒常的な成長を確保できる。第2の人生において、第1の人生での努力と苦労が日々のトレーディングに反映されるようになるのである。",
@@ -9406,7 +9406,7 @@
     "isbn": "9784040722009",
     "asin": "4040722000",
     "readDate": "2019/11/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2009/9784040722009.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2009/9784040722009.jpg",
     "highlights": []
   },
   {
@@ -9417,7 +9417,7 @@
     "isbn": "9784334034696",
     "asin": "4334034691",
     "readDate": "2019/11/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4696/9784334034696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4696/9784334034696.jpg",
     "highlights": []
   },
   {
@@ -9428,7 +9428,7 @@
     "isbn": "9784101016412",
     "asin": "4101016410",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6412/9784101016412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6412/9784101016412.jpg",
     "highlights": []
   },
   {
@@ -9439,7 +9439,7 @@
     "isbn": "9784046043436",
     "asin": "4046043431",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3436/9784046043436.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3436/9784046043436.jpg",
     "highlights": []
   },
   {
@@ -9450,7 +9450,7 @@
     "isbn": "9784041069691",
     "asin": "4041069696",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9691/9784041069691.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9691/9784041069691.jpg",
     "highlights": [
       {
         "text": "日本、アメリカ、ヨーロッパの３つのマーケットのうち、時差の関係から月曜日に最初に市場が開くのは日本。 なので週末に世界的な事件が起きると、日本で最初に影響があらわれる。 イギリスのＥＵ離脱決定、トランプの勝利など、欧米の政治的な事件があると、まず大きく売られる。そのとき日本では売られすぎる傾向がある。 僕の経験からいえば、こういうときは 90％は逆張りで買っていい。 トランプの大統領選勝利のように、「今後どうなってしまうんだ？」という状況のときこそ逆張りだ。 もちろん、これは何か大事件が起きた場合の話。通常時にダウ先物が安くなっているからといって逆張りするのは、「上がっているときには買い」の原則に反する。 逆パターンで、週末にアメリカに好材料が出て、ダウ先物が４００くらい大きくプラスしているときに日経平均も爆上げしたら、空売りする。 だいたいすぐ戻る。",
@@ -9466,7 +9466,7 @@
     "isbn": "9784049121650",
     "asin": "4049121654",
     "readDate": "2019/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1650/9784049121650.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1650/9784049121650.jpg",
     "highlights": [
       {
         "text": "「昔がどうだからって今が否定されるわけじゃないし……逆に今がいいから、昔がなかったことになるわけでもないんだけどさ。 繫 がりなんてあるようでないから、今こうしてるのが全部だし。今 綺麗 なら、今は好きなんだ。そう言うしかない」",
@@ -9482,7 +9482,7 @@
     "isbn": "9784150117009",
     "asin": "4150117004",
     "readDate": "2019/10/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7009/9784150117009.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7009/9784150117009.jpg",
     "highlights": [
       {
         "text": "これから物語るのは、数年の前後はあってもだいたい第二次大戦から第三次大不況のあいだに落ちつく、あの悪夢の時代の実話である。",
@@ -9506,7 +9506,7 @@
     "isbn": "9784150413378",
     "asin": "4150413371",
     "readDate": "2019/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3378/9784150413378.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3378/9784150413378.jpg",
     "highlights": []
   },
   {
@@ -9517,7 +9517,7 @@
     "isbn": "9784040724607",
     "asin": "4040724607",
     "readDate": "2019/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4607/9784040724607.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4607/9784040724607.jpg",
     "highlights": []
   },
   {
@@ -9528,7 +9528,7 @@
     "isbn": "9784040729367",
     "asin": "4040729366",
     "readDate": "2019/10/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9367/9784040729367.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9367/9784040729367.jpg",
     "highlights": []
   },
   {
@@ -9539,7 +9539,7 @@
     "isbn": "9784040729350",
     "asin": "4040729358",
     "readDate": "2019/10/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9350/9784040729350.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9350/9784040729350.jpg",
     "highlights": []
   },
   {
@@ -9550,7 +9550,7 @@
     "isbn": "9784065170168",
     "asin": "4065170168",
     "readDate": "2019/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0168/9784065170168.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0168/9784065170168.jpg",
     "highlights": [
       {
         "text": "われわれがいま生きている「この社会」とは、どんな社会なのでしょうか。 「社会」というよく分からないものの情勢をさぐるために、従来「右／左」あるいは「保守／リベラル」という概念対が用いられてきました。「右」「左」「保守」「リベラル」というそれぞれの言葉の中身は、話し手の立場や文脈によってその都度、微妙に異なったりします。しかしまずは一般的に、「保守」あるいは「右」を「伝統や歴史を守って急激な社会変化を好まない傾向性」、「リベラル」あるいは「左」を「平等な社会を目指して社会を（ときに急進的に） 改革しようとする方向性」と理解するところから話をはじめましょう。",
@@ -9570,7 +9570,7 @@
     "isbn": "9784040721996",
     "asin": "4040721993",
     "readDate": "2019/10/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1996/9784040721996.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1996/9784040721996.jpg",
     "highlights": [
       {
         "text": "あとがきを書きながらも、自分の青春時代はいつだったかなと考えています。高校と大学は同じくらい楽しかったのですが、青春というワードを入れると高校の 頃 かな？ くだらない思い出でいっぱいです。教室でチョーク粉パーティーをして身体中カラフルで早退したり、 顧問 の自転車の空気キャップを 抜いてマンホールの中に 証拠 隠滅 したり、授業中にマリオ○ートで８人対戦してレインボーロードでめっちゃ身体が 傾いたり。 当時の自分からしたら 些細 なことなのでしょうが、こうやって思い出すとゴミみたいな 奴 だなと改めて実感します。でもゴミみたいなこと、今読んでる中高生の皆さんは進行形でやっているだろうし、大学生や社会人の方もやってきたはずです。否定させません、絶対やってます。赤の他人からしたらゴミみたいなのですが、当の本人たちにとっては、すげー楽しいですよね。芸人にとって鼻水はダイアモンドと同じです。だからこそ、今が青春の人たちって、すげー 羨ましいです。部活帰りにコンビニでたむろしている学生さんを見ると、ノスタルジックな気持ちになります。ベンチで初々しくも制服カップルが会話しているのを見たら、後ろからベンチを引っくり返したくなります。いや、これは僕が中高生時代から思ってることだから関係なさそうです。 青春時代は 戻ってきません。だからこそ僕は、自分ができなかった体験を補うべく書いているのかもしれません。カッコイイこと言ったなと思いましたが、最初に書こうと思ったジャンルはバトルものでした。 というわけで、今が青春だという方々は、思う存分に青春してください。凪木同様に青春なんか終わっちまったという方々は、たまに集まった友達と昔話に花を 咲かしたり、ガールズバーでチャンネーと会話したり、青春ラブコメを読んで過去補正… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -9586,7 +9586,7 @@
     "isbn": "9784334754099",
     "asin": "4334754090",
     "readDate": "2019/10/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4099/9784334754099.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4099/9784334754099.jpg",
     "highlights": []
   },
   {
@@ -9597,7 +9597,7 @@
     "isbn": "9784480084392",
     "asin": "4480084398",
     "readDate": "2019/10/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48008439.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48008439.jpg",
     "highlights": [
       {
         "text": "第一、功利的にいっても、いまあるヒトの脳というものを、手間暇かけて人工的に作ったところで、なんの得もない。ヒトの脳を作る必要などまったくない。そんなものなら、いまだって、それこそ腐るほどある。これは当り前のことだが、しばしば誤解を生じる点である。人工知能が人間を置き換えるというのは、単なる誤解に過ぎない。第一、機械というのは、ヒトの脳ほどいい加減なものではない。 それなら、ヒトの脳を置換するものはないか。それはもちろんある。あると思う。それはなにか。ヒトの脳を包含する脳である。",
@@ -9617,7 +9617,7 @@
     "isbn": "9784532197698",
     "asin": "4532197694",
     "readDate": "2019/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7698/9784532197698.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7698/9784532197698.jpg",
     "highlights": []
   },
   {
@@ -9628,7 +9628,7 @@
     "isbn": "9784041073261",
     "asin": "404107326X",
     "readDate": "2019/10/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3261/9784041073261.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3261/9784041073261.jpg",
     "highlights": [
       {
         "text": "「われわれの時代は、あまりにも理性を過大評価しているのかも知れんな……」テッドはにやにや笑った。「吸いこんだだけで、恍惚となる香りがあることを思うと、これから先は、〝古代の知恵〟である、フェロモンや向精神薬のことを、もっと考えなきゃいかんだろう。──人類の〝幸福〟のために……」",
@@ -9656,7 +9656,7 @@
     "isbn": "9784152098863",
     "asin": "4152098864",
     "readDate": "2019/09/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8863/9784152098863.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8863/9784152098863.jpg",
     "highlights": [
       {
         "text": "しかし、そうやって半ば暴力的に規範となる文化を取り入れることによって、それまで見えていなかったものが見えてくるのだ。なんとなくカッコ良さそうだからという理由で、理解できないフランス映画を観る。賢く見られたいからという理由で、ニーチェやマルクスやピケティを読む。人気だからという理由で、日本画やモダンアートの展覧会へ行く。そうやって、人々は本来興味のなかったものに興味を持つ。",
@@ -9676,7 +9676,7 @@
     "isbn": "9784103145332",
     "asin": "4103145331",
     "readDate": "2019/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5332/9784103145332.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5332/9784103145332.jpg",
     "highlights": []
   },
   {
@@ -9687,7 +9687,7 @@
     "isbn": "9784532197681",
     "asin": "4532197686",
     "readDate": "2019/09/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7681/9784532197681.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7681/9784532197681.jpg",
     "highlights": []
   },
   {
@@ -9698,7 +9698,7 @@
     "isbn": "9784150505448",
     "asin": "4150505446",
     "readDate": "2019/09/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5448/9784150505448.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5448/9784150505448.jpg",
     "highlights": []
   },
   {
@@ -9709,7 +9709,7 @@
     "isbn": "9784003234310",
     "asin": "4003234316",
     "readDate": "2019/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4310/9784003234310.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4310/9784003234310.jpg",
     "highlights": []
   },
   {
@@ -9720,7 +9720,7 @@
     "isbn": "9784048932851",
     "asin": "4048932853",
     "readDate": "2019/09/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2851/9784048932851.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2851/9784048932851.jpg",
     "highlights": []
   },
   {
@@ -9731,7 +9731,7 @@
     "isbn": "9784150503536",
     "asin": "4150503532",
     "readDate": "2019/09/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3536/9784150503536.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3536/9784150503536.jpg",
     "highlights": [
       {
         "text": "いったい病気の「本質」とか「新しい病気」とはなにをいうのか？ 医者は自然科学者とはちがう。自然科学者は、多くの生命体を広くとりあげ、それらがある方法によってある環境に適合してゆくさまを研究するが、このとき、方法も環境も平均で考えている。これに反して医者が問題にするのは、一個の生命体、すなわち、逆境のなかで自己のアイデンティティを守りぬこうとする個人としての人間である。",
@@ -9775,7 +9775,7 @@
     "isbn": "9784101171081",
     "asin": "4101171084",
     "readDate": "2019/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -9786,7 +9786,7 @@
     "isbn": "9784150505431",
     "asin": "4150505438",
     "readDate": "2019/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5431/9784150505431.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5431/9784150505431.jpg",
     "highlights": [
       {
         "text": "その昔、まだ人工知能という言葉すら存在していなかった頃、アラン・チューリング（ 74） はすでに機械の自己学習に言及していた。一九四八年と一九五〇年に執筆した、機械の知能に関する論文の中で、彼はこう述べている。機械が 考える ためには、より正確には、考えることができる生物のように行動するためには、われわれを取り巻く世界や社会の実情に関する膨大な量の知識を持たなくてはならない、と。しかし、これらの知識を機械に移行するのは気の遠くなるような作業であるばかりか、終わりがない。人間の知識には明確な限度というものがないからだ。チューリングによれば、知識をいちいちプログラム言語に変換するよりも、機械に学習能力を持たせる方がはるかに効率的だという。つまり、機械が周囲の状況や自らのいる場所、自らの行動を観察し、それによって知識や技術を獲得する能力を持つということだ。",
@@ -9810,7 +9810,7 @@
     "isbn": "9784003394816",
     "asin": "400339481X",
     "readDate": "2019/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4816/9784003394816.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4816/9784003394816.jpg",
     "highlights": []
   },
   {
@@ -9821,7 +9821,7 @@
     "isbn": "9784062586702",
     "asin": "4062586703",
     "readDate": "2019/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6702/9784062586702.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6702/9784062586702.jpg",
     "highlights": []
   },
   {
@@ -9832,7 +9832,7 @@
     "isbn": "9784775971147",
     "asin": "477597114X",
     "readDate": "2019/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1147/9784775971147.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1147/9784775971147.jpg",
     "highlights": [
       {
         "text": "一．長期間にわたって平均以上の利益を上げることができる企業を探す 二．その企業の株価が本質的価値より安くなるまで待ってから買う 三．企業価値が低下するか、株価が割高になるか、さらに優れた投資先が見つかるまで、その銘柄を保有する。保有期間は、月単位というよりも年単位で考える 四．この手順を必要に応じて繰り返す",
@@ -9860,7 +9860,7 @@
     "isbn": "9784167913403",
     "asin": "4167913402",
     "readDate": "2019/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3403/9784167913403.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3403/9784167913403.jpg",
     "highlights": []
   },
   {
@@ -9871,7 +9871,7 @@
     "isbn": "9784864727778",
     "asin": "4864727775",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7778/9784864727778.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7778/9784864727778.jpg",
     "highlights": []
   },
   {
@@ -9882,7 +9882,7 @@
     "isbn": "9784150502225",
     "asin": "4150502226",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2225/9784150502225.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2225/9784150502225.jpg",
     "highlights": [
       {
         "text": "いわゆる あまりに 人間的なものは、ほとんどつねに、 前 人間的なものであり、したがってわれわれにも高等動物にも共通に存在するものだ、ということを理解してもらいたい。心配は無用、私は人間の性質をそのまま動物に投影しているわけではない。むしろ私はその逆に、どれほど多くの動物的な遺産が人間の中に残っているかをしめしているにすぎないのだ。私",
@@ -9914,7 +9914,7 @@
     "isbn": "9784344032156",
     "asin": "4344032152",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2156/9784344032156.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2156/9784344032156.jpg",
     "highlights": [
       {
         "text": "長く運営されることで徐々に特定の層に利益が滞留し始めると、当然それ以外の人の間で新しいシステムの誕生を望む声が高まっていきます。 また人間には「飽き」があるので、長く同じ環境にいると不満がなかったとしても、新しい環境を望んでしまう傾向があります。",
@@ -9942,7 +9942,7 @@
     "isbn": "9784150313838",
     "asin": "4150313830",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3838/9784150313838.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3838/9784150313838.jpg",
     "highlights": []
   },
   {
@@ -9953,7 +9953,7 @@
     "isbn": "9784094511420",
     "asin": "4094511423",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1420/9784094511420.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1420/9784094511420.jpg",
     "highlights": []
   },
   {
@@ -9964,7 +9964,7 @@
     "isbn": "9784004315414",
     "asin": "4004315417",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5414/9784004315414.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5414/9784004315414.jpg",
     "highlights": [
       {
         "text": "多数決という意思集約の方式は、日本を含む多くの国の選挙で当たり前に使われている。だがそれは慣習のようなもので、他の方式と比べて優れているから採用されたわけではない。そもそも多数決以外の方式を考えたりはしないのが通常だろう。だが民主制のもとで選挙が果たす重要性を考えれば、多数決を安易に採用するのは、思考停止というより、もはや文化的奇習の一種である。",
@@ -10000,7 +10000,7 @@
     "isbn": "9784334754082",
     "asin": "4334754082",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4082/9784334754082.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4082/9784334754082.jpg",
     "highlights": []
   },
   {
@@ -10011,7 +10011,7 @@
     "isbn": "9784101171197",
     "asin": "410117119X",
     "readDate": "2019/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1197/9784101171197.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1197/9784101171197.jpg",
     "highlights": []
   },
   {
@@ -10022,7 +10022,7 @@
     "isbn": "9784152098801",
     "asin": "4152098805",
     "readDate": "2019/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8801/9784152098801.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8801/9784152098801.jpg",
     "highlights": [
       {
         "text": "「あんた、何者だ」無理に発した声も掠れ気味だったが、彼女はあっさりと応じた。 「北条美亜羽」 ミァハ。どこかで聞き覚えのある名前に出くわし、検索を掛けようとして、実継はヒエロが外れてしまっていることを思い出す。それを見透かしたように彼女が告げた。 「小説から取った、僕自身でつけた名前だ。二十一世紀初頭のディストピア文学から」",
@@ -10066,7 +10066,7 @@
     "isbn": "9784101171340",
     "asin": "4101171343",
     "readDate": "2019/08/10",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51FcOSxanPL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51FcOSxanPL.jpg",
     "highlights": [
       {
         "text": "そこにおいてこそ作者は、胸を張って言おうではないか。読者に誤読の自由があるのなら、作者にだって「誤作」の自由があると。 読者はこの虚構に参加していただきたい。いや。展開にかかわった以上、その読者はこの虚構の作者であると同時に登場人物になることさえあり得る。作者が作中に登場することは、今となってはさほど珍しいことではない。",
@@ -10086,7 +10086,7 @@
     "isbn": "9784044092221",
     "asin": "4044092222",
     "readDate": "2019/08/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2221/9784044092221.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2221/9784044092221.jpg",
     "highlights": [
       {
         "text": "小プリニウスに限らず、多くのローマ人にとって（といっても、上層のローマ人にとって、という意味だが）の理想の老後は、 otium honestum という言葉に要約できます。直訳すると「名誉ある閑暇」ですが、わかりやすくいうと、老後の時間を高尚な趣味に費やし楽しむこと、同輩や後輩の範となるように最期を生きること、でした。 しかし、この名誉ある閑暇を実現させるためには、名声、財力、教養の三つに加えて、心身の健康が必要条件でした。小プリニウスは、これらの諸条件がすべてそろって初めて理想の老後を送ることができる、と信じていたので、三二歳で痛風を患って以来、その痛みに苦しめられ続け、老境にいたってもはやその痛みに耐えられなくなったクィントゥス＝コレッリウス＝ルフスが自ら食を断って六七歳で自害したことを、ひどく悲しみましたが、と同時に、その死に方に理解も示しています（同一・一二）。大事なのは、どれだけ生きるかではなく、いかに生きるかである、",
@@ -10102,7 +10102,7 @@
     "isbn": "9784150103149",
     "asin": "4150103143",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/51Q5q1sn1xL._SX334_BO1,204,203,200_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/51Q5q1sn1xL._SX334_BO1,204,203,200_.jpg",
     "highlights": [
       {
         "text": "司書の話だと、英語じゃないんですって。でも、それに近いラテン語はあるそうです。ウビーク（ｕｂｉｑｕｅ）といって、その意味は──」 「あらゆる場所、だ」ジョーはいった。 フランセスカ・スパニッシュはうなずいた。「ええ、そういう意味。でも、ＵＢＩＫという単語はありません。夢の中ではそんな綴りだったけど」 「おなじ単語だよ」ジョーはいった。「ただ、綴りがちがうだけさ」",
@@ -10122,7 +10122,7 @@
     "isbn": "9784140057063",
     "asin": "4140057068",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7063/9784140057063.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7063/9784140057063.jpg",
     "highlights": []
   },
   {
@@ -10133,7 +10133,7 @@
     "isbn": "9784061590922",
     "asin": "4061590928",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0922/9784061590922.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0922/9784061590922.jpg",
     "highlights": [
       {
         "text": "群衆は、ただ過激な感情にのみ動かされるのであるから、その心を捉えようとする弁士は、強い断定的な言葉を大いに用いねばならない。誇張し断言し 反覆 すること、そして推論によって何かを証明しようと決して試みないこと、これが、民衆の会合で弁士がよく用いる論法である。",
@@ -10173,7 +10173,7 @@
     "isbn": "9784022618443",
     "asin": "4022618442",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8443/9784022618443.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8443/9784022618443.jpg",
     "highlights": [
       {
         "text": "都会ではそうした環境は稀少です。親が「外遊び」というのを相当意識して、そういう場所に連れて行くなどして、かなり意図的にさせないと、自分からはしません。 つまり、親にそういう知識、意識、意欲があるかないかで、子どもの脳の発達に大きな格差が生まれてしまう。 最近、都心の公園をたまたま通りがかった友人から聞いた話です。 子どもが木登りをしていました。イチジクの木に登って実を食べていたのです。 しかも相当に高いところまで登っていたのは、なんと女の子でした。 聞くと、名門と呼ばれる私立小学校の子でした。下に数人の子がいて見ていたそうです。 私立小へ行くことと頭の良し悪しは直接には関係しませんが、少なくとも彼女の親は教育に熱心だったはずです。だとすると、幼いころから、外遊びも十分にさせていた可能性があります。 一方で、そういうことをさせられなかった子どもは、木登りもできなければ、勉強もできない。その子が大人になって、子どもを生んでも、そういう教育をしない。そうすれば、その子どもも同じようになってしまう。 私が危惧しているのは、そういう格差です。 小学校の先生からも、こんな話を聞きました。最近の子どもは、かけっこが速い子どもは勉強もできる。身体に特に異状はないのに、かけっこがちゃんとできない子は勉強もできないそうです。 せめて「バリアオンリー」の家を、と言ったのも、こういう事態が進みかねないからです。",
@@ -10237,7 +10237,7 @@
     "isbn": "9784041085202",
     "asin": "4041085209",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784041085202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784041085202.jpg",
     "highlights": []
   },
   {
@@ -10248,7 +10248,7 @@
     "isbn": "9784041075548",
     "asin": "4041075548",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5548/9784041075548.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5548/9784041075548.jpg",
     "highlights": []
   },
   {
@@ -10259,7 +10259,7 @@
     "isbn": "9784041061114",
     "asin": "4041061113",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1114/9784041061114.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1114/9784041061114.jpg",
     "highlights": []
   },
   {
@@ -10270,7 +10270,7 @@
     "isbn": "9784041061091",
     "asin": "4041061091",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1091/9784041061091.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1091/9784041061091.jpg",
     "highlights": []
   },
   {
@@ -10281,7 +10281,7 @@
     "isbn": "9784845914333",
     "asin": "4845914336",
     "readDate": "2019/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4333/9784845914333.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4333/9784845914333.jpg",
     "highlights": [
       {
         "text": "その日のうちにやりたいこと、やらねばならないことを決め、それを毎日必ず決まった時間にやる。そうすれば欲望に煩わされることはない」",
@@ -10305,7 +10305,7 @@
     "isbn": "9784844398844",
     "asin": "4844398849",
     "readDate": "2019/07/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8844/9784844398844.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8844/9784844398844.jpg",
     "highlights": []
   },
   {
@@ -10316,7 +10316,7 @@
     "isbn": "9784905073246",
     "asin": "4905073243",
     "readDate": "2019/07/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3246/9784905073246.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3246/9784905073246.jpg",
     "highlights": []
   },
   {
@@ -10327,7 +10327,7 @@
     "isbn": "9784898154151",
     "asin": "4898154158",
     "readDate": "2019/07/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4151/9784898154151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4151/9784898154151.jpg",
     "highlights": [
       {
         "text": "「え？ 青春？」 「青春映画とか青春小説とか、あとロックのバンドが歌ってるでしょ、若者の悩みやら葛藤みたいなのを。でもね、あんなの青春だと思ったらダメよ。あれは全部、大人が作ってるんだからね」 「うん？」 「ああいうのは大人のみみっちい後悔を子供に演じさせてるだけなの。あんたは本物の子供なんだから、そんなのに付き合わなくて",
@@ -10359,7 +10359,7 @@
     "isbn": "9784334962272",
     "asin": "4334962270",
     "readDate": "2019/07/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2272/9784334962272.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2272/9784334962272.jpg",
     "highlights": [
       {
         "text": "もし 暗黒 郷 がわれわれの未来のなかにあるとすれば――人種差別的なファシズムへと社会が回帰することを予想した作家フィリップ・ロスやシンクレア・ルイスが描く悪夢のなかにではなく――能力にもとづく生産性至上主義という教えのなかにあるはずだ。",
@@ -10375,7 +10375,7 @@
     "isbn": "9784905425182",
     "asin": "4905425182",
     "readDate": "2019/07/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5182/9784905425182.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5182/9784905425182.jpg",
     "highlights": [
       {
         "text": "スマナサーラ 「自分に合っている仕事を探す」ということに対しては、私はずっと養老先生と同じく、反対意見を言っています。あれは「自分を変えたくはない」「発展させたくはない」「プログレスさせたくはない」という反進化論です。進化させたくないんです。 釈 今の人たちは、「確固たる自分」というものが「ある」ということを前提としている。だからこそ、「何かもっと自分に向いた仕事があるんじゃないか」とか、「もっと自分にぴったりの場所があるんじゃないか」という方向へと向かってしまうのでしょうね。そういえば、一時期、「自分探し」なんていう言葉も 流行りました。しかし、その「本当の自分がどこかにある」という前提と、だから「それを損ないたくない」「それを必死で守ろうとする」といった生き方は、構造的な苦悩を生み出し続けるのではないでしょうか。",
@@ -10391,7 +10391,7 @@
     "isbn": "9784336063557",
     "asin": "4336063559",
     "readDate": "2019/07/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3557/9784336063557.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3557/9784336063557.jpg",
     "highlights": []
   },
   {
@@ -10402,7 +10402,7 @@
     "isbn": "9784150117245",
     "asin": "4150117241",
     "readDate": "2019/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7245/9784150117245.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7245/9784150117245.jpg",
     "highlights": []
   },
   {
@@ -10413,7 +10413,7 @@
     "isbn": "9784152098498",
     "asin": "415209849X",
     "readDate": "2019/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8498/9784152098498.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8498/9784152098498.jpg",
     "highlights": [
       {
         "text": "無限の図書館が示すこのメタファーはこれまでに、ほかにも無数のかたちで表現されてきた。音符のありとあらゆる組み合わせ、さまざまなものを収めた無限に続くキャビネット、ありうるかぎりのたんぱく質配列の連なり、推理小説のありとあらゆるプロット、神を意味する秘密の呼称の一覧、万人に開かれた図書館としての世界や自然やグーグル、普遍的著作としての聖書、コーラン、ファースト・フォリオ、そして『フィネガンズ・ウェイク』、タイプライターを打つサル、あらゆる次元の暗号文、自動筆記、連続的物語叙述（訳注 絵画などで異なる時間をひとつの構図のなかに描き込む方法。異時同図とも呼ばれる）、名もなき都市、数学的および量子力学的不確定性の形式的叙述、未知の海（mare incognitum） や無主の地（terra nullius）、ありとあらゆるツイート。ピクセルで構成されるを使用すれば、あらゆる文字列だけでなく、あらゆる画像を作り出せる。固体は理論上、限りなく薄い平面にスライスできる。",
@@ -10437,7 +10437,7 @@
     "isbn": "9784152098702",
     "asin": "4152098708",
     "readDate": "2019/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8702/9784152098702.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8702/9784152098702.jpg",
     "highlights": [
       {
         "text": "全身全霊で研究に打ち込むんだ。成果を得ることなど考えず、ひたすら励め。研究に専念していれば、知らず知らずのうちに一生が終わる。〝腰を据える〟というのは、つまりそういうことだ。 あるいはその反対に、金儲けを唯一の目標として、どうやって稼ぐかだけを一心不乱に考えるのでもいい。その場合も、稼いだ金をどう使うかなんか考えちゃだめだ。そして死ぬ間際、枕元に山積みになった金貨を見ながら、グランデ（一八三三年に刊行されたバルザックの長篇小説『ウジェニー・グランデ』の登場人物） みたいにこう言うのさ。『ああ、これで体が温まる』ってね……。だから、すばらしい人生を送る鍵は、なにかひとつのものに夢中になることにある。たとえば父さんの場合は……」",
@@ -10457,7 +10457,7 @@
     "isbn": "9784065160145",
     "asin": "4065160146",
     "readDate": "2019/07/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0145/9784065160145.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0145/9784065160145.jpg",
     "highlights": [
       {
         "text": "やはり HKE の別名義にあたる THE DARKEST FUTURE の『FLORAL SHOPPE 2』は、アメリカの音楽家 Vektroid によるヴェイパーウェイヴの金字塔といえる作品『FLORAL SHOPPE』の悪意に満ちたパロディであると同時に、ある意味でヴェイパーウェイヴのひとつの極北といえる作品だ。資本主義に対する批判的アイロニーの極点、それは端的に世界の終末──アーティスト名が表しているように「もっともダークな未来」──を提示することであり、そのためにはヴェイパーウェイヴそれ自体を破壊することすら厭わない。",
@@ -10481,7 +10481,7 @@
     "isbn": "9784150505387",
     "asin": "4150505381",
     "readDate": "2019/07/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5387/9784150505387.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5387/9784150505387.jpg",
     "highlights": [
       {
         "text": "情報を集めるという行為そのものが結果に悪影響を与えてしまう場合に、どうしたら適切な情報にもとづく判断ができるのだろう。これはきわめて困難な状況で、パラドックスに限りなく近いと言える。 この種の問題にぶつかったとき、たいていの人は直感的に、「見る」ことと「跳ぶ」ことを 秤 にかける必要があるというようなことを口にするだろう。つまり、判断基準を定めるのに十分な数のアパートを見たうえで、その基準を満たすものならよしとするということだ。実際、このように秤にかけるという考え方は正論そのものだ。もっとも、どこで線を引くべきかと問われたら、ほとんどの人は自信をもって答えることが できない。しかし、安心してよい。答えはあるのだ。 三七パーセント。 最良の物件に入居できる可能性を最大にしたければ、部屋探しに 充てる時間の三七パーセント（一カ月かけるつもりなら最初の一一日間）までは結論を出さずにただ物件を見て回る。小切手帳は家に置いておき、判断基準を定めることに専念する。しかし三七パーセント以降は、それまでに見たどの物件よりもよい部屋に出会ったらすぐさま保証金を払って契約するのだ。これは「見る」と「跳ぶ」を直感的に満足のいく形で折りあわせた答えであるばかりでなく、 最適であることが証明可能な 解となる。",
@@ -10541,7 +10541,7 @@
     "isbn": "9784150313791",
     "asin": "4150313792",
     "readDate": "2019/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784150313791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784150313791.jpg",
     "highlights": [
       {
         "text": "「人は誰でも他人を苦しめ、不幸にする、たとえその気がなくともね。誰かの役に立たねばならない、周囲を幸福にせねばならないなんてさ、考えないことだ。もしそんなことが実現できていると感じたなら、それは思い上がりってもん",
@@ -10557,7 +10557,7 @@
     "isbn": "9784309025216",
     "asin": "4309025218",
     "readDate": "2019/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5216/9784309025216.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5216/9784309025216.jpg",
     "highlights": [
       {
         "text": "ＡＲは街を美しくする──そういう触れ込みだった。 ひしめく看板。がなり立てる音声広告。いきなり目の前に突き出されるフライヤー。それらは物理的実体を伴っていて、聞きたくない音、見たくない色彩を排除できず、チラシを配る人間や地置きの広告サインは歩行のさまたげとなった。それにくらべて、ＡＲならばいくらでもフィルタできる。空間という資源をほとんど侵害しない。好きなデザインで世界を飾ることもできる。そう 喧伝 されていたのだ。 実は逆だった。 ユーザが自分でフィルタを設定するからこそ ＡＲで飾られた街は魅力を失うのだ。 街は自室ではない。ねむるための巣穴ではなく、獲物を獲りにゆく山野なのだ。 街の光景も多数の主体の自律的活動が織りなす点では、山野と変わらぬ一種の〈自然〉だ。自分の思い通りにならない他者の 横溢。そこにこそ街の価値はある。ＡＲを重ね書きすることは、狩り場じゅうに自分の体臭を塗りこめるような愚行だ。",
@@ -10597,7 +10597,7 @@
     "isbn": "9784121506016",
     "asin": "4121506014",
     "readDate": "2019/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784121506016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784121506016.jpg",
     "highlights": [
       {
         "text": "愛は消える。変容する。形を変える。何を定義しているかすら、もはやわからない。愛に実態は乏しい。恋人との交歓の中で互いに「愛している」とささやきあったところで、その意味するものが必ずしも同じことだという保証はない。 なぜなら愛は、あいまいなものであるからだ。",
@@ -10645,7 +10645,7 @@
     "isbn": "9784309464855",
     "asin": "4309464858",
     "readDate": "2019/06/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4855/9784309464855.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4855/9784309464855.jpg",
     "highlights": [
       {
         "text": "仕事の多さから夢は生じ、言葉の多さから暴言は生じるものである。",
@@ -10665,7 +10665,7 @@
     "isbn": "9784864726924",
     "asin": "4864726922",
     "readDate": "2019/06/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6924/9784864726924.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6924/9784864726924.jpg",
     "highlights": []
   },
   {
@@ -10676,7 +10676,7 @@
     "isbn": "9784040730301",
     "asin": "4040730305",
     "readDate": "2019/06/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0301/9784040730301.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0301/9784040730301.jpg",
     "highlights": []
   },
   {
@@ -10687,7 +10687,7 @@
     "isbn": "9784864727488",
     "asin": "4864727481",
     "readDate": "2019/06/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7488/9784864727488.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7488/9784864727488.jpg",
     "highlights": []
   },
   {
@@ -10698,7 +10698,7 @@
     "isbn": "9784434208232",
     "asin": "4434208233",
     "readDate": "2019/06/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8232/9784434208232.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8232/9784434208232.jpg",
     "highlights": []
   },
   {
@@ -10709,7 +10709,7 @@
     "isbn": "9784003279250",
     "asin": "4003279255",
     "readDate": "2019/06/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9250/9784003279250.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9250/9784003279250.jpg",
     "highlights": [
       {
         "text": "はっきりした物言いより、暗示の方が遥かにその効果が大きいのです。人間の心理にはどうやら、断定に対してはそれを否定しようとする傾きがある。",
@@ -10749,7 +10749,7 @@
     "isbn": "9784150504489",
     "asin": "4150504482",
     "readDate": "2019/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4489/9784150504489.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4489/9784150504489.jpg",
     "highlights": [
       {
         "text": "ヨーロッパでは、貴金属不足の状況を打破するために二つの方策を考えた。一つは、労働と製品、つまり奴隷と木材を輸出することで、バグダッドで銀を、コルドバやカイロではアフリカの金を入手する方法だ。もう一方は、イスラム社会に戦争を挑んで貴金属を略奪するやり方だ。繰り返しおこなわれた十字軍の遠征やそれに引き続く征服のための戦いは、異教徒をキリスト教徒に改宗させるという目的のほか、ヨーロッパの貴金属不足を克服しようという意図があった。",
@@ -10781,7 +10781,7 @@
     "isbn": "9784864726672",
     "asin": "4864726671",
     "readDate": "2019/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6672/9784864726672.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6672/9784864726672.jpg",
     "highlights": []
   },
   {
@@ -10792,7 +10792,7 @@
     "isbn": "9784150122232",
     "asin": "4150122237",
     "readDate": "2019/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2232/9784150122232.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2232/9784150122232.jpg",
     "highlights": [
       {
         "text": "自分が何者かを知る唯一の方法は、新しいなにかを創造することだろう。",
@@ -10812,7 +10812,7 @@
     "isbn": "9784152094452",
     "asin": "4152094451",
     "readDate": "2019/05/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4452/9784152094452.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4452/9784152094452.jpg",
     "highlights": [
       {
         "text": "「私さ」梃子はいった。「したくないことしなくていいようにしたくて」 周りが梃子を見た。「したくないこと？」 「昔あったんだけど幼稚園で」咳払い梃子は言葉を継いだ。「おもちゃだったと思うんだけどさ、先生がいうのよはいじゃあお片付け競争しますみたいな。誰が一番速いかなあそれじゃあ用意どんとかっていうとさあ、みんな何か片付け始めるんだよね。あほみたいなんだけどさ本当。あれ本当頭おかしいよね。私は片付けたくねえんだっつうの、何でびりだと馬鹿みたいになんだよって思って。馬鹿みたいにいわれたんだけどさその時に私。何かさあやりたくないこととか？ 強制的に何かやらす時ってすぐに競争にするよね人は」いって梃子は恥ずかしそうに笑った。「ああいうのよくないよね。競争させればいうこと聞くだろみたいな発想？ 不健全だよね。子供は馬鹿だからさあ、聞いちゃうわけじゃんそういう風にされると。そうじゃなく正しくない圧力には屈しちゃ駄目ってこと教えないと」",
@@ -10840,7 +10840,7 @@
     "isbn": "9784532357696",
     "asin": "4532357691",
     "readDate": "2019/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7696/9784532357696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7696/9784532357696.jpg",
     "highlights": []
   },
   {
@@ -10851,7 +10851,7 @@
     "isbn": "9784167910600",
     "asin": "4167910608",
     "readDate": "2019/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0600/9784167910600.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0600/9784167910600.jpg",
     "highlights": [
       {
         "text": "会計は、収入と支出を集計するだけでなく、投資家に還元すべき利益剰余金の累計を計算するために活用されたのである。",
@@ -10867,7 +10867,7 @@
     "isbn": "9784150118457",
     "asin": "4150118450",
     "readDate": "2019/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8457/9784150118457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8457/9784150118457.jpg",
     "highlights": []
   },
   {
@@ -10878,7 +10878,7 @@
     "isbn": "9784822244576",
     "asin": "4822244571",
     "readDate": "2019/05/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224457.jpg",
     "highlights": []
   },
   {
@@ -10889,7 +10889,7 @@
     "isbn": "9784093801041",
     "asin": "4093801045",
     "readDate": "2019/05/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1041/9784093801041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1041/9784093801041.jpg",
     "highlights": [
       {
         "text": "かつては漁業そのものが原始的略奪産業と呼ばれていた時代がある。農業のように育てることをせず、資本を使わず、自然界が生産した漁獲物を収奪してくるからだ。",
@@ -10917,7 +10917,7 @@
     "isbn": "9784309464695",
     "asin": "4309464696",
     "readDate": "2019/05/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4695/9784309464695.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4695/9784309464695.jpg",
     "highlights": [
       {
         "text": "新しいものが何ひとつないことを 知っているゆえに何ごとをもはじめないのは 衒学的な詭弁── 原罪だ。",
@@ -10933,7 +10933,7 @@
     "isbn": "9784532355395",
     "asin": "4532355397",
     "readDate": "2019/05/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5395/9784532355395.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5395/9784532355395.jpg",
     "highlights": []
   },
   {
@@ -10944,7 +10944,7 @@
     "isbn": "9784049120172",
     "asin": "4049120178",
     "readDate": "2019/04/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784049120172.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784049120172.jpg",
     "highlights": []
   },
   {
@@ -10955,7 +10955,7 @@
     "isbn": "9784040731018",
     "asin": "4040731018",
     "readDate": "2019/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1018/9784040731018.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1018/9784040731018.jpg",
     "highlights": []
   },
   {
@@ -10966,7 +10966,7 @@
     "isbn": "9784150504427",
     "asin": "4150504423",
     "readDate": "2019/04/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4427/9784150504427.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4427/9784150504427.jpg",
     "highlights": []
   },
   {
@@ -10977,7 +10977,7 @@
     "isbn": "9784150505363",
     "asin": "4150505365",
     "readDate": "2019/04/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784150505363.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784150505363.jpg",
     "highlights": []
   },
   {
@@ -10988,7 +10988,7 @@
     "isbn": "9784048936163",
     "asin": "4048936166",
     "readDate": "2019/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6163/9784048936163.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6163/9784048936163.jpg",
     "highlights": []
   },
   {
@@ -10999,7 +10999,7 @@
     "isbn": "9784150118440",
     "asin": "4150118442",
     "readDate": "2019/04/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8440/9784150118440.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8440/9784150118440.jpg",
     "highlights": []
   },
   {
@@ -11010,7 +11010,7 @@
     "isbn": "9784152098375",
     "asin": "4152098376",
     "readDate": "2019/03/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8375/9784152098375.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8375/9784152098375.jpg",
     "highlights": []
   },
   {
@@ -11021,7 +11021,7 @@
     "isbn": "9784152098412",
     "asin": "4152098414",
     "readDate": "2019/03/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784152098412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784152098412.jpg",
     "highlights": []
   },
   {
@@ -11032,7 +11032,7 @@
     "isbn": "9784492444474",
     "asin": "4492444475",
     "readDate": "2019/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4474/9784492444474.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4474/9784492444474.jpg",
     "highlights": []
   },
   {
@@ -11043,7 +11043,7 @@
     "isbn": "9784492654651",
     "asin": "4492654658",
     "readDate": "2019/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784492654651.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784492654651.jpg",
     "highlights": []
   },
   {
@@ -11054,7 +11054,7 @@
     "isbn": "9784781651132",
     "asin": "4781651135",
     "readDate": "2019/03/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784781651132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784781651132.jpg",
     "highlights": []
   },
   {
@@ -11065,7 +11065,7 @@
     "isbn": "9784152097767",
     "asin": "4152097760",
     "readDate": "2019/03/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7767/9784152097767.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7767/9784152097767.jpg",
     "highlights": []
   },
   {
@@ -11076,7 +11076,7 @@
     "isbn": "9784152097750",
     "asin": "4152097752",
     "readDate": "2019/02/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7750/9784152097750.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7750/9784152097750.jpg",
     "highlights": []
   },
   {
@@ -11087,7 +11087,7 @@
     "isbn": "9784781617268",
     "asin": "4781617263",
     "readDate": "2019/02/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7268/9784781617268.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7268/9784781617268.jpg",
     "highlights": []
   },
   {
@@ -11098,7 +11098,7 @@
     "isbn": "9784781617411",
     "asin": "4781617417",
     "readDate": "2019/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7411/9784781617411.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7411/9784781617411.jpg",
     "highlights": []
   },
   {
@@ -11109,7 +11109,7 @@
     "isbn": "9784864106627",
     "asin": "4864106622",
     "readDate": "2019/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6627/9784864106627.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6627/9784864106627.jpg",
     "highlights": []
   },
   {
@@ -11120,7 +11120,7 @@
     "isbn": "9784532197353",
     "asin": "453219735X",
     "readDate": "2019/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7353/9784532197353.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7353/9784532197353.jpg",
     "highlights": []
   },
   {
@@ -11131,7 +11131,7 @@
     "isbn": "9784532197346",
     "asin": "4532197341",
     "readDate": "2019/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7346/9784532197346.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7346/9784532197346.jpg",
     "highlights": []
   },
   {
@@ -11142,7 +11142,7 @@
     "isbn": "9784532197339",
     "asin": "4532197333",
     "readDate": "2019/02/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7339/9784532197339.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7339/9784532197339.jpg",
     "highlights": []
   },
   {
@@ -11153,7 +11153,7 @@
     "isbn": "9784152095596",
     "asin": "4152095598",
     "readDate": "2019/02/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5596/9784152095596.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5596/9784152095596.jpg",
     "highlights": [
       {
         "text": "幸福は「自分の注意を何にどう割り振るか」で決まる。",
@@ -11221,7 +11221,7 @@
     "isbn": "9784492503027",
     "asin": "4492503021",
     "readDate": "2019/02/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3027/9784492503027.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3027/9784492503027.jpg",
     "highlights": []
   },
   {
@@ -11232,7 +11232,7 @@
     "isbn": "9784797382228",
     "asin": "4797382228",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2228/9784797382228.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2228/9784797382228.jpg",
     "highlights": []
   },
   {
@@ -11243,7 +11243,7 @@
     "isbn": "9784150312343",
     "asin": "4150312346",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2343/9784150312343.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2343/9784150312343.jpg",
     "highlights": [
       {
         "text": "そして、何の意味もない人生だった。 妻もいない。子供もいない。自分が何のためにこの世界を生きてきたのか意味を見出せない。俺が唯一愛した人は、俺のせいでこの世界から消えてしまった。 だが、それももう終わりだ。 泡は沈む。 さぁ、世界を消し去ってしまおう。 こんな、愛する人のいない世界なんて。",
@@ -11263,7 +11263,7 @@
     "isbn": "9784150312336",
     "asin": "4150312338",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2336/9784150312336.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2336/9784150312336.jpg",
     "highlights": [
       {
         "text": "「ああいう作品のほとんどって、主人公が何度も世界をやり直して自分の望む未来に変えていくって感じじゃない？ 思ったんだけど、それって主人公が自分の望まない並行世界を勝手に否定してるってことなのよね。その世界はその世界で、自分じゃない自分が生きて作り上げてきた世界なのに」",
@@ -11279,7 +11279,7 @@
     "isbn": "9784887218215",
     "asin": "4887218214",
     "readDate": "2019/02/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8215/9784887218215.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8215/9784887218215.jpg",
     "highlights": []
   },
   {
@@ -11290,7 +11290,7 @@
     "isbn": "9784142230907",
     "asin": "4142230905",
     "readDate": "2019/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0907/9784142230907.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0907/9784142230907.jpg",
     "highlights": []
   },
   {
@@ -11301,7 +11301,7 @@
     "isbn": "9784908925344",
     "asin": "4908925348",
     "readDate": "2019/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5344/9784908925344.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5344/9784908925344.jpg",
     "highlights": []
   },
   {
@@ -11312,7 +11312,7 @@
     "isbn": "9784152097200",
     "asin": "4152097205",
     "readDate": "2019/01/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7200/9784152097200.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7200/9784152097200.jpg",
     "highlights": [
       {
         "text": "一般的な一〇代の若者は、グループのなかで信頼される存在になりたいと願い、少なくとも温かく受け容れられたいと考えるものだ。そして、服や音楽について友人たちと共通の好みをもつことが、グループに受け容れられるひとつの手段になる。このとき、特定のアーティストやバンドの存在が、好きな音楽ジャンルを選ぶ決め手となる。あなたや友人たちは、たんにリコーダーが使われているからといって、一部の曲をそのジャンルから除外しようとするのではなく、アルバムやアーティスト全体を支持するようになる。もうひとつ大切なのは、まわりのほぼ全員を「ダサい」とみなすことによって、あなたと友人は自分たちを「かっこいい」と考えるということだ。あるかっこいいバンドを見つけたら、自分たちだけが彼らのファンなのだと信じようとする。だから、大好きなバンドがメインストリームで人気を集めるようになると、ひどくがっかりするものだ。一",
@@ -11356,7 +11356,7 @@
     "isbn": "9784309464831",
     "asin": "4309464831",
     "readDate": "2019/01/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4831/9784309464831.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4831/9784309464831.jpg",
     "highlights": [
       {
         "text": "ある。ミラノの自宅の書物の迷路（まさに記憶の集積）に私たちを誘いつつ、ウンベルト・エーコはこう言う。「私たちの存在は私たち自身の記憶にほかならない。記憶こそ私たちの魂、記憶を失えば私たちは魂を失う」と。 記憶を失ってはならない、繰り返しこう言い続けたエーコの言葉を、私たちも心にとどめておきたい。",
@@ -11372,7 +11372,7 @@
     "isbn": "9784101050089",
     "asin": "4101050082",
     "readDate": "2019/01/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0089/9784101050089.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0089/9784101050089.jpg",
     "highlights": []
   },
   {
@@ -11383,7 +11383,7 @@
     "isbn": "9784480082961",
     "asin": "4480082964",
     "readDate": "2019/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2961/9784480082961.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2961/9784480082961.jpg",
     "highlights": []
   },
   {
@@ -11394,7 +11394,7 @@
     "isbn": "9784150504144",
     "asin": "4150504148",
     "readDate": "2019/01/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4144/9784150504144.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4144/9784150504144.jpg",
     "highlights": [
       {
         "text": "ショーペンハウアーはこう書いている。「とてもわかりやすく、それでいて何とも不可解な、言いようのない音楽の深みは、音楽が私たちの最も内側にある感情をすべて再現しているのに、リアリティがまったくなく、痛みからはかけ離れている……という事実に起因する。音楽は人生とそこで起こる出来事の真髄のみを表現し、決してそれ自体を表現するのではない」 音楽を聴くと聴覚を使い、感情がわくだけでなく、運動することにもなる。「われわれは筋肉を使って音楽を聴く」とニーチェも書いている。",
@@ -11434,7 +11434,7 @@
     "isbn": "9784150503901",
     "asin": "4150503907",
     "readDate": "2019/01/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3901/9784150503901.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3901/9784150503901.jpg",
     "highlights": []
   },
   {
@@ -11445,7 +11445,7 @@
     "isbn": "9784153350151",
     "asin": "415335015X",
     "readDate": "2019/01/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0151/9784153350151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0151/9784153350151.jpg",
     "highlights": []
   },
   {
@@ -11456,7 +11456,7 @@
     "isbn": "9784336042972",
     "asin": "4336042977",
     "readDate": "2019/01/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3360/33604297.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3360/33604297.jpg",
     "highlights": []
   },
   {
@@ -11467,7 +11467,7 @@
     "isbn": "9784766425192",
     "asin": "4766425197",
     "readDate": "2019/01/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5192/9784766425192.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5192/9784766425192.jpg",
     "highlights": []
   },
   {
@@ -11478,7 +11478,7 @@
     "isbn": "9784864727174",
     "asin": "4864727171",
     "readDate": "2019/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7174/9784864727174.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7174/9784864727174.jpg",
     "highlights": []
   },
   {
@@ -11489,7 +11489,7 @@
     "isbn": "9784334753504",
     "asin": "4334753507",
     "readDate": "2019/01/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3504/9784334753504.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3504/9784334753504.jpg",
     "highlights": [
       {
         "text": "は、あなたたちが、まるで永遠に生きられるかのように生きているからだ。あなたたちが、自分のもろさにいつまでも気づかないからだ。あなたたちが、どれだけたくさんの時間が過ぎてしまったかを、気にもとめないからだ。あなたたちが、まるで豊かにあふれる泉から湧いてくるかのように、時間を無駄使いしているからだ。たぶん、そんなことをしているうちに、あなたたちの最後の日となる、まさにその日がやってくるのだろう――まあその日だって、［自分のためでなく］ 別のだれかや、別の用事のために使われているわけだがね。 あなたたちは、どんなことでも、死すべき人間のように恐れる。そのくせ、どんなことでも、不死なる神のように欲するのだ。",
@@ -11573,7 +11573,7 @@
     "isbn": "9784863542457",
     "asin": "4863542453",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2457/9784863542457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2457/9784863542457.jpg",
     "highlights": []
   },
   {
@@ -11584,7 +11584,7 @@
     "isbn": "9784864726658",
     "asin": "4864726655",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6658/9784864726658.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6658/9784864726658.jpg",
     "highlights": []
   },
   {
@@ -11595,7 +11595,7 @@
     "isbn": "9784094516104",
     "asin": "4094516107",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6104/9784094516104.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6104/9784094516104.jpg",
     "highlights": []
   },
   {
@@ -11606,7 +11606,7 @@
     "isbn": "9784152097866",
     "asin": "4152097868",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7866/9784152097866.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7866/9784152097866.jpg",
     "highlights": []
   },
   {
@@ -11617,7 +11617,7 @@
     "isbn": "9784041308011",
     "asin": "4041308011",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/81NctqtympL._SL200_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/81NctqtympL._SL200_.jpg",
     "highlights": [
       {
         "text": "失業罪などという罪ができたのも、憲法改正のおかげだ。改正に反対しきれなかったのは、革新勢力が 反対 にばかり熱をいれ、しかも反対運動の足なみがそろわなかったからだ。─",
@@ -11665,7 +11665,7 @@
     "isbn": "9784560080399",
     "asin": "4560080399",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0399/9784560080399.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0399/9784560080399.jpg",
     "highlights": []
   },
   {
@@ -11676,7 +11676,7 @@
     "isbn": "9784152098061",
     "asin": "4152098066",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8061/9784152098061.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8061/9784152098061.jpg",
     "highlights": []
   },
   {
@@ -11687,7 +11687,7 @@
     "isbn": "9784003279298",
     "asin": "4003279298",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9298/9784003279298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9298/9784003279298.jpg",
     "highlights": []
   },
   {
@@ -11698,7 +11698,7 @@
     "isbn": "9784891767815",
     "asin": "4891767812",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7815/9784891767815.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7815/9784891767815.jpg",
     "highlights": []
   },
   {
@@ -11709,7 +11709,7 @@
     "isbn": "9784150311308",
     "asin": "4150311307",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1308/9784150311308.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1308/9784150311308.jpg",
     "highlights": [
       {
         "text": "彼女は機嫌良さそうに、式の引き出物の相談をしてきたよ。どうも、僕と暮らしていたのは、得体のしれない化け物だったらしい。僕は恐怖した。もし彼女の不貞を知っていることを悟られたら、この化け物に殺されると思って、表面を取り繕って誤魔化し、夜は二人で買った寝台に入って、知らない男の体液が付いているのを知りながら、それでも逃げられずに、朝までずっと吐き気に耐えた。地獄さ。それからは、助かりたい一心で離別を進めた。その女は、彼とは別れるつもりだったんです、本当に好きなのは貴方なんです、なんていう代筆作家が考えたような台詞を並べ立てて、ああ、これは本当に人間ではないのかもしれない、機械的な反射で言葉を並べるだけ、一見して自我のように見えるだけで、その実は神経節の反応で動くだけの、昆虫のようなものなんだと理解した。そうして僕は、その本質的な理解と引き換えに、ほとんど全てを失ったのさ」 私は言葉を無くし、酒を呷ったが、飲み干しても次の言葉が出ず、注ぎ足そうとして、しかし、瓶は空で、沈黙だけが続いた。遠",
@@ -11729,7 +11729,7 @@
     "isbn": "9784334039790",
     "asin": "4334039790",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9790/9784334039790.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9790/9784334039790.jpg",
     "highlights": [
       {
         "text": "故郷に残った４人と比べ、移住した４人は、社会経済的にあきらかに高いにあり、そのまま最期を迎えることになる。私の祖父が若いころに気づいていたように、ヒルビリーにとって社会的に上昇する最善の方法は、州外に移住することだったのだ。",
@@ -11769,7 +11769,7 @@
     "isbn": "9784040728247",
     "asin": "4040728246",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8247/9784040728247.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8247/9784040728247.jpg",
     "highlights": []
   },
   {
@@ -11780,7 +11780,7 @@
     "isbn": "9784040728186",
     "asin": "4040728181",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8186/9784040728186.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8186/9784040728186.jpg",
     "highlights": [
       {
         "text": "誰に臆することなく自分の意見を述べられる＝自己中、空気読めない 他人の意見を柔軟に受け入れられる＝どうでもいい、人に興味がない",
@@ -11800,7 +11800,7 @@
     "isbn": "9784140817513",
     "asin": "4140817518",
     "readDate": "2018/12/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7513/9784140817513.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7513/9784140817513.jpg",
     "highlights": []
   },
   {
@@ -11811,7 +11811,7 @@
     "isbn": "9784150504533",
     "asin": "4150504539",
     "readDate": "2018/12/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4533/9784150504533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4533/9784150504533.jpg",
     "highlights": []
   },
   {
@@ -11822,7 +11822,7 @@
     "isbn": "9784041308196",
     "asin": "4041308194",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "「読まざるこそ自然なれ」といっても、──その知恵さえ、 読まなければ、あたえられないという、おかしなパラドックスによって呪われている。『ホモ』は『サピエンス』によって呪われているのだ。その 種 がこの地球上に出現した時から……。",
@@ -11890,7 +11890,7 @@
     "isbn": "9784309625034",
     "asin": "4309625037",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5034/9784309625034.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5034/9784309625034.jpg",
     "highlights": []
   },
   {
@@ -11901,7 +11901,7 @@
     "isbn": "9784065132555",
     "asin": "406513255X",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2555/9784065132555.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2555/9784065132555.jpg",
     "highlights": []
   },
   {
@@ -11912,7 +11912,7 @@
     "isbn": "9784094517620",
     "asin": "4094517626",
     "readDate": "2018/11/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7620/9784094517620.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7620/9784094517620.jpg",
     "highlights": [
       {
         "text": "たった一言で伝えられる想いもあれば、どんなに言葉を尽くしたって届かない気持ちもあり、だからこそ、ありとあらゆる手段でもって、それを形にしようとするのです。 例えば、小説なんてその最たるものなのではないでしょうか。 語らないからこそ伝わるものがあり、語り倒すことで何一つ伝えないこともある。 その解釈のほとんどすべては読者の方に委ねるほかないのですが、願わくば、少しでも多く、この想いが届けばいいなと祈りながら私は日々書いております。 あるいは、彼と彼女も。さらに言えば、彼も彼女も。 そんな風に言葉を 紡ぎ、心をつなぎ、日々の続きを送っていくのだと思います。",
@@ -11948,7 +11948,7 @@
     "isbn": "9784791771035",
     "asin": "4791771036",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1035/9784791771035.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1035/9784791771035.jpg",
     "highlights": []
   },
   {
@@ -11959,7 +11959,7 @@
     "isbn": "9784781607986",
     "asin": "4781607985",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7986/9784781607986.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7986/9784781607986.jpg",
     "highlights": []
   },
   {
@@ -11970,7 +11970,7 @@
     "isbn": "9784775972328",
     "asin": "4775972324",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2328/9784775972328.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2328/9784775972328.jpg",
     "highlights": [
       {
         "text": "株式投資で成功する戦略とは、アメリカの上場企業の株式すべてを、極めて低いコストで保有すること、である。そうすることで、これらの企業が配当や利益成長というかたちでもたらすリターンのほぼすべてを獲得することができるのだ。 この戦略を実行する最良の方法も極めてシンプルだ。 市場全体のポートフォリオを有するファンドを取得し、永遠に持ち続けることである。",
@@ -12026,7 +12026,7 @@
     "isbn": "9784040697437",
     "asin": "404069743X",
     "readDate": "2018/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7437/9784040697437.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7437/9784040697437.jpg",
     "highlights": [
       {
         "text": "「その顔は……さすがに理解したようね。会話のコツと同じ、本物の『ほめ』というのは、その人が人生において、何をこだわっているのかを探る事なのよ。ほめられたいのは外見である場合もあるし、学業や部活、仕事である場合もある。何かの趣味である可能性もある。それを掘り当てるのが 貴方 の仕事なの」",
@@ -12054,7 +12054,7 @@
     "isbn": "9784040695518",
     "asin": "4040695518",
     "readDate": "2018/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5518/9784040695518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5518/9784040695518.jpg",
     "highlights": [
       {
         "text": "「つまりあたしが言いたいのはね、自分のキャラと世界観を客観的に把握すること、そしてそれに『似合う』服を選ぶことよ。",
@@ -12122,7 +12122,7 @@
     "isbn": "9784103311621",
     "asin": "4103311622",
     "readDate": "2018/11/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1621/9784103311621.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1621/9784103311621.jpg",
     "highlights": []
   },
   {
@@ -12133,7 +12133,7 @@
     "isbn": "9784101001203",
     "asin": "4101001200",
     "readDate": "2018/11/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10100120.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10100120.jpg",
     "highlights": []
   },
   {
@@ -12144,7 +12144,7 @@
     "isbn": "9784150504526",
     "asin": "4150504520",
     "readDate": "2018/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4526/9784150504526.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4526/9784150504526.jpg",
     "highlights": []
   },
   {
@@ -12155,7 +12155,7 @@
     "isbn": "9784150310004",
     "asin": "4150310009",
     "readDate": "2018/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0004/9784150310004.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0004/9784150310004.jpg",
     "highlights": [
       {
         "text": "寄せてはかえし 寄せてはかえし かえしては寄せる波の音は、何億年ものほとんど永劫にちかいむかしからこの世界をどよもしていた。",
@@ -12215,7 +12215,7 @@
     "isbn": "9784048922814",
     "asin": "4048922815",
     "readDate": "2018/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2814/9784048922814.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2814/9784048922814.jpg",
     "highlights": []
   },
   {
@@ -12226,7 +12226,7 @@
     "isbn": "9784048658911",
     "asin": "4048658913",
     "readDate": "2018/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8911/9784048658911.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8911/9784048658911.jpg",
     "highlights": []
   },
   {
@@ -12237,7 +12237,7 @@
     "isbn": "9784048653947",
     "asin": "4048653946",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3947/9784048653947.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3947/9784048653947.jpg",
     "highlights": []
   },
   {
@@ -12248,7 +12248,7 @@
     "isbn": "9784048651356",
     "asin": "4048651358",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1356/9784048651356.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1356/9784048651356.jpg",
     "highlights": []
   },
   {
@@ -12259,7 +12259,7 @@
     "isbn": "9784048691734",
     "asin": "4048691732",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1734/9784048691734.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1734/9784048691734.jpg",
     "highlights": []
   },
   {
@@ -12270,7 +12270,7 @@
     "isbn": "9784048668088",
     "asin": "4048668080",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8088/9784048668088.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8088/9784048668088.jpg",
     "highlights": []
   },
   {
@@ -12281,7 +12281,7 @@
     "isbn": "9784822244668",
     "asin": "4822244660",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224466.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224466.jpg",
     "highlights": [
       {
         "text": "ない。「トレーディングはすべからく投資家には有害なのだ」と言ったバンガード・グループの創始者、ジョン・ボーグルに私は賛成だ。彼に言わせると、「トレーディングに手を染めると、自らの首を絞めることになる。その誘惑に負けそうになったらミス・マフェットにならって、蜘蛛（スパイダーズ）やその同類を見かけたら、さっさと逃げることだ」",
@@ -12297,7 +12297,7 @@
     "isbn": "9784048664875",
     "asin": "4048664875",
     "readDate": "2018/11/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4875/9784048664875.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4875/9784048664875.jpg",
     "highlights": []
   },
   {
@@ -12308,7 +12308,7 @@
     "isbn": "9784270007082",
     "asin": "4270007087",
     "readDate": "2018/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7082/9784270007082.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7082/9784270007082.jpg",
     "highlights": []
   },
   {
@@ -12319,7 +12319,7 @@
     "isbn": "9784822246808",
     "asin": "4822246809",
     "readDate": "2018/11/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6808/9784822246808.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6808/9784822246808.jpg",
     "highlights": []
   },
   {
@@ -12330,7 +12330,7 @@
     "isbn": "9784023315303",
     "asin": "4023315303",
     "readDate": "2018/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5303/9784023315303.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5303/9784023315303.jpg",
     "highlights": []
   },
   {
@@ -12341,7 +12341,7 @@
     "isbn": "9784791765553",
     "asin": "4791765559",
     "readDate": "2018/11/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5553/9784791765553.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5553/9784791765553.jpg",
     "highlights": []
   },
   {
@@ -12352,7 +12352,7 @@
     "isbn": "9784152098023",
     "asin": "4152098023",
     "readDate": "2018/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8023/9784152098023.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8023/9784152098023.jpg",
     "highlights": []
   },
   {
@@ -12363,7 +12363,7 @@
     "isbn": "9784309464800",
     "asin": "4309464807",
     "readDate": "2018/10/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784309464800.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784309464800.jpg",
     "highlights": []
   },
   {
@@ -12374,7 +12374,7 @@
     "isbn": "9784152095657",
     "asin": "4152095652",
     "readDate": "2018/10/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5657/9784152095657.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5657/9784152095657.jpg",
     "highlights": [
       {
         "text": "私たち人間は、健康になるように進化したのではない。困難の多い多様な条件のもとでできるだけ多くの子を持てるようにと自然選択の作用を受けたのである。結果として、私たちは何不自由のない快適な条件のもとで何を食べ、どれだけ運動するかについて、合理的な選択ができるようには進化していない。",
@@ -12402,7 +12402,7 @@
     "isbn": "9784532356286",
     "asin": "4532356288",
     "readDate": "2018/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6286/9784532356286.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6286/9784532356286.jpg",
     "highlights": []
   },
   {
@@ -12413,7 +12413,7 @@
     "isbn": "9784760149858",
     "asin": "4760149856",
     "readDate": "2018/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9858/9784760149858.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9858/9784760149858.jpg",
     "highlights": []
   },
   {
@@ -12424,7 +12424,7 @@
     "isbn": "9780735213678",
     "asin": "0735213674",
     "readDate": "2018/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9780735213678.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9780735213678.jpg",
     "highlights": []
   },
   {
@@ -12435,7 +12435,7 @@
     "isbn": "9784150503895",
     "asin": "4150503893",
     "readDate": "2018/10/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3895/9784150503895.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3895/9784150503895.jpg",
     "highlights": []
   },
   {
@@ -12446,7 +12446,7 @@
     "isbn": "9784152097989",
     "asin": "4152097981",
     "readDate": "2018/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7989/9784152097989.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7989/9784152097989.jpg",
     "highlights": []
   },
   {
@@ -12457,7 +12457,7 @@
     "isbn": "9784041030400",
     "asin": "4041030404",
     "readDate": "2018/10/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0400/9784041030400.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0400/9784041030400.jpg",
     "highlights": [
       {
         "text": "大切なのは、「心とは、そもそもそういうものだ」と理解しておくことです。心とは求めつづけるもの。それゆえに渇きつづけるもの──。",
@@ -12505,7 +12505,7 @@
     "isbn": "9784150505073",
     "asin": "4150505071",
     "readDate": "2018/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5073/9784150505073.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5073/9784150505073.jpg",
     "highlights": [
       {
         "text": "たとえば、〈モナド〉（１という数）は、あらゆる数の生成源であり、物質世界に存在する水、空気、火などと同じくらい現実的な実体であると同時に、あらゆる創造物の根源にある〝形而上学的な調和〟を意味するひとつの観念でもあった（ ８）。",
@@ -12529,7 +12529,7 @@
     "isbn": "9780062464347",
     "asin": "0062464345",
     "readDate": "2018/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4347/9780062464347.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4347/9780062464347.jpg",
     "highlights": []
   },
   {
@@ -12540,7 +12540,7 @@
     "isbn": "9784041017890",
     "asin": "4041017890",
     "readDate": "2018/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7890/9784041017890.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7890/9784041017890.jpg",
     "highlights": [
       {
         "text": "経験は我々に多くのことを教えてくれるが、その教え方は人生の貴重な時間を無駄に食い尽くしてしまう。ゆえに、その特別な知恵を学ぶために必要な時間の長さを考えると、経験による教えはそれほど価値があるとはいえない。死を目前にしてわかっても、それは無駄になるだけだ。さらに、経験による知識とは流行に似ている。今日、成功した行動も、 明日 にはもはやうまく働かず、役にたたないだろう。 原理原則だけが長続きする。そして今、私はこの原理原則を手にしている。なぜならば、私を偉大なものへと導いてくれる法則が、これらの巻物の言葉の中にあるからだ。",
@@ -12568,7 +12568,7 @@
     "isbn": "9784488590017",
     "asin": "4488590012",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4885/48859001.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4885/48859001.jpg",
     "highlights": [
       {
         "text": "人間とは究極的には、無数の多種多様な独立した人格の集合体と考えられるかもしれないということだ。",
@@ -12584,7 +12584,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2018/09/26",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -12595,7 +12595,7 @@
     "isbn": "9784150310585",
     "asin": "4150310580",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0585/9784150310585.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0585/9784150310585.jpg",
     "highlights": []
   },
   {
@@ -12606,7 +12606,7 @@
     "isbn": "9784344031821",
     "asin": "4344031822",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1821/9784344031821.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1821/9784344031821.jpg",
     "highlights": []
   },
   {
@@ -12617,7 +12617,7 @@
     "isbn": "9784334036676",
     "asin": "4334036678",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6676/9784334036676.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6676/9784334036676.jpg",
     "highlights": [
       {
         "text": "この解釈では、観測者に認識できなくなってしまった世界が無数に存在していることになります。それは膨大な数の平行世界となって存在し続けます。あなたはすべてのありうる世界に無数に分裂していくことになります。エヴェレット解釈の支持者であるブライス・ドウィットは、この解釈を「多世界解釈」と呼びました。",
@@ -12649,7 +12649,7 @@
     "isbn": "9784150103361",
     "asin": "4150103364",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "こうした不平は、人間性に本来そなわった一つの習性なのだ。石炭時代の人々は、蒸気機関の発明に不平を鳴らしている。シェイクスピアの芝居の一つに出てくる配役は、火薬の発明を嘆いている。おそらく、千年後の時代の人々は、電子頭脳の発明を非難していることだろう。",
@@ -12689,7 +12689,7 @@
     "isbn": "9784150313142",
     "asin": "4150313148",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3142/9784150313142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3142/9784150313142.jpg",
     "highlights": [
       {
         "text": "意識とは、文明により個人にダウンロードされるソフトウェアである、と。",
@@ -12705,7 +12705,7 @@
     "isbn": "9784488018252",
     "asin": "4488018254",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784488018252.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784488018252.jpg",
     "highlights": []
   },
   {
@@ -12716,7 +12716,7 @@
     "isbn": "9784783725077",
     "asin": "4783725071",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -12727,7 +12727,7 @@
     "isbn": "9784265951376",
     "asin": "4265951376",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1376/9784265951376.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1376/9784265951376.jpg",
     "highlights": []
   },
   {
@@ -12738,7 +12738,7 @@
     "isbn": "9784802510288",
     "asin": "4802510284",
     "readDate": "2018/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0288/9784802510288.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0288/9784802510288.jpg",
     "highlights": []
   },
   {
@@ -12749,7 +12749,7 @@
     "isbn": "9784295003359",
     "asin": "4295003352",
     "readDate": "2018/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3359/9784295003359.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3359/9784295003359.jpg",
     "highlights": []
   },
   {
@@ -12760,7 +12760,7 @@
     "isbn": "9784150120856",
     "asin": "4150120854",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0856/9784150120856.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0856/9784150120856.jpg",
     "highlights": [
       {
         "text": "「悔い改めよ、ハーレクィン！」とチクタクマンはいった。 「くそくらえ」 彼らは〈矯正院〉へ彼を送った。彼らは〈矯正院〉で彼をたたきなおした。それは『一九八四年』でウィンストン・スミスが受けた方法とそっくりだったが、誰もそんな本のことを覚えていなかったし、どうせ技術は大昔からあるものだった。",
@@ -12776,7 +12776,7 @@
     "isbn": "9784101800998",
     "asin": "4101800995",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0998/9784101800998.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0998/9784101800998.jpg",
     "highlights": []
   },
   {
@@ -12787,7 +12787,7 @@
     "isbn": "9784797490039",
     "asin": "4797490039",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7974/79749003.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7974/79749003.jpg",
     "highlights": []
   },
   {
@@ -12798,7 +12798,7 @@
     "isbn": "9784003233511",
     "asin": "4003233514",
     "readDate": "2018/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784003233511.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784003233511.jpg",
     "highlights": []
   },
   {
@@ -12809,7 +12809,7 @@
     "isbn": "9784152093967",
     "asin": "415209396X",
     "readDate": "2018/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3967/9784152093967.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3967/9784152093967.jpg",
     "highlights": []
   },
   {
@@ -12820,7 +12820,7 @@
     "isbn": "9784167907822",
     "asin": "4167907828",
     "readDate": "2018/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7822/9784167907822.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7822/9784167907822.jpg",
     "highlights": []
   },
   {
@@ -12831,7 +12831,7 @@
     "isbn": "9784834081374",
     "asin": "4834081370",
     "readDate": "2018/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1374/9784834081374.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1374/9784834081374.jpg",
     "highlights": []
   },
   {
@@ -12842,7 +12842,7 @@
     "isbn": "9784560007501",
     "asin": "4560007500",
     "readDate": "2018/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7501/9784560007501.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7501/9784560007501.jpg",
     "highlights": []
   },
   {
@@ -12853,7 +12853,7 @@
     "isbn": "9784047344518",
     "asin": "4047344516",
     "readDate": "2018/09/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4518/9784047344518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4518/9784047344518.jpg",
     "highlights": []
   },
   {
@@ -12864,7 +12864,7 @@
     "isbn": "9784003279212",
     "asin": "4003279212",
     "readDate": "2018/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9212/9784003279212.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9212/9784003279212.jpg",
     "highlights": []
   },
   {
@@ -12875,7 +12875,7 @@
     "isbn": "9784062202947",
     "asin": "4062202948",
     "readDate": "2018/09/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2947/9784062202947.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2947/9784062202947.jpg",
     "highlights": []
   },
   {
@@ -12886,7 +12886,7 @@
     "isbn": "9784087606249",
     "asin": "4087606244",
     "readDate": "2018/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6249/9784087606249.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6249/9784087606249.jpg",
     "highlights": []
   },
   {
@@ -12897,7 +12897,7 @@
     "isbn": "9784152093950",
     "asin": "4152093951",
     "readDate": "2018/09/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3950/9784152093950.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3950/9784152093950.jpg",
     "highlights": []
   },
   {
@@ -12908,7 +12908,7 @@
     "isbn": "9784102200025",
     "asin": "4102200029",
     "readDate": "2018/09/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0025/9784102200025.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0025/9784102200025.jpg",
     "highlights": []
   },
   {
@@ -12919,7 +12919,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2018/09/08",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "ひとつ言えることは、この「鈍感力」こそが、見たこともない景色を見せてくれたということ。",
@@ -12939,7 +12939,7 @@
     "isbn": "9784065125557",
     "asin": "4065125553",
     "readDate": "2018/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5557/9784065125557.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5557/9784065125557.jpg",
     "highlights": [
       {
         "text": "作者は。ほとんどなんの良心の 呵責 もなく物語の登場人物を殺す。どころか利用する。娯楽に。感動に。 憂さ晴らしに。 ある意味では死の展示場。良質な物語を生むための死の生産工場。ほとんどすべての物語は不幸を必要とする。まず不幸がある。それを解体。解決してハッピーエンド。または失敗してバッドエンド。多くの物語に共通する基本構造。なるほど身勝手かもな。",
@@ -12955,7 +12955,7 @@
     "isbn": "9784150505189",
     "asin": "4150505187",
     "readDate": "2018/09/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5189/9784150505189.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5189/9784150505189.jpg",
     "highlights": [
       {
         "text": "が、海賊版のｍｐ３の大半は、少数の組織されたグループから発信されていた。",
@@ -12975,7 +12975,7 @@
     "isbn": "9784152095459",
     "asin": "4152095458",
     "readDate": "2018/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5459/9784152095459.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5459/9784152095459.jpg",
     "highlights": []
   },
   {
@@ -12986,7 +12986,7 @@
     "isbn": "9784151310805",
     "asin": "4151310800",
     "readDate": "2018/08/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0805/9784151310805.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0805/9784151310805.jpg",
     "highlights": [
       {
         "text": "頭文字はどっちも同じで、Ｕ・Ｎ・Ｏｗｅｎだ。ところで、ちょいと連想を働かせて、この名前をＵＮｋｎｏｗｎと変えてみたら、どうだろう。アンノウン、すなわち、〝名なし〟だよ！」",
@@ -13002,7 +13002,7 @@
     "isbn": "9784163908502",
     "asin": "4163908501",
     "readDate": "2018/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8502/9784163908502.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8502/9784163908502.jpg",
     "highlights": [
       {
         "text": "製薬会社には思いがけない味方がいた。１９６０年に『引き裂かれた自己（６）』を著した精神分析医のＲ・Ｄ・レインだ。この本はカウンターカルチャーのバイブルになった。ヒッピー、吟遊詩人、アメリカやヨーロッパの大学で反戦活動を行っていた活動家がこの本を抱え、狂気は「狂った世界への完全に合理的な反応だ」というレインの教義を唱えていた。 レインの名声はまたたく間に広まった。レインは「反精神医学」運動の顔になり、精神病の烙印を押すことを終わりにしようと訴えた。レインは狂気を前向きな概念として捉えていた。ベトナム戦争を賞賛し、大学構内での銃乱射を許すような社会では、人の精神が社会そのものよりも狂っているとは考えられないと唱えた。実際、反対意見に「狂気」という烙印を押すこと自体が、彼らの口を封じる手段なのだと言っていた。",
@@ -13038,7 +13038,7 @@
     "isbn": "9784150504199",
     "asin": "4150504199",
     "readDate": "2018/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4199/9784150504199.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4199/9784150504199.jpg",
     "highlights": [
       {
         "text": "金銭的インセンティブに頼るかどうかを決めるには、そのインセンティブが、守るに値する姿勢や規範を蝕むかどうかを問う必要がある。この問いに答えるには、市場の論理は道徳の論理にならざるをえない。要するに、経済学者は「道徳を売買」しなければならないのである。",
@@ -13054,7 +13054,7 @@
     "isbn": "9784061842236",
     "asin": "4061842234",
     "readDate": "2018/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/06184223.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/06184223.jpg",
     "highlights": []
   },
   {
@@ -13065,7 +13065,7 @@
     "isbn": "9784101001708",
     "asin": "4101001707",
     "readDate": "2018/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1708/9784101001708.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1708/9784101001708.jpg",
     "highlights": []
   },
   {
@@ -13076,7 +13076,7 @@
     "isbn": "9784065122617",
     "asin": "4065122619",
     "readDate": "2018/07/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2617/9784065122617.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2617/9784065122617.jpg",
     "highlights": []
   },
   {
@@ -13087,7 +13087,7 @@
     "isbn": "9784152091314",
     "asin": "4152091312",
     "readDate": "2018/07/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1314/9784152091314.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1314/9784152091314.jpg",
     "highlights": []
   },
   {
@@ -13098,7 +13098,7 @@
     "isbn": "9784334033583",
     "asin": "433403358X",
     "readDate": "2018/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403358.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403358.jpg",
     "highlights": [
       {
         "text": "動物というのは、基本的な設計をもつ祖先がいる。そして次の段階は、その祖先の設計図を借りてきて変更するしか、新たな動物を創り出す術はない。だから、新しい設計は、所詮は祖先の設計図のどこかを消しゴムで消し、何か簡単にできることを付け加えることでしか、実現できないのだ。",
@@ -13114,7 +13114,7 @@
     "isbn": "9784167658144",
     "asin": "4167658143",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8144/9784167658144.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8144/9784167658144.jpg",
     "highlights": [
       {
         "text": "戦って勝つためには「非人間的」でなくてはならないと、すなわち「人間らしさ」を捨てて機械や昆虫のように感情のない無機質な装甲兵器になってしまわなくてはダメなのだと、彼らが無意識に考えているということなのだろうか？ だとしたら、男の子は大変だなぁ。幼い頃から「戦って勝つ」ことを義務づけられ、そのために「人間性を捨てよ」と諭されているも同然ではないか。次から次に現れるより強大な敵と戦い続け、しかも負けることを許されず、そのためには人間であることすら捨てなくてはならないなんて、そんなメッセージを幼少時から受け取り続けた男の子たちは、実生活において否応なく「負け」を認めなくてはならなくなった時に、女の子よりも遥かに大きな挫折感を味わうのだろうな。",
@@ -13138,7 +13138,7 @@
     "isbn": "9784167658137",
     "asin": "4167658135",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8137/9784167658137.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8137/9784167658137.jpg",
     "highlights": [
       {
         "text": "女王様は、太宰治が大嫌いである。 単なる人でなしのくせに、文学的あるいは哲学的な苦悩と絶望を声高に喧伝することによって、己の弱さや愚劣さやだらしなさを正当化している、キザで驕慢なナルシスト……これが女王様の「太宰」観だ。",
@@ -13154,7 +13154,7 @@
     "isbn": "9784488146078",
     "asin": "4488146074",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6078/9784488146078.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6078/9784488146078.jpg",
     "highlights": []
   },
   {
@@ -13165,7 +13165,7 @@
     "isbn": "9784167658120",
     "asin": "4167658127",
     "readDate": "2018/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8120/9784167658120.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8120/9784167658120.jpg",
     "highlights": [
       {
         "text": "接客業においてもっとも必要とされる能力は、客が何を求めて来ているのか、自分はどんな役割を果たせばいいのか、瞬時に摑むセンスだと思う。指名したホストには色恋を求めても、ヘルプに求めるものは、また",
@@ -13197,7 +13197,7 @@
     "isbn": "9784023316324",
     "asin": "4023316326",
     "readDate": "2018/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6324/9784023316324.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6324/9784023316324.jpg",
     "highlights": []
   },
   {
@@ -13208,7 +13208,7 @@
     "isbn": "9784163900247",
     "asin": "4163900241",
     "readDate": "2018/07/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0247/9784163900247.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0247/9784163900247.jpg",
     "highlights": [
       {
         "text": "現在、「草食男子」などと呼ばれる若い男たちも、女のエロス権力への潜在的な恐怖を「抑圧」ではなく「忌避」という形で表現している人々なのかもしれない。男は生涯、女を恐れ続ける生き物なのだ。",
@@ -13284,7 +13284,7 @@
     "isbn": "9784167658076",
     "asin": "4167658070",
     "readDate": "2018/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765807.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765807.jpg",
     "highlights": [
       {
         "text": "世の中の人間のタイプは「自分の持っていない物を数えあげつつ生きる人」と「自分の持っている物を数えあげつつ生きる人」の、大きくふたつに分かれるのかもしれない。 傍",
@@ -13308,7 +13308,7 @@
     "isbn": "9784167658052",
     "asin": "4167658054",
     "readDate": "2018/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765805.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765805.jpg",
     "highlights": [
       {
         "text": "ちょっとしたファンタジー小説並みの「心の旅」であったのだ。ファンタジー小説とは、「往きて還りし物語」である、と言われる。主人公が何かを求めて旅立ち、そして最後に戻ってくる物語。",
@@ -13336,7 +13336,7 @@
     "isbn": "9784757160590",
     "asin": "4757160593",
     "readDate": "2018/06/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0590/9784757160590.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0590/9784757160590.jpg",
     "highlights": []
   },
   {
@@ -13347,7 +13347,7 @@
     "isbn": "9784757746466",
     "asin": "4757746466",
     "readDate": "2018/06/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6466/9784757746466.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6466/9784757746466.jpg",
     "highlights": []
   },
   {
@@ -13358,7 +13358,7 @@
     "isbn": "9784167658106",
     "asin": "4167658100",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8106/9784167658106.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8106/9784167658106.jpg",
     "highlights": [
       {
         "text": "ナルシシズムとは何か。それは、他者の視線を満たすことだけを欲求する空っぽの自己なのである。",
@@ -13402,7 +13402,7 @@
     "isbn": "9784140815458",
     "asin": "4140815450",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5458/9784140815458.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5458/9784140815458.jpg",
     "highlights": [
       {
         "text": "もしもアップルがこのまま自分たちの道を進めば、すべての製品のボタンはひとつになる。今では、Siri（シリ）という音声認識機能も開発されたので、ボタンがなくなる日を覚悟してもいいだろう。結局、「１」よりもシンプルな数字は「０」だけだからだ。",
@@ -13430,7 +13430,7 @@
     "isbn": "9784314010030",
     "asin": "4314010037",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3140/31401003.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3140/31401003.jpg",
     "highlights": []
   },
   {
@@ -13441,7 +13441,7 @@
     "isbn": "9784757160583",
     "asin": "4757160585",
     "readDate": "2018/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0583/9784757160583.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0583/9784757160583.jpg",
     "highlights": []
   },
   {
@@ -13452,7 +13452,7 @@
     "isbn": "9784334751791",
     "asin": "4334751792",
     "readDate": "2018/06/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1791/9784334751791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1791/9784334751791.jpg",
     "highlights": []
   },
   {
@@ -13463,7 +13463,7 @@
     "isbn": "9784150503680",
     "asin": "4150503680",
     "readDate": "2018/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784150503680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784150503680.jpg",
     "highlights": [
       {
         "text": "「これはゲーテが『ファウスト』のなかで使ってる言葉で、ルーカスはそれに現代語という服を着せている。科学技術はわれわれを救いはしない、というメッセージだ。現代のコンピュータ、機械器具、そんなものでは十分ではない。われわれは自分の直観に、自分の真の存在に頼らなければならない」",
@@ -13523,7 +13523,7 @@
     "isbn": "9784309253725",
     "asin": "4309253725",
     "readDate": "2018/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3725/9784309253725.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3725/9784309253725.jpg",
     "highlights": []
   },
   {
@@ -13534,7 +13534,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2018/06/12",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "① システム基本計画 … システム導入を検討する（本書では対象外） ②提案対応 … システムを導入する業者を決定する（本書では対象外） ③要件定義 … システムの要件を取りまとめる（2章） ④基本設計 … システムの基本的な動きをまとめる（3章） ⑤詳細設計 … パラメーターやフォローなどシステムの詳細を決める（4章） ⑥テスト … システム構築した結果をテストする（5章） ⑦移行 … システムを開始するための作業を行う（6章）",
@@ -13582,7 +13582,7 @@
     "isbn": "9784575154399",
     "asin": "4575154393",
     "readDate": "2018/06/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4399/9784575154399.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4399/9784575154399.jpg",
     "highlights": [
       {
         "text": "もっと重要な教訓がある。こういう学生たちは、結婚したあと、いずれ定年離婚になるのではないかということである。なぜなら、出産に対する態度が「知ってらア」なのだから、育児だって同じだろうと思われるからである。おそらく自分では育児に関わらないし、関わる気もないかもしれない。結婚する気すらないかもしれない。",
@@ -13734,7 +13734,7 @@
     "isbn": "9784152097323",
     "asin": "4152097329",
     "readDate": "2018/06/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784152097323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784152097323.jpg",
     "highlights": []
   },
   {
@@ -13745,7 +13745,7 @@
     "isbn": "9784798039435",
     "asin": "4798039438",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9435/9784798039435.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9435/9784798039435.jpg",
     "highlights": []
   },
   {
@@ -13756,7 +13756,7 @@
     "isbn": "9784101171050",
     "asin": "410117105X",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1050/9784101171050.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1050/9784101171050.jpg",
     "highlights": [
       {
         "text": "マスコミが報道すれば、なんだってビッグ・ニュースになるのです」彼はうなずいた。「報道価値なんて、報道したあとからいくらでも出てくるんです。",
@@ -13772,7 +13772,7 @@
     "isbn": "9784822267896",
     "asin": "482226789X",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7896/9784822267896.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7896/9784822267896.jpg",
     "highlights": []
   },
   {
@@ -13783,7 +13783,7 @@
     "isbn": "9784152097316",
     "asin": "4152097310",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7316/9784152097316.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7316/9784152097316.jpg",
     "highlights": []
   },
   {
@@ -13794,7 +13794,7 @@
     "isbn": "9784062050760",
     "asin": "4062050765",
     "readDate": "2018/05/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784062050760.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784062050760.jpg",
     "highlights": []
   },
   {
@@ -13805,7 +13805,7 @@
     "isbn": "9784152097576",
     "asin": "4152097574",
     "readDate": "2018/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784152097576.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784152097576.jpg",
     "highlights": [
       {
         "text": "なぜ人間は、ほれぼれするような知性と、がっかりするような無知をあわせ持っているのか。たいていの人間は限られた理解しか持ち合わせていないのに、これほど多くを成し遂げてこられたのはなぜなのか。本書ではこうした疑問に答えていく。",
@@ -13873,7 +13873,7 @@
     "isbn": "9784766421620",
     "asin": "4766421620",
     "readDate": "2018/05/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1620/9784766421620.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1620/9784766421620.jpg",
     "highlights": []
   },
   {
@@ -13884,7 +13884,7 @@
     "isbn": "9784334751647",
     "asin": "4334751644",
     "readDate": "2018/05/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1647/9784334751647.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1647/9784334751647.jpg",
     "highlights": [
       {
         "text": "天の星々よ、光を消せ。おれのこの胸の奥底にわだかまる黒い野望に、光を当てるな。手のやることを目には見せるな。やらねばならぬ。やってしまって、たとえ目が見るのを怖れるようなことであっても、やるしかない。（",
@@ -13912,7 +13912,7 @@
     "isbn": "9784062884426",
     "asin": "4062884429",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4426/9784062884426.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4426/9784062884426.jpg",
     "highlights": [
       {
         "text": "中世盛期以降、ドイツの貴族は城・領地・修道院の三つをもって勢力の基盤とした",
@@ -13956,7 +13956,7 @@
     "isbn": "9784880591452",
     "asin": "4880591459",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/51iqmXywSnL._AC_SL1500_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/51iqmXywSnL._AC_SL1500_.jpg",
     "highlights": []
   },
   {
@@ -13967,7 +13967,7 @@
     "isbn": "9784042118046",
     "asin": "4042118046",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8046/9784042118046.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8046/9784042118046.jpg",
     "highlights": [
       {
         "text": "た。「自分がどんなに大きなお姉さんなのか考えなさい。今日はどんなにがんばったか考えなさい。今、何時だか考えなさい。なんでもいいから考えなさい。とにかく泣いちゃだめ！」",
@@ -13991,7 +13991,7 @@
     "isbn": "9784781680088",
     "asin": "4781680089",
     "readDate": "2018/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0088/9784781680088.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0088/9784781680088.jpg",
     "highlights": [
       {
         "text": "完成した標語よりも、標語について人々に考えさせることのほうが、社会的な影響力があると考えられていたのである。高額の賞金を用意し、射幸心を利用して人々を教化しようというのも、「楽しいプロパガンダ」の一種であったことがわかるだろう。",
@@ -14007,7 +14007,7 @@
     "isbn": "9784334037383",
     "asin": "4334037380",
     "readDate": "2018/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7383/9784334037383.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7383/9784334037383.jpg",
     "highlights": [
       {
         "text": "ます。「左右」の意味を「東西南北」で説明し、「東西南北」を「左右」で説明するのは、循環論法です。 『新明解国語辞典』は、この点、工夫しています。 みぎ【右】 アナログ時計の文字盤に向かった時に、一時から五時までの表示のある側。〔「明」という漢字の「月」が書かれている側と一致〕 （『新明解国語辞典』第７版）",
@@ -14039,7 +14039,7 @@
     "isbn": "9784062072281",
     "asin": "4062072289",
     "readDate": "2018/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2281/9784062072281.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2281/9784062072281.jpg",
     "highlights": []
   },
   {
@@ -14050,7 +14050,7 @@
     "isbn": "9784061592995",
     "asin": "4061592998",
     "readDate": "2018/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2995/9784061592995.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2995/9784061592995.jpg",
     "highlights": []
   },
   {
@@ -14061,7 +14061,7 @@
     "isbn": "9784863541948",
     "asin": "4863541945",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1948/9784863541948.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1948/9784863541948.jpg",
     "highlights": []
   },
   {
@@ -14072,7 +14072,7 @@
     "isbn": "9784822256784",
     "asin": "4822256782",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6784/9784822256784.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6784/9784822256784.jpg",
     "highlights": []
   },
   {
@@ -14083,7 +14083,7 @@
     "isbn": "9784167483210",
     "asin": "4167483211",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3210/9784167483210.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3210/9784167483210.jpg",
     "highlights": [
       {
         "text": "その焼け跡を見て、何を思ったか──。俺はもう、この世で「絶対」という言葉は使わないぞ、と。「絶対に俺のうちは焼けない」とか、「絶対に俺は人を殺さない」とか、「絶対に神風は吹く」とか、「絶対に日本は勝つ」とか、そういうことはあり得ない、そんなものはウソだ、と自分の家の焼け跡に立ち、荒涼たる焼け野原を見ながら思ったんです。それ以来、わたくしは「絶対」という言葉は使っていない。",
@@ -14147,7 +14147,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2018/04/30",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -14158,7 +14158,7 @@
     "isbn": "9784167483159",
     "asin": "4167483157",
     "readDate": "2018/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3159/9784167483159.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3159/9784167483159.jpg",
     "highlights": [
       {
         "text": "今日の日本および日本人にとって、いちばん大切なものは〝平衡感覚〟によって復元力を身につけることではないかと思う。内外情勢の変化によって、右に左に、大きくゆれるということは、やむをえない。ただ、適当な時期に平衡をとり戻すことができるか、できないかによって、民族の、あるいは個人の運命がきまるのではあるまいか。",
@@ -14186,7 +14186,7 @@
     "isbn": "9784003226216",
     "asin": "4003226216",
     "readDate": "2018/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6216/9784003226216.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6216/9784003226216.jpg",
     "highlights": []
   },
   {
@@ -14197,7 +14197,7 @@
     "isbn": "9784839946531",
     "asin": "4839946531",
     "readDate": "2018/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6531/9784839946531.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6531/9784839946531.jpg",
     "highlights": [
       {
         "text": "すべてのメディアは、われわれのすみからすみまで変えてしまう。それらのメディアは個人的、政治的、経済的、美的、心理的、道徳的、倫理的、社会的な出来事のすべてに深く浸透しているから、メディアはわれわれのどんな部分にも触れ、影響を及ぼし、変えてしまう。メディアはマッサージである。こうした環境としてのメディアの作用に関する知識なしには、社会と文化の変動を理解することはできない。 （マクルーハン『メディアはマッサージである』より）",
@@ -14265,7 +14265,7 @@
     "isbn": "9784334033224",
     "asin": "4334033229",
     "readDate": "2018/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403322.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403322.jpg",
     "highlights": [
       {
         "text": "わかった状態になったとき、各部分からは、「文脈と矛盾なく関連がつき、文脈を介して他の部分とも矛盾なく関連がつく意味」が引き出されているのです。",
@@ -14285,7 +14285,7 @@
     "isbn": "9784065020418",
     "asin": "4065020417",
     "readDate": "2018/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0418/9784065020418.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0418/9784065020418.jpg",
     "highlights": []
   },
   {
@@ -14296,7 +14296,7 @@
     "isbn": "9784062884457",
     "asin": "4062884453",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4457/9784062884457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4457/9784062884457.jpg",
     "highlights": [
       {
         "text": "モカとは、もともとアラビア半島南端のイエメンにある港町の名前です。",
@@ -14344,7 +14344,7 @@
     "isbn": "9784000259316",
     "asin": "4000259318",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9316/9784000259316.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9316/9784000259316.jpg",
     "highlights": []
   },
   {
@@ -14355,7 +14355,7 @@
     "isbn": "9784622078760",
     "asin": "4622078767",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8760/9784622078760.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8760/9784622078760.gif",
     "highlights": []
   },
   {
@@ -14366,7 +14366,7 @@
     "isbn": "9784000259309",
     "asin": "400025930X",
     "readDate": "2018/04/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9309/9784000259309.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9309/9784000259309.jpg",
     "highlights": []
   },
   {
@@ -14377,7 +14377,7 @@
     "isbn": "9784152095602",
     "asin": "4152095601",
     "readDate": "2018/04/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5602/9784152095602.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5602/9784152095602.jpg",
     "highlights": []
   },
   {
@@ -14388,7 +14388,7 @@
     "isbn": "9784480431691",
     "asin": "4480431691",
     "readDate": "2018/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1691/9784480431691.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1691/9784480431691.jpg",
     "highlights": []
   },
   {
@@ -14399,7 +14399,7 @@
     "isbn": "9784805727041",
     "asin": "4805727047",
     "readDate": "2018/04/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784805727041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784805727041.jpg",
     "highlights": []
   },
   {
@@ -14410,7 +14410,7 @@
     "isbn": "9784480097576",
     "asin": "4480097570",
     "readDate": "2018/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784480097576.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784480097576.jpg",
     "highlights": []
   },
   {
@@ -14421,7 +14421,7 @@
     "isbn": "9784101098548",
     "asin": "4101098549",
     "readDate": "2018/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8548/9784101098548.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8548/9784101098548.jpg",
     "highlights": [
       {
         "text": "人類の理想はなんであろう。となると、これは大問題で一冊や二冊の本で論じきれるものではない。また、論じてみたところで、なんの結論も出てこないにきまっている。しかし、人間個人の理想となると、すべて共通で「ぬれ手でアワといった調子で大金をつかみたい」の一語につきる。この欲望が心の奥にあれば、あなたは人間であり、しかも正気であるとの証明ともなるわけであろう。",
@@ -14437,7 +14437,7 @@
     "isbn": "9784102033012",
     "asin": "4102033017",
     "readDate": "2018/03/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3012/9784102033012.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3012/9784102033012.jpg",
     "highlights": [
       {
         "text": "人間は精神的な教養を積むよりも富を積むほうに千万倍の努力を 献 げている。だからすでに得た富を 殖やそうとして、席の暖まる暇もないほどに忙しく、 蟻 のようにこつこつと、朝から晩まで骨を折っている人が実に多い。富を殖やすための手段の世界を自己の視界とし、この狭い視界からそとに出れば、何一つ知らない。精神はからっぽで、そのため、ほかのものはいっさい受けつける力がない。最高級の享楽、すなわち精神的享楽は、 高嶺 の花である。暇はかからないで金のかかる 刹那 的・感能的な享楽を合間合間にむさぼって、最高級の享楽の 填め合せをしようとするけれども、一向填め合せにはならない。",
@@ -14549,7 +14549,7 @@
     "isbn": "9784103145325",
     "asin": "4103145323",
     "readDate": "2018/03/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5325/9784103145325.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5325/9784103145325.jpg",
     "highlights": []
   },
   {
@@ -14560,7 +14560,7 @@
     "isbn": "9784334752064",
     "asin": "4334752063",
     "readDate": "2018/03/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2064/9784334752064.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2064/9784334752064.jpg",
     "highlights": [
       {
         "text": "資本とはなにか。 「蓄積され貯蔵された一定量の労働である。」（",
@@ -14600,7 +14600,7 @@
     "isbn": "9784488772017",
     "asin": "4488772013",
     "readDate": "2018/03/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2017/9784488772017.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2017/9784488772017.jpg",
     "highlights": []
   },
   {
@@ -14611,7 +14611,7 @@
     "isbn": "9784334753696",
     "asin": "4334753698",
     "readDate": "2018/03/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3696/9784334753696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3696/9784334753696.jpg",
     "highlights": [
       {
         "text": "人間は精神的な教養を積むよりも富を積むほうに千万倍の努力を 献 げている。だからすでに得た富を 殖やそうとして、席の暖まる暇もないほどに忙しく、 蟻 のようにこつこつと、朝から晩まで骨を折っている人が実に多い。富を殖やすための手段の世界を自己の視界とし、この狭い視界からそとに出れば、何一つ知らない。精神はからっぽで、そのため、ほかのものはいっさい受けつける力がない。最高級の享楽、すなわち精神的享楽は、 高嶺 の花である。暇はかからないで金のかかる 刹那 的・感能的な享楽を合間合間にむさぼって、最高級の享楽の 填め合せをしようとするけれども、一向填め合せにはならない。",
@@ -14723,7 +14723,7 @@
     "isbn": "9784484101132",
     "asin": "4484101130",
     "readDate": "2018/03/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784484101132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784484101132.jpg",
     "highlights": []
   },
   {
@@ -14734,7 +14734,7 @@
     "isbn": "9784391146912",
     "asin": "4391146916",
     "readDate": "2018/02/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6912/9784391146912.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6912/9784391146912.jpg",
     "highlights": []
   },
   {
@@ -14745,7 +14745,7 @@
     "isbn": "9784532356873",
     "asin": "4532356873",
     "readDate": "2018/02/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784532356873.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784532356873.jpg",
     "highlights": []
   },
   {
@@ -14756,7 +14756,7 @@
     "isbn": "9784000296441",
     "asin": "4000296442",
     "readDate": "2018/01/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6441/9784000296441.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6441/9784000296441.jpg",
     "highlights": []
   },
   {
@@ -14767,7 +14767,7 @@
     "isbn": "9784000296595",
     "asin": "4000296590",
     "readDate": "2018/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6595/9784000296595.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6595/9784000296595.jpg",
     "highlights": []
   },
   {
@@ -14778,7 +14778,7 @@
     "isbn": "9784802510172",
     "asin": "4802510179",
     "readDate": "2018/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784802510172.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784802510172.jpg",
     "highlights": []
   },
   {
@@ -14789,7 +14789,7 @@
     "isbn": "9784003369524",
     "asin": "4003369521",
     "readDate": "2018/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9524/9784003369524.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9524/9784003369524.jpg",
     "highlights": []
   },
   {
@@ -14800,7 +14800,7 @@
     "isbn": "9784327401689",
     "asin": "4327401684",
     "readDate": "2017/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1689/9784327401689.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1689/9784327401689.jpg",
     "highlights": []
   },
   {
@@ -14811,7 +14811,7 @@
     "isbn": "9784150503673",
     "asin": "4150503672",
     "readDate": "2017/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3673/9784150503673.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3673/9784150503673.jpg",
     "highlights": []
   },
   {
@@ -14822,7 +14822,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2017/12/28",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/31g6QOM7JaL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/31g6QOM7JaL.jpg",
     "highlights": [
       {
         "text": "自分が何気なく読んでいるこの「本」というものは、実はものすごいツールなのではないか。ここには著者の生きてきた時間が凝縮されている。ひとりの人間が何十年とかけて積み上げてきたものを、短時間で吸収できるのだ。思想、哲学、発見、知見、そしてメッセージ。活版印刷がどうして人類史上最大クラスの発明なのか、わかった気がした。どんな高度な思想や学術的発見があっても、多くの人に伝えられなければ意味がない。知識というのは伝達されるから意味があるのだ。",
@@ -14858,7 +14858,7 @@
     "isbn": "9784908059704",
     "asin": "4908059705",
     "readDate": "2017/12/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784908059704.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784908059704.jpg",
     "highlights": []
   },
   {
@@ -14869,7 +14869,7 @@
     "isbn": "9784106103506",
     "asin": "4106103508",
     "readDate": "2017/12/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3506/9784106103506.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3506/9784106103506.jpg",
     "highlights": []
   },
   {
@@ -14880,7 +14880,7 @@
     "isbn": "9784150312848",
     "asin": "4150312842",
     "readDate": "2017/12/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2848/9784150312848.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2848/9784150312848.jpg",
     "highlights": []
   },
   {
@@ -14891,7 +14891,7 @@
     "isbn": "9784167909819",
     "asin": "4167909812",
     "readDate": "2017/12/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9819/9784167909819.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9819/9784167909819.jpg",
     "highlights": [
       {
         "text": "大統領選は、「 輝ける アメリカ」「 美しい アメリカ」と、マヘリア・ジャクソンの唄のようなスローガンで、徹底的におしまくった。──対立候補は老練な国際政治家で、アジア、中東、ヨーロッパ、アフリカのこんがらかった状況に対する彼の展望は、的確で、説得力があり、海外での人気は圧倒的だったが、アメリカ国内では、かえって理解者がすくなかった。",
@@ -14919,7 +14919,7 @@
     "isbn": "9784484101019",
     "asin": "4484101017",
     "readDate": "2017/12/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1019/9784484101019.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1019/9784484101019.jpg",
     "highlights": []
   },
   {
@@ -14930,7 +14930,7 @@
     "isbn": "9784103145318",
     "asin": "4103145315",
     "readDate": "2017/12/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5318/9784103145318.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5318/9784103145318.jpg",
     "highlights": [
       {
         "text": "さっきから同じ場所をどうどう巡りしているような気がしてならない。もしかして作者が困っておるのか。続きをどう書いていいかわからなくなり、執筆を中断しているのだろうか。あるいは何か他の理由で書けなくなったのか。 その通り。おれは書けなくなった。何故おれが書けなくなったかを書かねばなるまい。そもそも日本という国は今、福島の原発事故によって大きな胃の病に冒されている。これでもし頭の病や心臓の病を併発し外傷を受けでもすれば日本は終りであり、それは誰もが知っており、例えばその恐ろしい夢を見て夜中に覚醒し、それが夢ではなくて現実の恐怖なのだと認識した時に迫ってくるものは背筋が凍りつくほどの冷酷なものだ。だが福島の人以外は、それが目醒めている時であれば誰もがこれから眼を背けようとする。一般の社会人は日常の瑣事に逃げ込み、政府とてすぐに国際問題や政争に眼を向けようとする。われわれ作家にしても、いかに真剣に原発事故のことを考えようとしたところで、ともすれば荒唐無稽なファンタジイに逃避してしまうのが落ちであろう。しかもそのようなファンタジイには現実に対してどのような効果があるのか。ストレスという病から読者を遠ざけちょっとしたカタルシスを与えるくらいが関の山だ。当然のことだが問題の解決からは遥かに遠い。政府の言い方を真似れば喫緊の課題となっている恐怖の源を前にしてわれわれは立ちすくみ、ただ何もできずにぼんやりしているだけだ。 この事故はあと何十年も何百年も、それどころか何万年も何十万年も尾を引いて後世に及ぶ。その責任は誰が取るのかと言えばわれわれに決まっているようなものなのだが、それはとても取れるようなものではないのだから、結局は前の戦争を起して周辺諸国に迷惑をかけたのが自分たちのひと世代、ふた… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -14946,7 +14946,7 @@
     "isbn": "9784150120092",
     "asin": "4150120099",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784150120092.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784150120092.jpg",
     "highlights": []
   },
   {
@@ -14957,7 +14957,7 @@
     "isbn": "9784101171159",
     "asin": "4101171157",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -14968,7 +14968,7 @@
     "isbn": "9784087711196",
     "asin": "4087711196",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1196/9784087711196.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1196/9784087711196.jpg",
     "highlights": []
   },
   {
@@ -14979,7 +14979,7 @@
     "isbn": "9784101171012",
     "asin": "4101171017",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117101.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117101.jpg",
     "highlights": []
   },
   {
@@ -14990,7 +14990,7 @@
     "isbn": "9784101171074",
     "asin": "4101171076",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117107.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117107.jpg",
     "highlights": []
   },
   {
@@ -15001,7 +15001,7 @@
     "isbn": "9784101171135",
     "asin": "4101171130",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1135/9784101171135.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1135/9784101171135.jpg",
     "highlights": []
   },
   {
@@ -15012,7 +15012,7 @@
     "isbn": "9784101006055",
     "asin": "4101006059",
     "readDate": "2017/11/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6055/9784101006055.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6055/9784101006055.jpg",
     "highlights": []
   },
   {
@@ -15023,7 +15023,7 @@
     "isbn": "9784065104408",
     "asin": "4065104408",
     "readDate": "2017/11/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784065104408.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784065104408.jpg",
     "highlights": []
   },
   {
@@ -15034,7 +15034,7 @@
     "isbn": "9784041099155",
     "asin": "4041099153",
     "readDate": "2017/11/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9155/9784041099155.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9155/9784041099155.jpg",
     "highlights": []
   },
   {
@@ -15045,7 +15045,7 @@
     "isbn": "9784778315306",
     "asin": "4778315308",
     "readDate": "2017/11/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5306/9784778315306.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5306/9784778315306.jpg",
     "highlights": []
   },
   {
@@ -15056,7 +15056,7 @@
     "isbn": "9784040723396",
     "asin": "4040723392",
     "readDate": "2017/11/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3396/9784040723396.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3396/9784040723396.jpg",
     "highlights": []
   },
   {
@@ -15067,7 +15067,7 @@
     "isbn": "9784480689894",
     "asin": "4480689893",
     "readDate": "2017/11/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9894/9784480689894.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9894/9784480689894.jpg",
     "highlights": [
       {
         "text": "『人生』の世界へようこそ！ ここではあなたは種族「ホモ・サピエンス」の１人としてゲームをプレイします。あなたは美味しい食事をしたり、生殖行為を行ったり、人から 讃えられたり、自尊心を満足させることで「幸福点」を入手できます。ゲームオーバーになるまでに他のプレイヤーよりも多くの「幸福点」を稼ぎ、ハイスコアを目指しましょう！",
@@ -15095,7 +15095,7 @@
     "isbn": "9784822245641",
     "asin": "4822245640",
     "readDate": "2017/11/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224564.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224564.jpg",
     "highlights": [
       {
         "text": "そして日本で建造した船舶を使ったコンテナ輸送サービスを推進すべく、四億四〇〇〇万ドルの補助金財源を確保する。いま考えると信じられないほど寛容な補助金だった。船会社は新造船の五％しか自己資金を用意する必要はない。残りは政府系の日本開発銀行（現日本政策投資銀行）が出してくれる。三年間は返済猶予、四年目から一〇年間で返済するが、金利は五・五％で、政府が開銀から借り入れる利率より低かった。これで足りない分は都市銀行から調達しなければならないが、それでも借入金利のうち二％は政府が負担してくれる。言ってみればプレゼントのようなものだった。日本の船会社は七〇年末までに、合計一五八隻をすべて日本の造船メーカーに発注した（原注 13）。 日本以外では、一九六九年七月に",
@@ -15111,7 +15111,7 @@
     "isbn": "9784480058652",
     "asin": "4480058656",
     "readDate": "2017/11/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48005865.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48005865.jpg",
     "highlights": [
       {
         "text": "文字は新石器革命の条件ではなく結果として出現したのであり、知識を強固にするためというより、支配と搾取を容易にするためのものであったという考察を繰り広げる。",
@@ -15155,7 +15155,7 @@
     "isbn": "9784274068768",
     "asin": "4274068765",
     "readDate": "2017/11/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8768/9784274068768.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8768/9784274068768.jpg",
     "highlights": []
   },
   {
@@ -15166,7 +15166,7 @@
     "isbn": "9784150114510",
     "asin": "415011451X",
     "readDate": "2017/11/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011451.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011451.jpg",
     "highlights": []
   },
   {
@@ -15177,7 +15177,7 @@
     "isbn": "9784152097040",
     "asin": "4152097043",
     "readDate": "2017/10/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7040/9784152097040.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7040/9784152097040.jpg",
     "highlights": [
       {
         "text": "ドナトゥスはラテン語を書くのに用いられる文字とその種々の機能を一覧表にし、文字の3つの属性、すなわち字名 (nomen)、字形 (figura)、効力 (potestas) の定義で章を締めくくっている。アルフリック",
@@ -15209,7 +15209,7 @@
     "isbn": "9784062880381",
     "asin": "4062880385",
     "readDate": "2017/10/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0381/9784062880381.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0381/9784062880381.jpg",
     "highlights": [
       {
         "text": "FeliCaは、鉄道の自動改札をスムーズに通過するため、〇・二秒という短時間でデータの処理ができることを目指して開発された。最初に導入されたのは香港の交通カードであるオクトパスカードであったが、その後、ＪＲ東日本の Suica にも導入された。",
@@ -15233,7 +15233,7 @@
     "isbn": "9784167483104",
     "asin": "4167483106",
     "readDate": "2017/10/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1674/16748310.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1674/16748310.jpg",
     "highlights": [
       {
         "text": "ヒトラーは『わが闘争』で、日本人を想像力の欠如した劣等民族、ただしドイツの手先として使うなら、小器用で小利口で役に立つ国民",
@@ -15253,7 +15253,7 @@
     "isbn": "9784794218797",
     "asin": "4794218796",
     "readDate": "2017/10/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8797/9784794218797.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8797/9784794218797.jpg",
     "highlights": []
   },
   {
@@ -15264,7 +15264,7 @@
     "isbn": "9784151200519",
     "asin": "4151200517",
     "readDate": "2017/10/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0519/9784151200519.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0519/9784151200519.jpg",
     "highlights": []
   },
   {
@@ -15275,7 +15275,7 @@
     "isbn": "9784873117003",
     "asin": "4873117003",
     "readDate": "2017/10/02",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7003/9784873117003.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7003/9784873117003.jpg",
     "highlights": []
   },
   {
@@ -15286,7 +15286,7 @@
     "isbn": "9784140086681",
     "asin": "4140086688",
     "readDate": "2017/10/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6681/9784140086681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6681/9784140086681.jpg",
     "highlights": []
   },
   {
@@ -15297,7 +15297,7 @@
     "isbn": "9784309462554",
     "asin": "4309462553",
     "readDate": "2017/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3094/30946255.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3094/30946255.jpg",
     "highlights": [
       {
         "text": "本書によれば「生命、宇宙、その他もろもろ」の究極の答えは四十二である。なぜ四十二なのか、これについては「エジプトの『死者の書』に出てくる神の数と同じ」とか「ルイス・キャロルの『アリス』に出てくる規則の番号と同じ」とかいろいろ言われているようだが、ダグラス・アダムス本人は一貫して、「まったく意味のない数字として選んだ」と語っている。",
@@ -15317,7 +15317,7 @@
     "isbn": "9784062749367",
     "asin": "406274936X",
     "readDate": "2017/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0627/06274936.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0627/06274936.jpg",
     "highlights": [
       {
         "text": "生きてても虚しいわ。どんな偉いもんになってもどんなたくさんお金儲けても、人間死んだら煙か土か食い物や。火に焼かれて煙になるか、地に埋められて土んなるか、下手したらケモノに食べられてまうんやで」。",
@@ -15333,7 +15333,7 @@
     "isbn": "9784150113377",
     "asin": "4150113378",
     "readDate": "2017/09/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011337.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011337.jpg",
     "highlights": [
       {
         "text": "いずれ、バッハをきいたときに感じる歓びの生理学的根拠を、順を追って説明する人が出てくるだろうが、だからといって、いきなりその歓びが、〝原始的な〟反応だとか、生物学的ないかさまだとか、陶酔薬による高揚感と同様の空虚な体験だとかいうことになったりするだろうか？ 「あの子の笑顔を見",
@@ -15373,7 +15373,7 @@
     "isbn": "9784094516746",
     "asin": "4094516743",
     "readDate": "2017/09/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6746/9784094516746.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6746/9784094516746.jpg",
     "highlights": []
   },
   {
@@ -15384,7 +15384,7 @@
     "isbn": "9784794218780",
     "asin": "4794218788",
     "readDate": "2017/09/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8780/9784794218780.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8780/9784794218780.jpg",
     "highlights": []
   },
   {
@@ -15395,7 +15395,7 @@
     "isbn": "9784152097033",
     "asin": "4152097035",
     "readDate": "2017/09/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7033/9784152097033.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7033/9784152097033.jpg",
     "highlights": [
       {
         "text": "コンピューターについて、ノーバート・ウィーナーはたんなる微分方程式の計算機にとどまらないと考え、ヴァニヴァー・ブッシュは情報整理の効率化に役立つに違いないと信じた。そしてリックライダーは、その「思考する機械」を、何よりもまず通信デバイスとしてとらえた。人間とコンピューターとで労働を分配すれば、時間を節約し、民主制を洗練し、意思決定を改善できると彼は主張した。",
@@ -15411,7 +15411,7 @@
     "isbn": "9784864724920",
     "asin": "486472492X",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4920/9784864724920.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4920/9784864724920.jpg",
     "highlights": []
   },
   {
@@ -15422,7 +15422,7 @@
     "isbn": "9784864725330",
     "asin": "4864725330",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5330/9784864725330.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5330/9784864725330.jpg",
     "highlights": []
   },
   {
@@ -15433,7 +15433,7 @@
     "isbn": "9784864723473",
     "asin": "4864723478",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3473/9784864723473.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3473/9784864723473.jpg",
     "highlights": []
   },
   {
@@ -15444,7 +15444,7 @@
     "isbn": "9784864725866",
     "asin": "4864725861",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5866/9784864725866.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5866/9784864725866.jpg",
     "highlights": []
   },
   {
@@ -15455,7 +15455,7 @@
     "isbn": "9784864725620",
     "asin": "4864725624",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5620/9784864725620.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5620/9784864725620.jpg",
     "highlights": []
   },
   {
@@ -15466,7 +15466,7 @@
     "isbn": "9784864725217",
     "asin": "4864725217",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5217/9784864725217.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5217/9784864725217.jpg",
     "highlights": []
   },
   {
@@ -15477,7 +15477,7 @@
     "isbn": "9784864725408",
     "asin": "4864725403",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5408/9784864725408.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5408/9784864725408.jpg",
     "highlights": []
   },
   {
@@ -15488,7 +15488,7 @@
     "isbn": "9784864726023",
     "asin": "4864726027",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6023/9784864726023.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6023/9784864726023.jpg",
     "highlights": []
   },
   {
@@ -15499,7 +15499,7 @@
     "isbn": "9784334037468",
     "asin": "4334037461",
     "readDate": "2017/09/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7468/9784334037468.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7468/9784334037468.jpg",
     "highlights": []
   },
   {
@@ -15510,7 +15510,7 @@
     "isbn": "9784344426429",
     "asin": "4344426428",
     "readDate": "2017/09/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6429/9784344426429.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6429/9784344426429.jpg",
     "highlights": [
       {
         "text": "生きるのが苦しくなったときは、世間の価値観や周りの意見にとらわれずに「自分が何が好きか」という感覚をしっかり持つことが大事だ。「自分はこれが好きだ、これをしているときが幸せだ」というものをはっきり持てば充実感を味わえるし、同じような趣味や価値観を持つ仲間もできるし、人との繫がりができればそれが社会の中の居場所として自分を支えてくれる。",
@@ -15546,7 +15546,7 @@
     "isbn": "9784048704731",
     "asin": "4048704737",
     "readDate": "2017/09/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4731/9784048704731.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4731/9784048704731.jpg",
     "highlights": [
       {
         "text": "「作品の中にルールを作る。読者もそのルールを理解する。するとルールに 則っている間は先の展開が予測しやすくなるので、非常に読みやすくなります。逆にルールからわざと逸脱すれば、読者の感情を動かし、サプライズを与える事ができる。時計の振り子を想像してみて下さい。左に振れる。次は右に振れる。少し眺めていればそれだけでルールが完成します。〝左の次は右、右の次は左〟。読者は次の動きが予想できますから、とても読みやすい。あとは振り子の動きを少しずつ、少しずつ大きくしていく。そうして読みやすさを保ったままで大きな流れに引き込むんです」",
@@ -15562,7 +15562,7 @@
     "isbn": "9784041395035",
     "asin": "4041395038",
     "readDate": "2017/08/31",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51Z0KGUTkUL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51Z0KGUTkUL.jpg",
     "highlights": []
   },
   {
@@ -15573,7 +15573,7 @@
     "isbn": "9784163906836",
     "asin": "4163906835",
     "readDate": "2017/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6836/9784163906836.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6836/9784163906836.jpg",
     "highlights": [
       {
         "text": "ダニエルは世界には目に見えない優しい力があるという考えを、まだ捨てることができないでいた。「わたしは両親と同じ 蚊帳 の中で寝ていた。両親は大きなベッド、わたしは小さなベッドだ。わたしは九歳だった。そして神に祈った。こんな祈りの言葉を唱えたんだ。神様、あなたがとても忙しいことや、いまが厳しい時代だということはわかっています。多くは望みません。ただもう一日、生きながらえさせてください、と」",
@@ -15593,7 +15593,7 @@
     "isbn": "9784150115944",
     "asin": "415011594X",
     "readDate": "2017/08/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011594.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011594.jpg",
     "highlights": [
       {
         "text": "いっしょにいても、ひとりきりでいるのと変わりがなく、ゆえにわたしたちには、別れるほかに道がなかった。 ひとりきりで永遠を生きたいとは、だれも思わないのだから。",
@@ -15609,7 +15609,7 @@
     "isbn": "9784041050057",
     "asin": "4041050057",
     "readDate": "2017/08/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0057/9784041050057.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0057/9784041050057.jpg",
     "highlights": []
   },
   {
@@ -15620,7 +15620,7 @@
     "isbn": "9784122040120",
     "asin": "4122040124",
     "readDate": "2017/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0120/9784122040120.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0120/9784122040120.jpg",
     "highlights": []
   },
   {
@@ -15631,7 +15631,7 @@
     "isbn": "9784480069504",
     "asin": "448006950X",
     "readDate": "2017/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9504/9784480069504.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9504/9784480069504.jpg",
     "highlights": [
       {
         "text": "勉強は基礎が大切 右の勉強は、具体的で身体的な場面を離れた概念なのに気づくだろうか。勉強は……と言いかけて、適切な文字通りのことばが見当たらない。そこで建築の領域から表現を借りてくる。これを支えるのは 似ている という感覚である。メタファーは類似性をベースとする。",
@@ -15671,7 +15671,7 @@
     "isbn": "9784062839020",
     "asin": "4062839024",
     "readDate": "2017/08/24",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9020/9784062839020.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9020/9784062839020.jpg",
     "highlights": []
   },
   {
@@ -15682,7 +15682,7 @@
     "isbn": "9784480434036",
     "asin": "4480434038",
     "readDate": "2017/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4036/9784480434036.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4036/9784480434036.jpg",
     "highlights": []
   },
   {
@@ -15693,7 +15693,7 @@
     "isbn": "9784480065131",
     "asin": "448006513X",
     "readDate": "2017/07/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5131/9784480065131.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5131/9784480065131.jpg",
     "highlights": [
       {
         "text": "実際問題としては、組織の主たる層は一般人ですし、そして、一般人は哲学など毛ほどの興味もありません。このことはしかと胸に刻んでおいて下さい。浄土教のナムアミダブツなど一般人は悪霊退散の呪文程度にしか思ってませんし、毎日神棚に手を合わせていても 天岩戸 も知らなかったりします。",
@@ -15737,7 +15737,7 @@
     "isbn": "9784121022202",
     "asin": "4121022203",
     "readDate": "2017/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2202/9784121022202.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2202/9784121022202.jpg",
     "highlights": [
       {
         "text": "言語習得における見本の重要性",
@@ -15761,7 +15761,7 @@
     "isbn": "9784309226729",
     "asin": "4309226728",
     "readDate": "2017/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6729/9784309226729.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6729/9784309226729.jpg",
     "highlights": []
   },
   {
@@ -15772,7 +15772,7 @@
     "isbn": "9784309226712",
     "asin": "430922671X",
     "readDate": "2017/07/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6712/9784309226712.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6712/9784309226712.jpg",
     "highlights": []
   },
   {
@@ -15783,7 +15783,7 @@
     "isbn": "9784797386158",
     "asin": "4797386150",
     "readDate": "2017/07/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6158/9784797386158.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6158/9784797386158.jpg",
     "highlights": []
   },
   {
@@ -15794,7 +15794,7 @@
     "isbn": "9784048651936",
     "asin": "4048651935",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1936/9784048651936.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1936/9784048651936.jpg",
     "highlights": []
   },
   {
@@ -15805,7 +15805,7 @@
     "isbn": "9784048912518",
     "asin": "4048912518",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784048912518.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784048912518.jpg",
     "highlights": []
   },
   {
@@ -15816,7 +15816,7 @@
     "isbn": "9784048867337",
     "asin": "4048867334",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7337/9784048867337.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7337/9784048867337.jpg",
     "highlights": []
   },
   {
@@ -15827,7 +15827,7 @@
     "isbn": "9784048685955",
     "asin": "4048685953",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868595.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868595.jpg",
     "highlights": []
   },
   {
@@ -15838,7 +15838,7 @@
     "isbn": "9784048682756",
     "asin": "404868275X",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868275.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868275.jpg",
     "highlights": []
   },
   {
@@ -15849,7 +15849,7 @@
     "isbn": "9784048680127",
     "asin": "4048680129",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868012.jpg",
     "highlights": []
   },
   {
@@ -15860,7 +15860,7 @@
     "isbn": "9784048674614",
     "asin": "4048674617",
     "readDate": "2017/07/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867461.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867461.jpg",
     "highlights": []
   },
   {
@@ -15871,7 +15871,7 @@
     "isbn": "9784488523015",
     "asin": "4488523013",
     "readDate": "2017/07/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3015/9784488523015.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3015/9784488523015.jpg",
     "highlights": []
   },
   {
@@ -15882,7 +15882,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2017/06/30",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/91yx72KxkcL._SL1500_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/91yx72KxkcL._SL1500_.jpg",
     "highlights": [
       {
         "text": "──もぐりの人夫なんてこんなものだ。 彼等の大部分は俺同様失権者、つまり政府株をもたない連中だった。政府が株式会社組織の営利事業になって以来、政府株、すなわち行政株式会社の株を十株以上もたないものは一切の公民権──実は一切の人権を 剝奪 されるのだ。政府は物価操作一つで、この安い労働力をうんと作り出す事もできた──こんな常識的な事を知らなかった俺は、馬鹿と言われてもしかたがない。もっともはじめから知らなかったのか、知ってて忘れたのか、その点はっきりしなかったが。",
@@ -15898,7 +15898,7 @@
     "isbn": "9784488663032",
     "asin": "4488663036",
     "readDate": "2017/06/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3032/9784488663032.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3032/9784488663032.jpg",
     "highlights": [
       {
         "text": "くれればいいのだが、と彼は内心祈る気持だった。 「共に宇宙を旅する隣人として、惑星地球の全住民に代わって一言ご挨拶申し上げます。われわれは、生きとし生ける者すべてに対する平和と友好の意思をもってここにやって参りました。この邂逅が、両民族の恒久的共存の端緒とならんことを、そしてさらには深い相互理解を通じて節度ある共栄関係発展の契機とならんことを切に願うものであります。今より後、ガニメアンと地球人はそれによって共にその母星を後にし全宇宙の公海とも言うべきこの出会いの場所に旅し来たった最先端の知識の一層の進展に相携えて努力いたそうではありませんか」 ガニメアンたちは敬意を示して、ストレルの",
@@ -15914,7 +15914,7 @@
     "isbn": "9784048679046",
     "asin": "404867904X",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867904.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867904.jpg",
     "highlights": []
   },
   {
@@ -15925,7 +15925,7 @@
     "isbn": "9784334761745",
     "asin": "4334761747",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476174.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476174.jpg",
     "highlights": [
       {
         "text": "＊２「ぼくには日本の格闘技、バリツの心得があったから――これまでにも何度か役に立ったことがあるんだが――相手の腕をさっとすり抜けた」 バリツという格闘技は存在しないが、一八九九年にＥ・Ｗ・バートン＝ライトが〝バーティツ〟として英国に紹介した日本の護身術（つまり柔術）が、〝バリツ〟と誤記されたというのが定説。",
@@ -15941,7 +15941,7 @@
     "isbn": "9784061832466",
     "asin": "4061832468",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "志賀直哉の短編に『宿かりの死』というのがある。短編というよりは掌編ともいうべき小品で、ほんの一、二分で読み終えてしまうくらいの作品なのであるが、私はこの宿かりこそ、浪漫的読書人の姿ではないかと思う。",
@@ -15961,7 +15961,7 @@
     "isbn": "9784101006079",
     "asin": "4101006075",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784101006079.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784101006079.jpg",
     "highlights": []
   },
   {
@@ -15972,7 +15972,7 @@
     "isbn": "9784041305089",
     "asin": "404130508X",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -15983,7 +15983,7 @@
     "isbn": "9784757217645",
     "asin": "4757217641",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7645/9784757217645.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7645/9784757217645.jpg",
     "highlights": []
   },
   {
@@ -15994,7 +15994,7 @@
     "isbn": "9784041049938",
     "asin": "4041049938",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9938/9784041049938.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9938/9784041049938.jpg",
     "highlights": []
   },
   {
@@ -16005,7 +16005,7 @@
     "isbn": "9784040723389",
     "asin": "4040723384",
     "readDate": "2017/06/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3389/9784040723389.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3389/9784040723389.jpg",
     "highlights": []
   },
   {
@@ -16016,7 +16016,7 @@
     "isbn": "9784757217638",
     "asin": "4757217633",
     "readDate": "2017/06/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7638/9784757217638.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7638/9784757217638.jpg",
     "highlights": []
   },
   {
@@ -16027,7 +16027,7 @@
     "isbn": "9784153350205",
     "asin": "4153350206",
     "readDate": "2017/06/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0205/9784153350205.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0205/9784153350205.jpg",
     "highlights": []
   },
   {
@@ -16038,7 +16038,7 @@
     "isbn": "9784488605025",
     "asin": "4488605028",
     "readDate": "2017/06/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5025/9784488605025.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5025/9784488605025.jpg",
     "highlights": []
   },
   {
@@ -16049,7 +16049,7 @@
     "isbn": "9784152096845",
     "asin": "4152096845",
     "readDate": "2017/06/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6845/9784152096845.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6845/9784152096845.jpg",
     "highlights": []
   },
   {
@@ -16060,7 +16060,7 @@
     "isbn": "9784004306092",
     "asin": "4004306094",
     "readDate": "2017/06/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6092/9784004306092.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6092/9784004306092.gif",
     "highlights": []
   },
   {
@@ -16071,7 +16071,7 @@
     "isbn": "9784150504960",
     "asin": "4150504962",
     "readDate": "2017/06/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4960/9784150504960.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4960/9784150504960.jpg",
     "highlights": []
   },
   {
@@ -16082,7 +16082,7 @@
     "isbn": "9784480097699",
     "asin": "4480097694",
     "readDate": "2017/05/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7699/9784480097699.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7699/9784480097699.jpg",
     "highlights": []
   },
   {
@@ -16093,7 +16093,7 @@
     "isbn": "9784150312725",
     "asin": "4150312729",
     "readDate": "2017/05/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2725/9784150312725.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2725/9784150312725.jpg",
     "highlights": []
   },
   {
@@ -16104,7 +16104,7 @@
     "isbn": "9784150115418",
     "asin": "4150115419",
     "readDate": "2017/05/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011541.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011541.jpg",
     "highlights": []
   },
   {
@@ -16115,7 +16115,7 @@
     "isbn": "9784150504656",
     "asin": "4150504652",
     "readDate": "2017/05/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4656/9784150504656.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4656/9784150504656.jpg",
     "highlights": []
   },
   {
@@ -16126,7 +16126,7 @@
     "isbn": "9784480425997",
     "asin": "4480425993",
     "readDate": "2017/05/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5997/9784480425997.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5997/9784480425997.jpg",
     "highlights": []
   },
   {
@@ -16137,7 +16137,7 @@
     "isbn": "9784150504649",
     "asin": "4150504644",
     "readDate": "2017/05/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4649/9784150504649.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4649/9784150504649.jpg",
     "highlights": []
   },
   {
@@ -16148,7 +16148,7 @@
     "isbn": "9784167181147",
     "asin": "4167181142",
     "readDate": "2017/04/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16718114.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16718114.jpg",
     "highlights": []
   },
   {
@@ -16159,7 +16159,7 @@
     "isbn": "9784150300036",
     "asin": "4150300038",
     "readDate": "2017/04/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "かぎりなく宇宙にひろがってゆく。そのことにもとより何の意味もない。つねに充足は内にある。新しい精神は新しい冒険の所産か。人々は都市を造り、個室にひそみすでに夢の終ったことを知る。かぎりないその絶望のくりかえし。ここにあるものは終った夢の 堆積 だ。",
@@ -16191,7 +16191,7 @@
     "isbn": "9784062188043",
     "asin": "406218804X",
     "readDate": "2017/04/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8043/9784062188043.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8043/9784062188043.jpg",
     "highlights": [
       {
         "text": "凄味のある小説を書く作家として筆者がまず思い浮かべるのは色川武大である。この人は本人そのものに凄味があったのだが、これは直接つきあった者でないとわかるまい。色川武大は別に阿佐田哲也のペンネームで「麻雀放浪記」などのギャンブル小説を書いているが、特にギャンブル小説ではなくてもその作品すべてには凄味があり、純文学系統の作品であってもギャンブル小説に似た凄味を持っている。",
@@ -16283,7 +16283,7 @@
     "isbn": "9784000009775",
     "asin": "400000977X",
     "readDate": "2017/04/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9775/9784000009775.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9775/9784000009775.jpg",
     "highlights": []
   },
   {
@@ -16294,7 +16294,7 @@
     "isbn": "9784150117429",
     "asin": "415011742X",
     "readDate": "2017/04/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7429/9784150117429.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7429/9784150117429.jpg",
     "highlights": []
   },
   {
@@ -16305,7 +16305,7 @@
     "isbn": "9784150504809",
     "asin": "4150504806",
     "readDate": "2017/03/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4809/9784150504809.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4809/9784150504809.jpg",
     "highlights": []
   },
   {
@@ -16316,7 +16316,7 @@
     "isbn": "9784150504212",
     "asin": "4150504210",
     "readDate": "2017/03/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4212/9784150504212.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4212/9784150504212.jpg",
     "highlights": []
   },
   {
@@ -16327,7 +16327,7 @@
     "isbn": "9784040720777",
     "asin": "4040720776",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0777/9784040720777.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0777/9784040720777.jpg",
     "highlights": []
   },
   {
@@ -16338,7 +16338,7 @@
     "isbn": "9784061399648",
     "asin": "4061399640",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9648/9784061399648.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9648/9784061399648.jpg",
     "highlights": []
   },
   {
@@ -16349,7 +16349,7 @@
     "isbn": "9784061399655",
     "asin": "4061399659",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9655/9784061399655.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9655/9784061399655.jpg",
     "highlights": []
   },
   {
@@ -16360,7 +16360,7 @@
     "isbn": "9784150311216",
     "asin": "4150311218",
     "readDate": "2017/03/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1216/9784150311216.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1216/9784150311216.jpg",
     "highlights": [
       {
         "text": "「人は知るべきだ」 先生の言葉を反芻する。あの時僕は、どれくらい知るべきですか、と聞いた。 「知れるだけだよ」 道 終・常 イチ先生はそう答えた。",
@@ -16384,7 +16384,7 @@
     "isbn": "9784150310370",
     "asin": "4150310378",
     "readDate": "2017/03/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0370/9784150310370.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0370/9784150310370.jpg",
     "highlights": []
   },
   {
@@ -16395,7 +16395,7 @@
     "isbn": "9784061582712",
     "asin": "4061582712",
     "readDate": "2017/03/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0615/06158271.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0615/06158271.jpg",
     "highlights": [
       {
         "text": "この時私は始めて文学とはどんなものであるか、その 概念 を根本的に自力で作り上げるよりほかに、私を救う途はないのだと 悟ったのです。今までは全く他人本位で、根のない 萍 のように、そこいらをでたらめに 漂 よっていたから、 駄目 であったという事にようやく気がついたのです。私のここに他人本位というのは、自分の酒を人に飲んでもらって、後からその品評を聴いて、それを理が非でもそうだとしてしまういわゆる 人真似 を指すのです。",
@@ -16427,7 +16427,7 @@
     "isbn": "9784152096661",
     "asin": "4152096667",
     "readDate": "2017/03/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6661/9784152096661.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6661/9784152096661.jpg",
     "highlights": []
   },
   {
@@ -16438,7 +16438,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2017/03/04",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -16449,7 +16449,7 @@
     "isbn": "",
     "asin": null,
     "readDate": "2017/03/04",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/81KahmBP41L._AC_SX75_CR,0,0,75,75_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/81KahmBP41L._AC_SX75_CR,0,0,75,75_.jpg",
     "highlights": []
   },
   {
@@ -16460,7 +16460,7 @@
     "isbn": "9784041315224",
     "asin": "4041315220",
     "readDate": "2017/02/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5224/9784041315224.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5224/9784041315224.jpg",
     "highlights": []
   },
   {
@@ -16471,7 +16471,7 @@
     "isbn": "9784151200168",
     "asin": "4151200169",
     "readDate": "2017/02/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -16482,7 +16482,7 @@
     "isbn": "9784151200120",
     "asin": "4151200126",
     "readDate": "2017/02/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120012.jpg",
     "highlights": [
       {
         "text": "私は確信しているんだよ、リュカ、すべての人間は一冊の本を書くために生まれたのであって、ほかにはどんな目的もないんだ。天才的な本であろうと、 凡庸 な本であろうと、そんなことは大した問題じゃない。けれども、何も書かなければ、人は無為に生きたことになる。地上を通りすぎただけで 痕跡 を残さずに終わるのだから。",
@@ -16502,7 +16502,7 @@
     "isbn": "9784041305249",
     "asin": "4041305241",
     "readDate": "2017/02/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130524.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130524.jpg",
     "highlights": [
       {
         "text": "女性にとっては今や空前の結婚難時代となった。私が編集している男性雑誌「イリュージョン」でも、「いかにして女から逃げるか」だとか、「女と結婚しなくてすむ方法」とか「最も安あがりな離婚のしかた」「女はこうして男をだます」「あなたは女性に狙われている」などという特集をやると、たちまち四日足らずで売り切れてしまうぐらいだ。現にこの私も、三十三歳にして未だに運よく独身である。",
@@ -16534,7 +16534,7 @@
     "isbn": "9784334038540",
     "asin": "4334038549",
     "readDate": "2017/02/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8540/9784334038540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8540/9784334038540.jpg",
     "highlights": [
       {
         "text": "目の力によって対象と自分を分断し、境界線をはっきりさせること、それが近代における「大人になる」ということです。低次の感覚から高次の感覚へ――。教育とは、まさに子どもを触る世界から見る世界へ移行させることなのです。",
@@ -16562,7 +16562,7 @@
     "isbn": "9784101098302",
     "asin": "4101098301",
     "readDate": "2017/02/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8302/9784101098302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8302/9784101098302.jpg",
     "highlights": []
   },
   {
@@ -16573,7 +16573,7 @@
     "isbn": "9784006020019",
     "asin": "4006020015",
     "readDate": "2017/02/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0019/9784006020019.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0019/9784006020019.jpg",
     "highlights": [
       {
         "text": "この蛆虫のような学生どもはいったい何を考えてるのかね。ひとりひとりは みたいな脳しか持ってないみたいだし、きっと集団思考やっとるのだろうね。だいたい文学部へこんなにたくさん、何を教わりにくるんだい。文学なんてものは存在しないんだよね。あのう、これが文学だと認められたものの集合体、という意味でも、ある内在的特性があるからというので認知されたものという意味でも、文学なんて存在しないんだよね。だから当然この虫けらどもは、何を教わっていいかよくわからずにここへ来てるわけで、言ってみりゃこいつら、文学なんてどうでもいいんだよな」",
@@ -16649,7 +16649,7 @@
     "isbn": "9784150504755",
     "asin": "415050475X",
     "readDate": "2017/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4755/9784150504755.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4755/9784150504755.jpg",
     "highlights": []
   },
   {
@@ -16660,7 +16660,7 @@
     "isbn": "9784152094681",
     "asin": "4152094680",
     "readDate": "2017/02/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4681/9784152094681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4681/9784152094681.jpg",
     "highlights": []
   },
   {
@@ -16671,7 +16671,7 @@
     "isbn": "9784151200021",
     "asin": "4151200029",
     "readDate": "2017/02/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120002.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120002.jpg",
     "highlights": [
       {
         "text": "「良」か「不可」かを判定する基準として、ぼくらには、きわめて単純なルールがある。作文の内容は真実でなければならない、というルールだ。ぼくらが記述するのは、あるがままの事物、ぼくらが見たこと、ぼくらが聞いたこと、ぼくらが実行したこと、でなければならない。 たとえば、「おばあちゃんは魔女に似ている」と書くことは禁じられている。しかし、「人びとはおばあちゃんを〈魔女〉と呼ぶ」と書くことは許されている。 「〈小さな町〉は美しい」と書くことは禁じられている。なぜなら、〈小さな町〉は、ぼくらの目に美しく映り、それでいてほかの誰かの目には醜く映るのかもしれないから。 同じように、もしぼくらが「従卒は親切だ」と書けば、それは一個の真実ではない。というのは、もしかすると従卒に、ぼくらの知らない意地悪な面があるのかもしれないからだ。だから、ぼくらは単に、「従卒はぼくらに毛布をくれる」と書く。",
@@ -16687,7 +16687,7 @@
     "isbn": "9784779114304",
     "asin": "4779114306",
     "readDate": "2017/02/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784779114304.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784779114304.jpg",
     "highlights": []
   },
   {
@@ -16698,7 +16698,7 @@
     "isbn": "9784409130124",
     "asin": "4409130129",
     "readDate": "2017/01/28",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "エーデルマンが言うように、記憶とは事象の単なる記録や再生ではなく、個人の価値観や視点による再編、再建の作業なのである。",
@@ -16714,7 +16714,7 @@
     "isbn": "9784873117584",
     "asin": "4873117585",
     "readDate": "2017/01/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7584/9784873117584.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7584/9784873117584.jpg",
     "highlights": []
   },
   {
@@ -16725,7 +16725,7 @@
     "isbn": "9784150120979",
     "asin": "4150120978",
     "readDate": "2017/01/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0979/9784150120979.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0979/9784150120979.jpg",
     "highlights": []
   },
   {
@@ -16736,7 +16736,7 @@
     "isbn": "9784488663025",
     "asin": "4488663028",
     "readDate": "2017/01/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3025/9784488663025.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3025/9784488663025.jpg",
     "highlights": [
       {
         "text": "くれればいいのだが、と彼は内心祈る気持だった。 「共に宇宙を旅する隣人として、惑星地球の全住民に代わって一言ご挨拶申し上げます。われわれは、生きとし生ける者すべてに対する平和と友好の意思をもってここにやって参りました。この邂逅が、両民族の恒久的共存の端緒とならんことを、そしてさらには深い相互理解を通じて節度ある共栄関係発展の契機とならんことを切に願うものであります。今より後、ガニメアンと地球人はそれによって共にその母星を後にし全宇宙の公海とも言うべきこの出会いの場所に旅し来たった最先端の知識の一層の進展に相携えて努力いたそうではありませんか」 ガニメアンたちは敬意を示して、ストレルの",
@@ -16752,7 +16752,7 @@
     "isbn": "9784150121044",
     "asin": "4150121044",
     "readDate": "2016/12/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1044/9784150121044.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1044/9784150121044.jpg",
     "highlights": []
   },
   {
@@ -16763,7 +16763,7 @@
     "isbn": "9784040720760",
     "asin": "4040720768",
     "readDate": "2016/12/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784040720760.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784040720760.jpg",
     "highlights": [
       {
         "text": "「名古屋 駅で売ってる 生麩 のまんじゅうさ。昨日、久しぶりに中学時代の友達に会いに行って、さっき 戻ってきたんだ」 「へぇ、これ名古屋名物なのか……」 「名古屋名物というにはマイナーかもしれないけどね。でも、今まで食べた人全員に好評という、ヒット率の高い 逸品 だよ」 伊織 の言う通り、美味さだけでなくその軽さや 滑らかさが後を引いて、あっという間に三つ目を口にしてしまうくらいには大当たりだった。 「まぁでも、 純粋 に名古屋名物といえば、まずはひよこ型プリンの『ぴよりん』がお薦めかな。これはかつて存在したシャチホコ型シュークリーム『シャチボン』の流れをくむ、正統的な名古屋ネタスイーツだね。続いて名古屋〝らしさ〟を追求するなら断然、 坂角 の『ゆかり 黄金 缶』。名古屋駅限定のキンキラキンのパッケージに、中身はエビの 香りたっぷりのえびせんべい。 悪趣味 さとエビという、まさに名古屋のソウルをふんだんに盛り込んだ 傑作 だ。そういえば、名古屋名物に赤福やうなぎパイを 推す人がいるけど、あれはそれぞれ 伊勢 と 浜名湖 の名物であって厳密には名古屋じゃないからね。名古屋駅もそれを 憂慮 したのか、一度うなぎパイの方の取り扱いをやめたんだけど、それがかえって地元民の 怒りを買ってクレームが 殺到……」 「お前実は名古屋大好きだろそうなんだろ」 と、弁舌の止まらない伊織に 呆れつつ、俺は四つ目のまんじゅうを口に 放り込んだ。",
@@ -16799,7 +16799,7 @@
     "isbn": "9784150120009",
     "asin": "4150120005",
     "readDate": "2016/12/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0009/9784150120009.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0009/9784150120009.jpg",
     "highlights": [
       {
         "text": "人間は他の世界、他の文明と出会うために出かけて行ったくせに、自分自身のことも完全には知らないのだ。",
@@ -16815,7 +16815,7 @@
     "isbn": "9784094080667",
     "asin": "409408066X",
     "readDate": "2016/12/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408066.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408066.jpg",
     "highlights": []
   },
   {
@@ -16826,7 +16826,7 @@
     "isbn": "9784094080650",
     "asin": "4094080651",
     "readDate": "2016/12/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408065.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408065.jpg",
     "highlights": []
   },
   {
@@ -16837,7 +16837,7 @@
     "isbn": "9784041049921",
     "asin": "404104992X",
     "readDate": "2016/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9921/9784041049921.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9921/9784041049921.jpg",
     "highlights": []
   },
   {
@@ -16848,7 +16848,7 @@
     "isbn": "9784150115319",
     "asin": "4150115311",
     "readDate": "2016/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011531.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011531.jpg",
     "highlights": []
   },
   {
@@ -16859,7 +16859,7 @@
     "isbn": "9784488663018",
     "asin": "448866301X",
     "readDate": "2016/11/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3018/9784488663018.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3018/9784488663018.jpg",
     "highlights": []
   },
   {
@@ -16870,7 +16870,7 @@
     "isbn": "9784150112899",
     "asin": "4150112894",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011289.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011289.jpg",
     "highlights": []
   },
   {
@@ -16881,7 +16881,7 @@
     "isbn": "9784150112905",
     "asin": "4150112908",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011290.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011290.jpg",
     "highlights": []
   },
   {
@@ -16892,7 +16892,7 @@
     "isbn": "9784344424012",
     "asin": "4344424018",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4012/9784344424012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4012/9784344424012.jpg",
     "highlights": []
   },
   {
@@ -16903,7 +16903,7 @@
     "isbn": "9784061963771",
     "asin": "4061963775",
     "readDate": "2016/10/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3771/9784061963771.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3771/9784061963771.jpg",
     "highlights": []
   },
   {
@@ -16914,7 +16914,7 @@
     "isbn": "9784334761677",
     "asin": "4334761674",
     "readDate": "2016/10/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476167.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476167.jpg",
     "highlights": []
   },
   {
@@ -16925,7 +16925,7 @@
     "isbn": "9784334761639",
     "asin": "4334761631",
     "readDate": "2016/10/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476163.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476163.jpg",
     "highlights": [
       {
         "text": "た。「きみは見ているだけで、観察していないんだ。見ることと観察することとは、まるっきり違う。たとえば、玄関からこの部屋へ上がる階段を、きみは何度も見ているね」",
@@ -16949,7 +16949,7 @@
     "isbn": "9784102134061",
     "asin": "4102134069",
     "readDate": "2016/10/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4061/9784102134061.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4061/9784102134061.jpg",
     "highlights": []
   },
   {
@@ -16960,7 +16960,7 @@
     "isbn": "9784163695808",
     "asin": "416369580X",
     "readDate": "2016/10/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1636/16369580.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1636/16369580.jpg",
     "highlights": [
       {
         "text": "もちろん僕にだって負けず嫌いなところはなくはない。しかしなぜか、他人を相手に勝ったり負けたりすることには、昔から一貫してあまりこだわらなかった。そういう性向は大人になってもおおむね変わらない。何ごとによらず、他人に勝とうが負けようが、そんなに気にならない。それよりは、自分自身の設定した基準をクリアできるかできないか──そちらの方により関心が向く。そういう意味で長距離走は、僕のメンタリティーにぴたりとはまるスポーツだった。",
@@ -16992,7 +16992,7 @@
     "isbn": "9784102134054",
     "asin": "4102134050",
     "readDate": "2016/09/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1021/10213405.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1021/10213405.jpg",
     "highlights": []
   },
   {
@@ -17003,7 +17003,7 @@
     "isbn": "9784150504540",
     "asin": "4150504547",
     "readDate": "2016/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4540/9784150504540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4540/9784150504540.jpg",
     "highlights": [
       {
         "text": "しっかり定着したルーチンからはずれなくてはならないのに、そうするのをなぜか忘れていたという経験がないだろうか。たとえば、帰宅途中でドラッグストアに立ち寄らなくてはならないとしよう。一日じゅう、その用事のことが頭にある。リハーサルをする――そこへ行くのに、いつものルートから一歩だけそれて、臨時に方向転換するところを思い描いてみさえする。それなのになぜか、ふと気づくと、どこにも立ち寄らずに自宅の玄関先まで帰ってきている。あそこで方向転換するのを忘れ、そこを通り過ぎたことさえ覚えていない。それが、 考えもせず にやっている習慣であり、どんなに頭の一部が何かほかのことをしなければならないと知っていても、それに反して出しゃばってくる、ルーチンというものだ。",
@@ -17047,7 +17047,7 @@
     "isbn": "9784488013516",
     "asin": "4488013511",
     "readDate": "2016/09/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3516/9784488013516.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3516/9784488013516.jpg",
     "highlights": []
   },
   {
@@ -17058,7 +17058,7 @@
     "isbn": "9784488013523",
     "asin": "448801352X",
     "readDate": "2016/09/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -17069,7 +17069,7 @@
     "isbn": "9784003243848",
     "asin": "4003243846",
     "readDate": "2016/09/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/00324384.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/00324384.jpg",
     "highlights": [
       {
         "text": "掟の問題",
@@ -17101,7 +17101,7 @@
     "isbn": "9784041026229",
     "asin": "4041026229",
     "readDate": "2016/09/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6229/9784041026229.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6229/9784041026229.jpg",
     "highlights": []
   },
   {
@@ -17112,7 +17112,7 @@
     "isbn": "9784062760812",
     "asin": "4062760819",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0812/9784062760812.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0812/9784062760812.jpg",
     "highlights": [
       {
         "text": "愛は祈りだ。 僕は祈る。 僕の好きな人たちに皆そろって幸せになってほしい。 それぞれの願いを 叶えてほしい。 温かい場所で、あるいは涼しい場所で、とにかく心地よい場所で、それぞれの好きな人たちに囲まれて楽しく暮らしてほしい。 最大の幸福が空から皆に降り注ぐといい。 僕は世界中の全ての人たちが好きだ。 名前を知ってる人、知らない人、これから知ることになる人、これからも知らずに終わる人、そういう人たちを皆愛している。 なぜならうまくすれば僕とそういう人たちはとても仲良くなれるし、そういう可能性があるということで、僕にとっては皆を愛するに十分なのだ。 世界の全ての人々、皆の持つ僕との違いなんてもちろん僕はかまわない。 人は皆違って当然だ。 皆の欠点や失策や間違いについてすら僕は別にどうでもいい。 何かの偶然で知り合いになれる、ひょっとしたら友達になれる、もしかすると、お互いにとても大事な存在になれる、そういう可能性があるということで、僕は僕以外の人全員のことが好きなのだ。 一人一人、知り合えばさらに、個別に愛することができる。 僕達はたまたまお互いのことを知らないけれど、知り合ったら、うまくすれば、もしかすると、さらに深く強く愛し合えるのだ。 僕はだから、皆のために祈る。 祈りはそのまま、愛なのだ。 祈りも",
@@ -17136,7 +17136,7 @@
     "isbn": "9784042118039",
     "asin": "4042118038",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8039/9784042118039.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8039/9784042118039.jpg",
     "highlights": [
       {
         "text": "変わり方があまりに急だったので、とてもこわくなったアリスは、それでもまだ自分が 存在 していることに、ほっとしました。",
@@ -17156,7 +17156,7 @@
     "isbn": "9784101152080",
     "asin": "410115208X",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2080/9784101152080.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2080/9784101152080.jpg",
     "highlights": []
   },
   {
@@ -17167,7 +17167,7 @@
     "isbn": "9784101152097",
     "asin": "4101152098",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2097/9784101152097.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2097/9784101152097.jpg",
     "highlights": []
   },
   {
@@ -17178,7 +17178,7 @@
     "isbn": "9784396316921",
     "asin": "4396316925",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6921/9784396316921.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6921/9784396316921.jpg",
     "highlights": []
   },
   {
@@ -17189,7 +17189,7 @@
     "isbn": "9784622023487",
     "asin": "4622023482",
     "readDate": "2016/08/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -17200,7 +17200,7 @@
     "isbn": "9784150504595",
     "asin": "4150504598",
     "readDate": "2016/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4595/9784150504595.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4595/9784150504595.jpg",
     "highlights": []
   },
   {
@@ -17211,7 +17211,7 @@
     "isbn": "9784150504502",
     "asin": "4150504504",
     "readDate": "2016/08/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4502/9784150504502.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4502/9784150504502.jpg",
     "highlights": []
   },
   {
@@ -17222,7 +17222,7 @@
     "isbn": "9784150504496",
     "asin": "4150504490",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4496/9784150504496.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4496/9784150504496.jpg",
     "highlights": []
   },
   {
@@ -17233,7 +17233,7 @@
     "isbn": "9784041305256",
     "asin": "404130525X",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130525.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130525.jpg",
     "highlights": []
   },
   {
@@ -17244,7 +17244,7 @@
     "isbn": "9784048704694",
     "asin": "4048704699",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4694/9784048704694.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4694/9784048704694.jpg",
     "highlights": [
       {
         "text": "ピーター・ディキンスン『 生ける 屍』。サンリオＳＦ文庫。",
@@ -17260,7 +17260,7 @@
     "isbn": "9784062838986",
     "asin": "4062838982",
     "readDate": "2016/08/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8986/9784062838986.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8986/9784062838986.jpg",
     "highlights": []
   },
   {
@@ -17271,7 +17271,7 @@
     "isbn": "9784896375626",
     "asin": "4896375629",
     "readDate": "2016/08/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5626/9784896375626.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5626/9784896375626.jpg",
     "highlights": []
   },
   {
@@ -17282,7 +17282,7 @@
     "isbn": "9784896375084",
     "asin": "4896375084",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5084/9784896375084.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5084/9784896375084.jpg",
     "highlights": []
   },
   {
@@ -17293,7 +17293,7 @@
     "isbn": "9784062813860",
     "asin": "4062813866",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3860/9784062813860.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3860/9784062813860.jpg",
     "highlights": []
   },
   {
@@ -17304,7 +17304,7 @@
     "isbn": "9784896375411",
     "asin": "4896375416",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5411/9784896375411.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5411/9784896375411.jpg",
     "highlights": []
   },
   {
@@ -17315,7 +17315,7 @@
     "isbn": "9784799208038",
     "asin": "4799208039",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8038/9784799208038.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8038/9784799208038.jpg",
     "highlights": []
   },
   {
@@ -17326,7 +17326,7 @@
     "isbn": "9784896374650",
     "asin": "4896374657",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4650/9784896374650.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4650/9784896374650.jpg",
     "highlights": []
   },
   {
@@ -17337,7 +17337,7 @@
     "isbn": "9784896374858",
     "asin": "4896374851",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4858/9784896374858.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4858/9784896374858.jpg",
     "highlights": []
   },
   {
@@ -17348,7 +17348,7 @@
     "isbn": "9784799206805",
     "asin": "479920680X",
     "readDate": "2016/08/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6805/9784799206805.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6805/9784799206805.jpg",
     "highlights": []
   },
   {
@@ -17359,7 +17359,7 @@
     "isbn": "9784799207512",
     "asin": "4799207512",
     "readDate": "2016/08/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7512/9784799207512.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7512/9784799207512.jpg",
     "highlights": []
   },
   {
@@ -17370,7 +17370,7 @@
     "isbn": "9784101215266",
     "asin": "410121526X",
     "readDate": "2016/08/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5266/9784101215266.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5266/9784101215266.jpg",
     "highlights": [
       {
         "text": "医者さんに、魂とは何ですか、と言われて、僕はよくこれを言いますよ。分けられないものを明確に分けた途端に消えるものを魂というと。善と悪とかでもそうです。だから、魂の観点からものを見るというのは、そういう区別を全部、一遍、ご破算にして見ることなんです。障害のある人とない人、男と女、そういう区別を全部消して見る。",
@@ -17410,7 +17410,7 @@
     "isbn": "9784758031813",
     "asin": "4758031819",
     "readDate": "2016/08/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1813/9784758031813.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1813/9784758031813.jpg",
     "highlights": []
   },
   {
@@ -17421,7 +17421,7 @@
     "isbn": "9784150504113",
     "asin": "4150504113",
     "readDate": "2016/08/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4113/9784150504113.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4113/9784150504113.jpg",
     "highlights": []
   },
   {
@@ -17432,7 +17432,7 @@
     "isbn": "9784775949016",
     "asin": "4775949012",
     "readDate": "2016/08/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9016/9784775949016.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9016/9784775949016.jpg",
     "highlights": []
   },
   {
@@ -17443,7 +17443,7 @@
     "isbn": "9784864724470",
     "asin": "4864724474",
     "readDate": "2016/08/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4470/9784864724470.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4470/9784864724470.jpg",
     "highlights": []
   },
   {
@@ -17454,7 +17454,7 @@
     "isbn": "9784864724739",
     "asin": "4864724733",
     "readDate": "2016/08/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4739/9784864724739.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4739/9784864724739.jpg",
     "highlights": []
   },
   {
@@ -17465,7 +17465,7 @@
     "isbn": "9784864724241",
     "asin": "4864724245",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4241/9784864724241.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4241/9784864724241.jpg",
     "highlights": []
   },
   {
@@ -17476,7 +17476,7 @@
     "isbn": "9784102184219",
     "asin": "410218421X",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4219/9784102184219.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4219/9784102184219.jpg",
     "highlights": []
   },
   {
@@ -17487,7 +17487,7 @@
     "isbn": "9784777111053",
     "asin": "4777111059",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/9784777111053.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/9784777111053.jpg",
     "highlights": [
       {
         "text": "「君がバラのために使った時間が長ければ長いほど、バラは君にとって大切な存在になるんだ」 ――ボクがバラのために使った時間が長ければ長いほど……。 王子さまは、また、その言葉を覚えるために、くり返しました。 「人間たちは、みんな、このことを忘れてしまっている。 だけど、君は忘れちゃあだめだよ。 君は、いったん誰かを飼いならしたら、いつまでもその人との関係を大切にしなくちゃ」 ――いつまでもその人との関係を大切に……。 王子さまは、覚えるために、その言葉をくり返しました。",
@@ -17511,7 +17511,7 @@
     "isbn": "9784904209394",
     "asin": "4904209397",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9394/9784904209394.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9394/9784904209394.jpg",
     "highlights": [
       {
         "text": "私はもともと人工知能に興味があったのですが、実際に自分が研究に携わることになるそもそものきっかけは、東京駅の裏手にあった書店で『The Cognitive Computer』（邦題『考えるコンピュータ』ダイヤモンド社）という英語の原書を手に取ったことでした。",
@@ -17535,7 +17535,7 @@
     "isbn": "9784864724302",
     "asin": "486472430X",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4302/9784864724302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4302/9784864724302.jpg",
     "highlights": []
   },
   {
@@ -17546,7 +17546,7 @@
     "isbn": "9784864724449",
     "asin": "486472444X",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4449/9784864724449.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4449/9784864724449.jpg",
     "highlights": []
   },
   {
@@ -17557,7 +17557,7 @@
     "isbn": "9784864724661",
     "asin": "4864724660",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4661/9784864724661.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4661/9784864724661.jpg",
     "highlights": []
   },
   {
@@ -17568,7 +17568,7 @@
     "isbn": "9784864723428",
     "asin": "4864723427",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3428/9784864723428.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3428/9784864723428.jpg",
     "highlights": []
   },
   {
@@ -17579,7 +17579,7 @@
     "isbn": "9784864724999",
     "asin": "4864724997",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4999/9784864724999.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4999/9784864724999.jpg",
     "highlights": []
   },
   {
@@ -17590,7 +17590,7 @@
     "isbn": "9784864723978",
     "asin": "4864723974",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3978/9784864723978.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3978/9784864723978.jpg",
     "highlights": []
   },
   {
@@ -17601,7 +17601,7 @@
     "isbn": "9784763131201",
     "asin": "4763131206",
     "readDate": "2016/08/02",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784763131201.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784763131201.jpg",
     "highlights": [
       {
         "text": "は「モノ別」に片づけること。「今日はこの部屋を片づけよう」ではなく、「今日は洋服」「明日は本類」というふうに、「モノ」ごとに片づけを進めていくようにするのです。",
@@ -17633,7 +17633,7 @@
     "isbn": "9784150504106",
     "asin": "4150504105",
     "readDate": "2016/07/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4106/9784150504106.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4106/9784150504106.jpg",
     "highlights": []
   },
   {
@@ -17644,7 +17644,7 @@
     "isbn": "9784560070512",
     "asin": "4560070512",
     "readDate": "2016/07/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0512/9784560070512.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0512/9784560070512.jpg",
     "highlights": []
   },
   {
@@ -17655,7 +17655,7 @@
     "isbn": "9784048704823",
     "asin": "4048704826",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4823/9784048704823.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4823/9784048704823.jpg",
     "highlights": []
   },
   {
@@ -17666,7 +17666,7 @@
     "isbn": "9784048678100",
     "asin": "4048678108",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867810.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867810.jpg",
     "highlights": []
   },
   {
@@ -17677,7 +17677,7 @@
     "isbn": "9784048681384",
     "asin": "4048681389",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868138.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868138.jpg",
     "highlights": []
   },
   {
@@ -17688,7 +17688,7 @@
     "isbn": "9784048683951",
     "asin": "4048683950",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868395.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868395.jpg",
     "highlights": []
   },
   {
@@ -17699,7 +17699,7 @@
     "isbn": "9784048685962",
     "asin": "4048685961",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868596.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868596.jpg",
     "highlights": []
   },
   {
@@ -17710,7 +17710,7 @@
     "isbn": "9784048688802",
     "asin": "4048688804",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868880.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868880.jpg",
     "highlights": []
   },
   {
@@ -17721,7 +17721,7 @@
     "isbn": "9784048701259",
     "asin": "4048701258",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0487/04870125.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0487/04870125.jpg",
     "highlights": []
   },
   {
@@ -17732,7 +17732,7 @@
     "isbn": "9784048704304",
     "asin": "4048704303",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784048704304.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784048704304.jpg",
     "highlights": []
   },
   {
@@ -17743,7 +17743,7 @@
     "isbn": "9784040707426",
     "asin": "4040707427",
     "readDate": "2016/07/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7426/9784040707426.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7426/9784040707426.jpg",
     "highlights": []
   },
   {
@@ -17754,7 +17754,7 @@
     "isbn": "9784822279981",
     "asin": "4822279987",
     "readDate": "2016/07/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9981/9784822279981.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9981/9784822279981.jpg",
     "highlights": []
   },
   {
@@ -17765,7 +17765,7 @@
     "isbn": "9784873115146",
     "asin": "4873115140",
     "readDate": "2016/07/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5146/9784873115146.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5146/9784873115146.jpg",
     "highlights": []
   },
   {
@@ -17776,7 +17776,7 @@
     "isbn": "9784167906474",
     "asin": "4167906473",
     "readDate": "2016/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6474/9784167906474.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6474/9784167906474.jpg",
     "highlights": []
   },
   {
@@ -17787,7 +17787,7 @@
     "isbn": "9784098235018",
     "asin": "4098235013",
     "readDate": "2016/07/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5018/9784098235018.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5018/9784098235018.jpg",
     "highlights": []
   },
   {
@@ -17798,7 +17798,7 @@
     "isbn": "9784041039540",
     "asin": "4041039541",
     "readDate": "2016/07/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9540/9784041039540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9540/9784041039540.jpg",
     "highlights": []
   },
   {
@@ -17809,7 +17809,7 @@
     "isbn": "9784594074760",
     "asin": "4594074766",
     "readDate": "2016/07/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4760/9784594074760.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4760/9784594074760.jpg",
     "highlights": []
   },
   {
@@ -17820,7 +17820,7 @@
     "isbn": "9784041037188",
     "asin": "4041037182",
     "readDate": "2016/07/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7188/9784041037188.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7188/9784041037188.jpg",
     "highlights": []
   },
   {
@@ -17831,7 +17831,7 @@
     "isbn": "9784140018569",
     "asin": "4140018569",
     "readDate": "2016/07/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1400/14001856.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1400/14001856.jpg",
     "highlights": []
   },
   {
@@ -17842,7 +17842,7 @@
     "isbn": "9784062923682",
     "asin": "4062923688",
     "readDate": "2016/07/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3682/9784062923682.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3682/9784062923682.jpg",
     "highlights": []
   },
   {
@@ -17853,7 +17853,7 @@
     "isbn": "9784150114589",
     "asin": "4150114587",
     "readDate": "2016/07/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011458.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011458.jpg",
     "highlights": [
       {
         "text": "一七七〇年、クック船長の船、〈エンデヴァー〉がオーストラリアはクイーンズランドの海岸に座礁した。クックは部下の数人を修理にとりくませておき、その間に探検隊を率いて出かけ、アボリジニのひとびとに遭遇した。船員のひとりが、袋に子を入れて跳ねまわっている動物を指さして、あれはなんと呼ばれているのかとアボリジニにたずねた。そのアボリジニは、「カンガルー」と答えた。そのときから、クックと部下の船員たちはその動物をその語で呼ぶことになる。それは、のちになって彼らがその語は、〝あなたはなにを言っているのか？〟という意味であることを知るまで、変わらなかった。",
@@ -17873,7 +17873,7 @@
     "isbn": "9784480068248",
     "asin": "4480068244",
     "readDate": "2016/06/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8248/9784480068248.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8248/9784480068248.jpg",
     "highlights": [
       {
         "text": "心理学に最も多大な貢献をした心理学者として、アメリカでたびたび第一位にランクされるのが、行動主義心理学の祖スキナー（Burrhus Skinner） である。スキナーはネズミやハトを対象に、迷路やスキナー箱という実験的装置を用いて、その理論を発展させていった。",
@@ -17893,7 +17893,7 @@
     "isbn": "9784844396192",
     "asin": "4844396196",
     "readDate": "2016/05/24",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6192/9784844396192.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6192/9784844396192.jpg",
     "highlights": [
       {
         "text": "1-3-1 OSI参照モデル 代表的なネットワークの階層モデルは、OSI（Open Systems Interconnection、開放型システム間相互接続）参照モデルと呼ばれるものです。これはISOによって制定されたモデルで、ネットワークを以下の7階層に分けています。 ・アプリケーション層 アプリケーション固有のデータの形式ややり取りの手順などを定めます。 ・プレゼンテーション層 データの表現形式、具体的には文字コードやファイル形式の処理や変換を行います。 ・セッション層 通信の開始から終了までの手順を規定します。 ・トランスポート層 エラーの検出や回復など、データ伝送を制御します。 ・ネットワーク層 複数のネットワークから構成されたインターネットで、ルーターを介した機器間のデータ伝送を実現します。 ・データリンク層 単一のネットワーク内で、機器間（ルーターも含みます）のデータ伝送を実現します。 ・物理層 実際の通信に使われる各種の規格、仕様を定めます。",
@@ -17913,7 +17913,7 @@
     "isbn": "9784334751067",
     "asin": "4334751067",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475106.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475106.jpg",
     "highlights": []
   },
   {
@@ -17924,7 +17924,7 @@
     "isbn": "9784101098166",
     "asin": "4101098166",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8166/9784101098166.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8166/9784101098166.jpg",
     "highlights": []
   },
   {
@@ -17935,7 +17935,7 @@
     "isbn": "9784334751449",
     "asin": "433475144X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475144.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475144.jpg",
     "highlights": [
       {
         "text": "アクトン卿の〝権力は腐敗する。絶対的権力は絶対的に腐敗する〟",
@@ -17963,7 +17963,7 @@
     "isbn": "9784140816974",
     "asin": "414081697X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6974/9784140816974.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6974/9784140816974.jpg",
     "highlights": []
   },
   {
@@ -17974,7 +17974,7 @@
     "isbn": "9784101098197",
     "asin": "4101098190",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "童話の末尾のこの欠陥を指摘し、問題にしようかと思ったのだが、やめた。やはり「二人はいつまでもしあわせ」なのだと気づいたからである。二人は大冒険、大悲劇という共通体験を持っている。ぬるま湯のような状態のなかにあっても、それを話題にしさえすれば、過去の大苦痛の思い出がよみがえり、たちまち幸福感にひたれるというわけである。まったく、うらやましい限りだ。だからこそ、いつまでも語りつがれる童話ということになっているのだろう。",
@@ -18022,7 +18022,7 @@
     "isbn": "9784101098173",
     "asin": "4101098174",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10109817.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10109817.jpg",
     "highlights": []
   },
   {
@@ -18033,7 +18033,7 @@
     "isbn": "9784101098111",
     "asin": "4101098115",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8111/9784101098111.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8111/9784101098111.jpg",
     "highlights": []
   },
   {
@@ -18044,7 +18044,7 @@
     "isbn": "9784167651862",
     "asin": "4167651866",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1862/9784167651862.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1862/9784167651862.jpg",
     "highlights": [
       {
         "text": "人物だ。マンガーは、一九九五年、ハーヴァード・ビジネス・スクールで〝人間が判断を誤る心理〟と題する講演を行なった。他人の行動を予測するには、動機に目を向けさえすればいい、とマンガーは言う。",
@@ -18064,7 +18064,7 @@
     "isbn": "9784003361313",
     "asin": "4003361318",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1313/9784003361313.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1313/9784003361313.jpg",
     "highlights": [
       {
         "text": "わたしたちの意見が分かれるのは、ある人が他人よりも理性があるということによるのではなく、ただ、わたしたちが思考を異なる道筋で導き、同一のことを考察してはいないことから生じるのである。",
@@ -18128,7 +18128,7 @@
     "isbn": "9784422100982",
     "asin": "442210098X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0982/9784422100982.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0982/9784422100982.jpg",
     "highlights": [
       {
         "text": "世の中の人は皆、幸福を求めているが、その幸福を必ず見つける方法が一つある。それは、自分の気の持ち方を工夫することだ。幸福は外的な条件によって得られるものではなく、自分の気の持ち方一つで、どうにでもなる。 幸不幸は、財産、地位、職業などで決まるものではない。何を幸福と考え、また不幸と考えるか──その考え方が、幸不幸の分かれ目なのである。",
@@ -18152,7 +18152,7 @@
     "isbn": "9784047912755",
     "asin": "4047912751",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0479/04791275.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0479/04791275.gif",
     "highlights": []
   },
   {
@@ -18163,7 +18163,7 @@
     "isbn": "9784041036235",
     "asin": "4041036232",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6235/9784041036235.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6235/9784041036235.jpg",
     "highlights": []
   },
   {
@@ -18174,7 +18174,7 @@
     "isbn": "9784334751418",
     "asin": "4334751415",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475141.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475141.jpg",
     "highlights": []
   },
   {
@@ -18185,7 +18185,7 @@
     "isbn": "9784102071014",
     "asin": "4102071016",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1014/9784102071014.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1014/9784102071014.jpg",
     "highlights": []
   },
   {
@@ -18196,7 +18196,7 @@
     "isbn": "9784043878017",
     "asin": "404387801X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8017/9784043878017.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8017/9784043878017.jpg",
     "highlights": [
       {
         "text": "「我々の大方の苦悩は、あり得べき別の人生を夢想することから始まる。自分の可能性という当てにならないものに望みを託すことが諸悪の根元だ。今ここにある君以外、ほかの何者にもなれない自分を認めなくてはいけない。君がいわゆる薔薇色の学生生活を満喫できるわけがない。私が保証するからどっしりかまえておれ」",
@@ -18212,7 +18212,7 @@
     "isbn": "9784150120436",
     "asin": "4150120439",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784150120436.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784150120436.jpg",
     "highlights": []
   },
   {
@@ -18223,7 +18223,7 @@
     "isbn": "9784150120443",
     "asin": "4150120447",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0443/9784150120443.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0443/9784150120443.jpg",
     "highlights": []
   },
   {
@@ -18234,7 +18234,7 @@
     "isbn": "9784041305225",
     "asin": "4041305225",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -18245,7 +18245,7 @@
     "isbn": "9784894563698",
     "asin": "489456369X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3698/9784894563698.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3698/9784894563698.jpg",
     "highlights": [
       {
         "text": "したがって、無限の未来は、『無限遠』として距離──空間感覚に翻訳される。もっとも粗雑なたとえとして、時は『流れ』として表象される。これは、人間の意識の〝ふりかえり〟作用と〝予見〟作用により、時の経過感覚が、空間的な移動感覚として表象されたものである……。",
@@ -18265,7 +18265,7 @@
     "isbn": "9784150311193",
     "asin": "4150311196",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784150311193.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784150311193.jpg",
     "highlights": []
   },
   {
@@ -18276,7 +18276,7 @@
     "isbn": "9784167903169",
     "asin": "4167903164",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3169/9784167903169.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3169/9784167903169.jpg",
     "highlights": []
   },
   {
@@ -18287,7 +18287,7 @@
     "isbn": "9784167900366",
     "asin": "416790036X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0366/9784167900366.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0366/9784167900366.jpg",
     "highlights": []
   },
   {
@@ -18298,7 +18298,7 @@
     "isbn": "9784478066119",
     "asin": "4478066116",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6119/9784478066119.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6119/9784478066119.jpg",
     "highlights": [
       {
         "text": "哲人 多くの親や教育者たちは、これに 眉 をひそめ、もっと「役に立つもの」や「価値のあるもの」を与えようとします。その行為を 諌め、書物や玩具を没収し、自分たちがそこに価値を認めたものだけを与えるわけです。 無論、親たちは「子どものためを思って」そうしているのでしょう。しかしこれは、いっさいの「尊敬」を欠いた、子どもとの距離を遠ざけるだけの行為だと考えねばなりません。子どもたちの自然な関心を否定しているのですから。",
@@ -18346,7 +18346,7 @@
     "isbn": "9784761270438",
     "asin": "4761270438",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0438/9784761270438.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0438/9784761270438.jpg",
     "highlights": [
       {
         "text": "成功した企業がいかにして衰退するかを分析した（ ３）。コリンズによると、失敗の主な理由は企業が「規律なき拡大路線」に陥ったことだと言う。つまり、やたらと多くを求めすぎたのだ。このことは企業だけでなく、そこで働く個人にも当てはまる。",
@@ -18402,7 +18402,7 @@
     "isbn": "9784334752712",
     "asin": "4334752713",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2712/9784334752712.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2712/9784334752712.jpg",
     "highlights": [
       {
         "text": "そういうわけで重圧を与え続けると、バネの弾力がなくなるように、多読に走ると、精神のしなやかさが奪われる。自分の考えを持ちたくなければ、その絶対確実な方法（１） は、一分でも空き時間ができたら、すぐさま本を手に取ることだ。これを実践すると、生まれながら凡庸で単純な多くの人間は、博識が 仇 となってますます精神のひらめきを失い、またあれこれ書き散らすと、ことごとく失敗するはめになる。つまりポープ（２） の言葉通りになってしまう。",
@@ -18462,7 +18462,7 @@
     "isbn": "9784334751081",
     "asin": "4334751083",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475108.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475108.jpg",
     "highlights": [
       {
         "text": "啓蒙とは何か。 それは人間が、 みずから招いた未成年の状態から抜けでることだ。 未成年の状態とは、他人の指示を仰がなければ自分の理性を使うことができないということである（ １）。人間が未成年の状態にあるのは、理性がないからではなく、他人の指示を仰がないと、自分の理性を使う決意も勇気ももてないからなのだ。だから人間はみずからの責任において、未成年の状態にとどまっていることになる。こうして啓蒙の標語とでもいうものがあるとすれば、それは「 知る勇気をもて」（ ２）だ。すなわち「自分の理性を使う勇気をもて」ということだ。",
@@ -18518,7 +18518,7 @@
     "isbn": "9784062579681",
     "asin": "4062579685",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9681/9784062579681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9681/9784062579681.jpg",
     "highlights": []
   },
   {
@@ -18529,7 +18529,7 @@
     "isbn": "9784797321944",
     "asin": "4797321946",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1944/9784797321944.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1944/9784797321944.jpg",
     "highlights": []
   },
   {
@@ -18540,7 +18540,7 @@
     "isbn": "9784844365624",
     "asin": "4844365622",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5624/9784844365624.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5624/9784844365624.jpg",
     "highlights": []
   },
   {
@@ -18551,7 +18551,7 @@
     "isbn": "9784802510028",
     "asin": "4802510020",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0028/9784802510028.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0028/9784802510028.jpg",
     "highlights": []
   },
   {
@@ -18562,7 +18562,7 @@
     "isbn": "9784150116798",
     "asin": "4150116792",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6798/9784150116798.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6798/9784150116798.jpg",
     "highlights": []
   },
   {
@@ -18573,7 +18573,7 @@
     "isbn": "9784750514505",
     "asin": "4750514500",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4505/9784750514505.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4505/9784750514505.jpg",
     "highlights": []
   },
   {
@@ -18584,7 +18584,7 @@
     "isbn": "9784105393021",
     "asin": "4105393022",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/10539302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/10539302.jpg",
     "highlights": []
   },
   {
@@ -18595,7 +18595,7 @@
     "isbn": "9784152095787",
     "asin": "4152095784",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5787/9784152095787.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5787/9784152095787.jpg",
     "highlights": []
   },
   {
@@ -18606,7 +18606,7 @@
     "isbn": "9784873117386",
     "asin": "4873117380",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7386/9784873117386.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7386/9784873117386.jpg",
     "highlights": []
   },
   {
@@ -18617,7 +18617,7 @@
     "isbn": "9784873116983",
     "asin": "4873116988",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6983/9784873116983.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6983/9784873116983.jpg",
     "highlights": []
   },
   {
@@ -18628,7 +18628,7 @@
     "isbn": "9784150300012",
     "asin": "4150300011",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "したがって、無限の未来は、『無限遠』として距離──空間感覚に翻訳される。もっとも粗雑なたとえとして、時は『流れ』として表象される。これは、人間の意識の〝ふりかえり〟作用と〝予見〟作用により、時の経過感覚が、空間的な移動感覚として表象されたものである……。",
@@ -18648,7 +18648,7 @@
     "isbn": "9784150312015",
     "asin": "415031201X",
     "readDate": "2015/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2015/9784150312015.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2015/9784150312015.jpg",
     "highlights": []
   },
   {
@@ -18659,7 +18659,7 @@
     "isbn": "9784478025819",
     "asin": "4478025819",
     "readDate": "2015/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5819/9784478025819.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5819/9784478025819.jpg",
     "highlights": [
       {
         "text": "いかなる経験も、それ自体では成功の原因でも失敗の原因でもない。われわれは自分の経験によるショック——いわゆるトラウマ——に苦しむのではなく、経験の中から目的にかなうものを見つけ出す。 自分の経験によって決定されるのではなく、経験に与える意味によって自らを決定するのである」",
@@ -18715,7 +18715,7 @@
     "isbn": "9784040800202",
     "asin": "4040800206",
     "readDate": "2015/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0202/9784040800202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0202/9784040800202.jpg",
     "highlights": [
       {
         "text": "特徴表現学習（＊注",
@@ -18815,7 +18815,7 @@
     "isbn": "9784062560313",
     "asin": "4062560313",
     "readDate": "2015/08/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0313/9784062560313.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0313/9784062560313.jpg",
     "highlights": [
       {
         "text": "成人をしのぐ活躍をする子どものイメージが、昔話や神話などには世界共通の現象として存在することが認められる。つまり、人類はこのような超人的な子どもの話を好むのである。",
@@ -18955,7 +18955,7 @@
     "isbn": "9784151200533",
     "asin": "4151200533",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0533/9784151200533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0533/9784151200533.jpg",
     "highlights": []
   },
   {
@@ -18966,7 +18966,7 @@
     "isbn": "9784003226223",
     "asin": "4003226224",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6223/9784003226223.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6223/9784003226223.jpg",
     "highlights": []
   },
   {
@@ -18977,7 +18977,7 @@
     "isbn": "9784042334019",
     "asin": "4042334016",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784042334019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784042334019.jpg",
     "highlights": []
   },
   {
@@ -18988,7 +18988,7 @@
     "isbn": "9784150116774",
     "asin": "4150116776",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6774/9784150116774.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6774/9784150116774.jpg",
     "highlights": []
   },
   {
@@ -18999,7 +18999,7 @@
     "isbn": "9784150116781",
     "asin": "4150116784",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6781/9784150116781.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6781/9784150116781.jpg",
     "highlights": []
   }
 ]

--- a/public/books.ts
+++ b/public/books.ts
@@ -7,7 +7,7 @@ export const books = [
     "isbn": "9784492224168",
     "asin": "4492224165",
     "readDate": "2025/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4168/9784492224168_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4168/9784492224168_1_4.jpg",
     "highlights": []
   },
   {
@@ -18,7 +18,7 @@ export const books = [
     "isbn": "9784320023680",
     "asin": "4320023684",
     "readDate": "2025/08/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784320023680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784320023680.jpg",
     "highlights": []
   },
   {
@@ -29,7 +29,7 @@ export const books = [
     "isbn": "9784041026557",
     "asin": "4041026555",
     "readDate": "2025/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6557/9784041026557_1_12.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6557/9784041026557_1_12.jpg",
     "highlights": []
   },
   {
@@ -40,7 +40,7 @@ export const books = [
     "isbn": "9784087213485",
     "asin": "408721348X",
     "readDate": "2025/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3485/9784087213485_1_40.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3485/9784087213485_1_40.jpg",
     "highlights": [
       {
         "text": "債券の世界では、債券の投資から得られるリターンを「金利」や「利回り（イールド）」ということから、債券価格が上がれば、リターン（金利・利回り） は下がることになります。債券を勉強する際、金利が上がると価格は下がること、すなわち、金利と価格が逆の動きをすることを理解するのは難しいとされますが、高い値段で買うと、リターンが下がると考えれば当たり前に感じられるはずです。",
@@ -80,7 +80,7 @@ export const books = [
     "isbn": "9784094532425",
     "asin": "4094532420",
     "readDate": "2025/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2425/9784094532425_1_55.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2425/9784094532425_1_55.jpg",
     "highlights": []
   },
   {
@@ -91,7 +91,7 @@ export const books = [
     "isbn": "9784791704651",
     "asin": "4791704657",
     "readDate": "2025/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784791704651_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784791704651_1_3.jpg",
     "highlights": []
   },
   {
@@ -102,7 +102,7 @@ export const books = [
     "isbn": "9784062883382",
     "asin": "4062883384",
     "readDate": "2025/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3382/9784062883382.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3382/9784062883382.jpg",
     "highlights": [
       {
         "text": "１７４７年にリンドは、どの治療法が本当に有効であるのか調べるため、次のような試験を行なった。 12 人の壊血病患者を同じ場所に集め、毎日同じ食事を与えた。そして患者を２人ずつ６組に分け、それぞれにリンゴ果汁、硫酸塩溶液、酢、海水、ニンニクなどから作ったペースト、オレンジ２個とレモン１個を与えたのだ。また、症状を発したものの、通常の食事を続けた者もいたので、これも並行して観察を行なった。 結果は、わずか６日で出た。オレンジとレモンを与えられた兵士はほぼ完治、リンゴ果汁を飲んだ者はわずかに回復が見られたが、他の者は全く症状の改善が見られなかった。ここに、「柑橘類が壊血病の特効薬になる」という事実が、見事に証明されたのだ。 この実験は、現代の目からは当たり前にも映る。だが、他の条件をなるべく一定に揃え、比較対象群と共に実験を行なって、何が有効なのかをはっきりさせたリンドの手法は、全く画期的なものであった。現代の臨床試験はこの考え方を基礎としており、あらゆる医薬や医療器具などは、この試験をくぐったものだけが広く認められることになっている。 天才の着想というものは、その後一般に普及して当たり前になってしまい、後世から見るとその凄さがわからなくなることが少なくない。リンドの創出した「臨床試験」の考え方は、その典型的な例といえそうだ。",
@@ -118,7 +118,7 @@ export const books = [
     "isbn": "9784865284751",
     "asin": "4865284753",
     "readDate": "2025/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4751/9784865284751_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4751/9784865284751_1_2.jpg",
     "highlights": []
   },
   {
@@ -129,7 +129,7 @@ export const books = [
     "isbn": "9784167915827",
     "asin": "4167915820",
     "readDate": "2025/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5827/9784167915827_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5827/9784167915827_1_5.jpg",
     "highlights": [
       {
         "text": "「キューバ人の葉巻の吸い方を教えてやる」と言われ、「まず葉巻のお尻の部分を歯で嚙み切って吐き出せ！」と言われたのでやってみる。",
@@ -157,7 +157,7 @@ export const books = [
     "isbn": "9784166613281",
     "asin": "4166613286",
     "readDate": "2025/06/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3281/9784166613281_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3281/9784166613281_1_5.jpg",
     "highlights": []
   },
   {
@@ -168,7 +168,7 @@ export const books = [
     "isbn": "9784163917306",
     "asin": "4163917306",
     "readDate": "2025/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7306/9784163917306_1_23.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7306/9784163917306_1_23.jpg",
     "highlights": [
       {
         "text": "感情遮断弁があるからイーロン・マスクは冷淡だと言われるのだろう。だが、これがあるから積極的にリスクを取るイノベーターになれたとも言える。ジャスティンは次のようにも語っている。 「恐れも遮断できるんです。でも、恐れを遮断するには、喜びや共感などほかのものも一緒に遮断しないといけないのでしょう」 子ども時代のＰＴＳＤで、満たされるのを嫌うようになったのだろう。 「成功をかみしめるとか花の香りを楽しむとか、そういうのは、どうすればいいのかわかっていないのだと思います」 こう言うのは、グライムスという名前で活動する音楽家で、マスクの子ども３人の母親であるクレア・ブーシェイだ。 「人生は痛みの連続だと子ども時代にたたき込まれたのでしょう」 そのとおりだとマスクも同意している。 「私は苦しみが原点なのです。だから、ちょっとやそっとでは痛いと感じなくなりました」",
@@ -208,7 +208,7 @@ export const books = [
     "isbn": "9784778340186",
     "asin": "4778340183",
     "readDate": "2025/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0186/9784778340186_1_33.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0186/9784778340186_1_33.jpg",
     "highlights": []
   },
   {
@@ -219,7 +219,7 @@ export const books = [
     "isbn": "9784022736703",
     "asin": "4022736704",
     "readDate": "2025/06/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6703/9784022736703_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6703/9784022736703_1_2.jpg",
     "highlights": [
       {
         "text": "診断基準にはないものの、しばしばみられる特徴として、争いごとや感情的にぶつかるようなことを避けようとする傾向が挙げられる。不当な攻撃や非難であっても、やり返してさらに激しい争いになるくらいなら、引き下がって泣き寝入りする方を選ぶ。",
@@ -267,7 +267,7 @@ export const books = [
     "isbn": "9784488146238",
     "asin": "4488146236",
     "readDate": "2025/06/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6238/9784488146238.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6238/9784488146238.jpg",
     "highlights": []
   },
   {
@@ -278,7 +278,7 @@ export const books = [
     "isbn": "9784065363775",
     "asin": "4065363772",
     "readDate": "2025/06/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3775/9784065363775_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3775/9784065363775_1_2.jpg",
     "highlights": []
   },
   {
@@ -289,7 +289,7 @@ export const books = [
     "isbn": "9784150310608",
     "asin": "4150310602",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0608/9784150310608_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0608/9784150310608_1_2.jpg",
     "highlights": [
       {
         "text": "「で、結果は。ぼくの何が欠落していたのかな。ナルシシズムやユーモアとは言わせないよ」 キャロライン・シェパードはお義理の微笑を返し、そしてこう口を開いた。 意識、と。 「意識だって」 あまりにシュールな答えを受け、私は吹き出す。けれど彼女は沈黙し、沈痛な面持ちのまま私の瞳に視線をすえ続けていた。",
@@ -321,7 +321,7 @@ export const books = [
     "isbn": "9784150311032",
     "asin": "415031103X",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1032/9784150311032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1032/9784150311032.jpg",
     "highlights": []
   },
   {
@@ -332,7 +332,7 @@ export const books = [
     "isbn": "9784150310912",
     "asin": "4150310912",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0912/9784150310912.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0912/9784150310912.jpg",
     "highlights": [
       {
         "text": "ちなみに、この映画のラストシーン、映画がスタッフロールに行く直前の一瞬、フィンチャーの物凄い「悪意」が仕掛けてあります。わずか２フレーム（１／ 12 秒）程度の映像なので何が映っているか分からない人もいるかも知れませんが、映画の内容を考えればその映像が何かは明白。よく税関を通ったものです、この映画。税関や映倫委員に対する面当てであるうえ、我々観客に対する「あっかんべえ」でもあるこの一瞬は、映画史に刻み込まれるべきイタズラです。",
@@ -352,7 +352,7 @@ export const books = [
     "isbn": "9784422230450",
     "asin": "442223045X",
     "readDate": "2025/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0450/9784422230450_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0450/9784422230450_1_3.jpg",
     "highlights": []
   },
   {
@@ -363,7 +363,7 @@ export const books = [
     "isbn": "9784150311872",
     "asin": "4150311870",
     "readDate": "2025/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1872/9784150311872.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1872/9784150311872.jpg",
     "highlights": []
   },
   {
@@ -374,7 +374,7 @@ export const books = [
     "isbn": "9784150311865",
     "asin": "4150311862",
     "readDate": "2025/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1865/9784150311865.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1865/9784150311865.jpg",
     "highlights": []
   },
   {
@@ -385,7 +385,7 @@ export const books = [
     "isbn": "9784087711677",
     "asin": "4087711676",
     "readDate": "2025/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1677/9784087711677.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1677/9784087711677.jpg",
     "highlights": []
   },
   {
@@ -396,7 +396,7 @@ export const books = [
     "isbn": "9784478116982",
     "asin": "4478116989",
     "readDate": "2025/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6982/9784478116982_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6982/9784478116982_1_8.jpg",
     "highlights": []
   },
   {
@@ -407,7 +407,7 @@ export const books = [
     "isbn": "9784479797036",
     "asin": "4479797033",
     "readDate": "2025/05/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7036/9784479797036.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7036/9784479797036.jpg",
     "highlights": [
       {
         "text": "このように、サブスクリプション型の大きな特徴は売り切り型と比べて圧倒的に乗り換えがしやすい（スイッチングコストが低い）ことです。乗り換えがしやすいということはインターネット以降のプロダクト・サービスの常識です。それは、収益性を保つ上で「一度買ってもらうこと」だけでなく、「長く使い続けてもらうこと」 が最優先課題になったということです。",
@@ -467,7 +467,7 @@ export const books = [
     "isbn": "9784163919096",
     "asin": "4163919090",
     "readDate": "2025/05/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9096/9784163919096_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9096/9784163919096_1_7.jpg",
     "highlights": [
       {
         "text": "日本は、ドイツ以上に二つ目の「西洋」、つまり「自由主義の伝統は持たないが近代的な西洋」に属している。しかし日本もまた危機に直面している。この点に関しては同様のことがロシアにも中国にも言えるが、非常に低い出生率がそれを示している。日本はドイツと同じく、ＮＡＴＯが崩壊することでアメリカの支配下から解放されるだろう。しかし日本はそれによって、韓国とともに、中国と独力で向き合わなければならなくなる。",
@@ -491,7 +491,7 @@ export const books = [
     "isbn": "9784839987800",
     "asin": "4839987807",
     "readDate": "2025/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7800/9784839987800_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7800/9784839987800_1_4.jpg",
     "highlights": []
   },
   {
@@ -502,7 +502,7 @@ export const books = [
     "isbn": "9784532356132",
     "asin": "453235613X",
     "readDate": "2025/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6132/9784532356132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6132/9784532356132.jpg",
     "highlights": [
       {
         "text": "偉大な文明の存続を脅かす要因としては、国境に押し寄せる異邦人よりも、その文明がみずから生み出した内部の 経済的 不均衡のほうが重大であることを示しており、これは古代ローマ帝国から現代ヨーロッパにいたるまでの歴史にも当てはまる。 たとえば、政治面での過剰な中央集権化は帝国の衰退の一般的な要因であり、通常はこうした集権化の実現から百年以降に衰退が始まる。",
@@ -558,7 +558,7 @@ export const books = [
     "isbn": "9784065020357",
     "asin": "4065020352",
     "readDate": "2025/04/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0357/9784065020357.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0357/9784065020357.jpg",
     "highlights": []
   },
   {
@@ -569,7 +569,7 @@ export const books = [
     "isbn": "9784492503409",
     "asin": "4492503404",
     "readDate": "2025/04/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3409/9784492503409_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3409/9784492503409_1_2.jpg",
     "highlights": [
       {
         "text": "各カンパニーは独立した法人とみなし、責任と権限を明確にしています。その裏返しとして、サイロ化しやすいのです。分厚いレンガで囲われていて中が見えない。まさに「壁」です。アウトプット（業績）はわかっても、その中身まではよく見えません。どこに問題があって目標が達成できなかったのか、その原因がわからなければ、対処法も解決策も考えられません。",
@@ -617,7 +617,7 @@ export const books = [
     "isbn": "9784781619835",
     "asin": "4781619835",
     "readDate": "2025/03/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9835/9784781619835_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9835/9784781619835_1_2.jpg",
     "highlights": [
       {
         "text": "「チヤホヤされているときは、自分が何者かを忘れていられる」点には、どうかお気をつけください。自分が何者でもないと悩んでいる人、とくに若い人が、チヤホヤされたりスポットライトを浴びたりして快感を覚え、悩みを忘れてしまった結果、「これこそが解決策」と早合点をしてしまうことがあります。",
@@ -665,7 +665,7 @@ export const books = [
     "isbn": "9784040824994",
     "asin": "4040824997",
     "readDate": "2025/03/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4994/9784040824994_1_12.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4994/9784040824994_1_12.jpg",
     "highlights": []
   },
   {
@@ -676,7 +676,7 @@ export const books = [
     "isbn": "9784101054315",
     "asin": "4101054312",
     "readDate": "2025/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4315/9784101054315_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4315/9784101054315_1_2.jpg",
     "highlights": [
       {
         "text": "① 一つの商品にたくさんの情報価値＝語りたくなる、伝えたくなる価値を盛り込む ② 発信しようとする情報を受け手の身になって考える、整理する ③ 時代を読む ④ 関与者を多く作る ⑤ 即効性のあるメディアほど情報感度は鈍い。雑誌→新聞→ラジオ・テレビの順番を意識する ⑥ 追い駆けるより追い駆けさせる構造を作る",
@@ -716,7 +716,7 @@ export const books = [
     "isbn": "9784142231652",
     "asin": "4142231650",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784142231652_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784142231652_1_3.jpg",
     "highlights": []
   },
   {
@@ -727,7 +727,7 @@ export const books = [
     "isbn": "9784002710808",
     "asin": "4002710807",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0808/9784002710808_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0808/9784002710808_1_2.jpg",
     "highlights": []
   },
   {
@@ -738,7 +738,7 @@ export const books = [
     "isbn": "9784569845999",
     "asin": "4569845991",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5999/9784569845999_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5999/9784569845999_1_2.jpg",
     "highlights": []
   },
   {
@@ -749,7 +749,7 @@ export const books = [
     "isbn": "9784101171319",
     "asin": "4101171319",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1319/9784101171319.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1319/9784101171319.jpg",
     "highlights": []
   },
   {
@@ -760,7 +760,7 @@ export const books = [
     "isbn": "9784094532012",
     "asin": "4094532013",
     "readDate": "2025/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2012/9784094532012_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2012/9784094532012_1_4.jpg",
     "highlights": []
   },
   {
@@ -771,7 +771,7 @@ export const books = [
     "isbn": "9784778319663",
     "asin": "4778319664",
     "readDate": "2025/03/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9663/9784778319663_1_10.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9663/9784778319663_1_10.jpg",
     "highlights": [
       {
         "text": "邪神ちゃんマーケティングは弱者のためのメソッドです。 ご存じの方も多いと思いますが、マーケティング理論には ランチェスター戦略 という有名な考え方があります。これは「同じ武器を持った者同士が戦うと数が多い方が勝つ」 という当たり前のことを前提として「狭いところで大人数と少人数が１対１で戦うとどちらも同じ損害を受ける」「広いところで大人数と少人数が戦うと少人数の方が大きい損害を受ける」 という２つの法則を導きます。このことから少人数の時はなるべく局地戦で戦うべきだし、大人数の時はなるべく広域で戦うとよいということがわかります。",
@@ -811,7 +811,7 @@ export const books = [
     "isbn": "9784791776597",
     "asin": "4791776593",
     "readDate": "2025/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6597/9784791776597_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6597/9784791776597_1_3.jpg",
     "highlights": [
       {
         "text": "マーク・フィッシャーは著書『わが人生の亡霊たち』の序文にあたる文章の中で、「いずれにせよ、誰にとってであれ、自分自身であること（さらに言えば、自分自身を売り込むことを強いられること） ほど惨めなことはない。文化や文化に対する分析が価値を持つのは、それが自分自身からの逃走を可能にするかぎりでのことなのだ」と述べていた（３）。",
@@ -935,7 +935,7 @@ export const books = [
     "isbn": "9784153400375",
     "asin": "4153400378",
     "readDate": "2025/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0375/9784153400375_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0375/9784153400375_1_7.jpg",
     "highlights": [
       {
         "text": "ただ実際には、マーケットに売却せずに住み続けるのであれば、購入後の価格の変動は何の影響もない。 いくら価格が上昇しても、株式や債券と同様、売却して「益出し」をしない限り、果実を得ることはできないので、あくまでも「含み益」を 眺めているだけの状態にある。あるいは仮に売却して含み益を享受したとしても、次に住む家に買い替える必要が出てくる。不動産価格が上がっているということは、現在住んでいるレベルの家を買った当時の値段では 買えない ことを意味するので、同等の家に移り住むためには、場合によっては売却益以上の金銭負担がかかってくる。 下落している場合も同様で、住み続けられるのであれば、何か損するわけではない。結局、自分が所有している「資産」であるはずの家の値段が上がることに気分を良くする、あるいは下がることに対して良い気分になれないだけなのだ。",
@@ -987,7 +987,7 @@ export const books = [
     "isbn": "9784297143299",
     "asin": "4297143291",
     "readDate": "2025/02/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3299/9784297143299_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3299/9784297143299_1_4.jpg",
     "highlights": []
   },
   {
@@ -998,7 +998,7 @@ export const books = [
     "isbn": "9784763141880",
     "asin": "4763141880",
     "readDate": "2025/02/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1880/9784763141880_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1880/9784763141880_1_3.jpg",
     "highlights": [
       {
         "text": "モンゴル帝国は４０００㎞離れたロシアを征服できても、２００㎞の対馬海峡を越えて日本を征服することはできませんでした。ドイツは１５００㎞離れたロシアに２０００両の戦車を送れても、 30 ㎞のドーバー海峡の向こうのイギリスには１両の戦車も送れませんでした。そしてアメリカには、１機の飛行機さえ飛ばすことができませんでした。海を越えた侵略は、陸を越えた侵略よりもそれほど難しいのです。 海洋国家は防御有利、大陸国家は攻撃有利。この違いが、それぞれの行動原理を根本的に異なるものにします。",
@@ -1066,7 +1066,7 @@ export const books = [
     "isbn": "9784910511559",
     "asin": "4910511555",
     "readDate": "2025/02/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1559/9784910511559_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1559/9784910511559_1_2.jpg",
     "highlights": []
   },
   {
@@ -1077,7 +1077,7 @@ export const books = [
     "isbn": "9784314011167",
     "asin": "4314011165",
     "readDate": "2025/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1167/9784314011167.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1167/9784314011167.jpg",
     "highlights": []
   },
   {
@@ -1088,7 +1088,7 @@ export const books = [
     "isbn": "9784802512046",
     "asin": "480251204X",
     "readDate": "2025/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2046/9784802512046_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2046/9784802512046_1_3.jpg",
     "highlights": [
       {
         "text": "つまりデジタル化とは、無尽蔵に広がる人の想像と欲望に対して、それを満足させる資源供給方法の最適化である。そしてこれには必然性がある。私たちの想像と欲望にリミットはないが、地球のリソースにはリミットがあるためである。欲望を効率的、効果的に処理する方法が必要なのだ。",
@@ -1192,7 +1192,7 @@ export const books = [
     "isbn": "9784094531978",
     "asin": "4094531971",
     "readDate": "2025/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1978/9784094531978_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1978/9784094531978_1_4.jpg",
     "highlights": []
   },
   {
@@ -1203,7 +1203,7 @@ export const books = [
     "isbn": "9784094531640",
     "asin": "4094531645",
     "readDate": "2025/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1640/9784094531640_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1640/9784094531640_1_7.jpg",
     "highlights": []
   },
   {
@@ -1214,7 +1214,7 @@ export const books = [
     "isbn": "9784094531183",
     "asin": "4094531181",
     "readDate": "2025/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1183/9784094531183_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1183/9784094531183_1_5.jpg",
     "highlights": []
   },
   {
@@ -1225,7 +1225,7 @@ export const books = [
     "isbn": "9784094530940",
     "asin": "4094530940",
     "readDate": "2025/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/9784094530940_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/9784094530940_1_5.jpg",
     "highlights": []
   },
   {
@@ -1236,7 +1236,7 @@ export const books = [
     "isbn": "9784093891837",
     "asin": "4093891834",
     "readDate": "2025/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1837/9784093891837_1_59.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1837/9784093891837_1_59.jpg",
     "highlights": []
   },
   {
@@ -1247,7 +1247,7 @@ export const books = [
     "isbn": "9784802511193",
     "asin": "4802511191",
     "readDate": "2025/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784802511193.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784802511193.jpg",
     "highlights": [
       {
         "text": "本書で扱うテーマは大きく３つある。１つは、「アジャイルに作る」ことで直面する「不確実性」への適応について。「アジャイルに作る」とは、作ることを通じて学びを得る活動にほかならない。 得られた学びをプロダクトづくりの中でどのようにして受け止めるのか。受け止め損なうと、様々な背景や思惑を抱いて集まってきている関係者、チームの期待に応えられず、プロダクトづくりは破綻する。最初の昔話がその例だ。",
@@ -1343,7 +1343,7 @@ export const books = [
     "isbn": "9784799330838",
     "asin": "4799330837",
     "readDate": "2025/01/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0838/9784799330838_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0838/9784799330838_1_2.jpg",
     "highlights": []
   },
   {
@@ -1354,7 +1354,7 @@ export const books = [
     "isbn": "9784814400911",
     "asin": "4814400918",
     "readDate": "2025/01/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0911/9784814400911_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0911/9784814400911_1_2.jpg",
     "highlights": []
   },
   {
@@ -1365,7 +1365,7 @@ export const books = [
     "isbn": "9784777831180",
     "asin": "4777831183",
     "readDate": "2024/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1180/9784777831180_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1180/9784777831180_1_4.jpg",
     "highlights": []
   },
   {
@@ -1376,7 +1376,7 @@ export const books = [
     "isbn": "9784048977609",
     "asin": "4048977601",
     "readDate": "2024/12/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7609/9784048977609_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7609/9784048977609_1_8.jpg",
     "highlights": []
   },
   {
@@ -1387,7 +1387,7 @@ export const books = [
     "isbn": "9784314011365",
     "asin": "431401136X",
     "readDate": "2024/12/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1365/9784314011365.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1365/9784314011365.jpg",
     "highlights": []
   },
   {
@@ -1398,7 +1398,7 @@ export const books = [
     "isbn": "9784478115244",
     "asin": "4478115249",
     "readDate": "2024/12/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784478115244_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784478115244_1_2.jpg",
     "highlights": [
       {
         "text": "ＧＥでは最初に業績目標が決められ、どうやってそれを達成するかは二の次である。その目標を達成するために必要な数字が各事業に割り振られ、方法はどうであれ、数字を達成することが厳しく求められる。",
@@ -1438,7 +1438,7 @@ export const books = [
     "isbn": "9784065312629",
     "asin": "4065312620",
     "readDate": "2024/11/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2629/9784065312629_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2629/9784065312629_1_8.jpg",
     "highlights": [
       {
         "text": "「戦場ヶ原」 「何よ。まだ国家に 叛意 を？」 「いやいや、愛国心だよ。そして新婚旅行の行き先だ」 「？」 「戦場ヶ原に行こう。何でも知っている委員長に教えてもらったところによると、日本有数の、星の綺麗な湿原らしいぜ」",
@@ -1458,7 +1458,7 @@ export const books = [
     "isbn": "9784296202010",
     "asin": "4296202014",
     "readDate": "2024/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2010/9784296202010_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2010/9784296202010_1_4.jpg",
     "highlights": [
       {
         "text": "「思考が煮詰まったら、すぐに『行動』するんだ。誰かに相談したり、新たな情報を集めたりすることで、また思考できる状態に戻す」 「そういえば、お父さんって考えるのがめっちゃ速いよね。私は一度考え始めると、ずーっと時間を使っちゃうんだけど…。お父さんは淀みなく考えている感じがするっていうか、停滞していないというか…。考えがどんどん進んでいく感じがする！」 「ははは、いい表現だ。思考は単発の活動ではなく、流れなんだよ。状況を認知し、思考し、そして止まる。それを行動で打破し、また認知に戻ってくる。こうやってテンポよく、考え方の循環サイクルを回していく必要があるんだ」",
@@ -1526,7 +1526,7 @@ export const books = [
     "isbn": "9784022519979",
     "asin": "4022519975",
     "readDate": "2024/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9979/9784022519979_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9979/9784022519979_1_3.jpg",
     "highlights": [
       {
         "text": "全てはパターンに還元されてしまうけれど、それは概念の分解能を上げすぎなのだ。 映画を観ていると「この展開って、固有名詞が違うだけで前観たあの映画とほとんど同じじゃん」と気づくことがある。漫画を読んでいると「前読んだのと全く同じ種類のギャグ」に出会うことがある。そういうことに気づくと、白けるというかなんというか「結局はガワだけ取り替えた同じソフトウェアで機嫌を取られてるだけなんだなあ」という思いに支配されてしまいそうになる。けれどもむしろ、構造化してパターン分けすること自体が、個別のものごとに宿る豊穣さを見失う原因になっていないだろうか。「分析」による把握が、かえって理解を画一化してしまうのだ。だから、つまり、全ての作品が何らかの既存のパターンに依存しているとしても、その中で表現される個々のディテールやニュアンスはユニークであり、それ自体が価値を持っている。そう考えるべきなのだろう。",
@@ -1550,7 +1550,7 @@ export const books = [
     "isbn": "9784153400061",
     "asin": "4153400068",
     "readDate": "2024/10/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0061/9784153400061_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0061/9784153400061_1_2.jpg",
     "highlights": []
   },
   {
@@ -1561,7 +1561,7 @@ export const books = [
     "isbn": "9784775970379",
     "asin": "4775970372",
     "readDate": "2024/10/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7759/77597037.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7759/77597037.jpg",
     "highlights": [
       {
         "text": "ある者が違法な会社で結託し、 新たに株を発行し、度を超えた取引を奨励する。 魅力ある空虚な名前と雰囲気で、 まずは信用を高めておいて、後から底へと突き落とす。 そして無の実体を株に分け、 群衆の不和を引き起こす。 ――デフォー",
@@ -1581,7 +1581,7 @@ export const books = [
     "isbn": "9784094532036",
     "asin": "409453203X",
     "readDate": "2024/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2036/9784094532036_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2036/9784094532036_1_2.jpg",
     "highlights": []
   },
   {
@@ -1592,7 +1592,7 @@ export const books = [
     "isbn": "9784791704538",
     "asin": "4791704533",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4538/9784791704538_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4538/9784791704538_1_3.jpg",
     "highlights": []
   },
   {
@@ -1603,7 +1603,7 @@ export const books = [
     "isbn": "9784144072376",
     "asin": "4144072371",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2376/9784144072376.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2376/9784144072376.jpg",
     "highlights": [
       {
         "text": "そして、マスコミは中立であるべきだ、という一部の言説に対し、「中立なマスコミという幻想」をまず捨てなさいと警鐘を鳴らしています。特にリベラル層に多く見られる傾向ですが、私たちはあたかも中立で民主的でまっさらな情報を発信するマスコミが存在する、あるいはすべきだとどこかで思い込んでいる。その思い込み自体がステレオタイプなのです。これについてはフランスの思想家トクヴィル（＊ 19） が、『アメリカのデモクラシー』という著作の中で「民主制を終わらせるのはマスメディアだ」と指摘しているように、メディアはその成り立ち自体が持つ限界から、中立にはなりえません。この事実を受け入れた上で、受け手である私たちの中にあるステレオタイプの存在と、送り手であるメディアがそれを強化するという関係性を知ることが大切です。 メディアにはスポンサーという出資者がいて、そこでの制約があること。記者や制作スタッフやコメンテーターにもステレオタイプな主観があること。そして何よりも重要なことは、リップマンが言うように、そこで発信される情報イコール「真実」では決してなく、あくまでも切り取られた事実の一部にすぎないのだと、私たちが理解することなのです。",
@@ -1619,7 +1619,7 @@ export const books = [
     "isbn": "9784022952745",
     "asin": "4022952741",
     "readDate": "2024/09/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2745/9784022952745_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2745/9784022952745_1_3.jpg",
     "highlights": [
       {
         "text": "日本以外の社会では、労働者が遂行すべき職務（job） が雇用契約に明確に規定されます。ところが、日本では、雇用契約に職務は明記されません。明記されるか、されないかというよりも、そもそも雇用契約上、職務が特定されていないのが普通です。どんな仕事をするか、職務に就くかというのは、使用者の命令によって定まります。いわば、日本の雇用契約は、その都度遂行すべき特定の職務が書き込まれる空白の石板なのです。ここから、日本における雇用の本質は職務（job） ではなく、所属（membership） にあると規定することができます。ジョブ型、メンバーシップ型という言葉の由来はここにあります。",
@@ -1667,7 +1667,7 @@ export const books = [
     "isbn": "9784569903880",
     "asin": "4569903886",
     "readDate": "2024/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784569903880_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784569903880_1_2.jpg",
     "highlights": [
       {
         "text": "議長席から見てジャコバン派が左側、ジロンド派が右側に着席したことから、前者を「左派」、後者を「右派」と呼ぶようになりました。 この場合の「右派」は、共同体（社会や家族） の伝統や秩序を重んじ、急激な変化を求めない考え方で、「保守主義」と言ってもいいでしょう。社会や家族を守ることが最高の価値であり、個人はその一員として頑張ろう、という立場です。 これに対して「左派」は、「共同体より個人。個人の権利と自由を制限するような伝統は、根本的につくり変えてしまえ」という考え方。改革や進歩を好み、言葉の本来の意味で「リベラル（自由主義者）」と呼ばれる人々です。",
@@ -1683,7 +1683,7 @@ export const books = [
     "isbn": "9784478114179",
     "asin": "447811417X",
     "readDate": "2024/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4179/9784478114179_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4179/9784478114179_1_2.jpg",
     "highlights": []
   },
   {
@@ -1694,7 +1694,7 @@ export const books = [
     "isbn": "9784591182253",
     "asin": "4591182258",
     "readDate": "2024/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2253/9784591182253_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2253/9784591182253_1_3.jpg",
     "highlights": []
   },
   {
@@ -1705,7 +1705,7 @@ export const books = [
     "isbn": "9784022952707",
     "asin": "4022952709",
     "readDate": "2024/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2707/9784022952707_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2707/9784022952707_1_3.jpg",
     "highlights": [
       {
         "text": "アメリカは、ユーラシアの歴史的帰結に影響をおよぼそうとして数千億ドルを費やしながらも、長い陸の国境を接する国で起こっているできごとを、不思議なほど静観している。しかも、その隣国は大混乱に 瀕 していて、イラクとアフガニスタンの合計の二倍近くの人口があるのだ。 もちろん、厳重な国境警備体制があれば、ナショナリズムを掲げ、健全に機能するアメリカが、部分的に無秩序状態で機能不全のメキシコと共存することはできる。しかしそんな状態は長くは続かない。",
@@ -1721,7 +1721,7 @@ export const books = [
     "isbn": "9784296103942",
     "asin": "4296103946",
     "readDate": "2024/09/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3942/9784296103942.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3942/9784296103942.jpg",
     "highlights": [
       {
         "text": "「いいかい。資料で大事なのは、図や文章じゃない。 伝えたいことがあるか、ないかだ。この資料にはそれがないんだよ」",
@@ -1833,7 +1833,7 @@ export const books = [
     "isbn": "9784062839006",
     "asin": "4062839008",
     "readDate": "2024/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9006/9784062839006.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9006/9784062839006.jpg",
     "highlights": [
       {
         "text": "「羽川。お前は何でも知ってるな」 「何でもは知らないわよ。知ってることだけ」 へらっと笑って、羽川はそう応じた。 昔のように──しかし、今の羽川は、こう付け加えた。 「知れば知るほど、知らないことが増えていく」 知ってる人も、いつか知らない人になる。",
@@ -1853,7 +1853,7 @@ export const books = [
     "isbn": "9784163918723",
     "asin": "4163918728",
     "readDate": "2024/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8723/9784163918723_1_21.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8723/9784163918723_1_21.jpg",
     "highlights": []
   },
   {
@@ -1864,7 +1864,7 @@ export const books = [
     "isbn": "9784065350355",
     "asin": "4065350352",
     "readDate": "2024/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0355/9784065350355_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0355/9784065350355_1_2.jpg",
     "highlights": [
       {
         "text": "あなた以外の人が全員正しく、あなた一人が大きな間違いを犯したとき、市場はあなたを罰しません。逆にその他の人が全員間違ってあなただけが正しかったときは大きく報います。 市場は、あなたの意見が少数意見である限りあなたの味方です。",
@@ -1932,7 +1932,7 @@ export const books = [
     "isbn": "9784822271787",
     "asin": "4822271781",
     "readDate": "2024/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1787/9784822271787.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1787/9784822271787.jpg",
     "highlights": [
       {
         "text": "「そうだ。会議は何かを決める場のはずだ。だから会議の終わりには必ず〝決まったこと〟と〝やるべきこと〟があるはずなんだ。定例会では、営業部門へ連絡するという〝やるべきこと〟が発生していたが、葵の先輩の片澤くんは分かっていなかった。もし会議の終わりに改めて確認していたら違ったと思わないか？」",
@@ -2028,7 +2028,7 @@ export const books = [
     "isbn": "9784167920258",
     "asin": "4167920255",
     "readDate": "2024/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784167920258_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784167920258_1_7.jpg",
     "highlights": [
       {
         "text": "「小さすぎる？」 「そこは東京 に じゃない。東京 をとすべきじゃないか、曾禰君。ひとつひとつの物件など、しょせん長い道のりの一里塚。私はつまり、最後には、東京そのものを建築する」",
@@ -2056,7 +2056,7 @@ export const books = [
     "isbn": "9784094530643",
     "asin": "4094530649",
     "readDate": "2024/08/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784094530643_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784094530643_1_3.jpg",
     "highlights": []
   },
   {
@@ -2067,7 +2067,7 @@ export const books = [
     "isbn": "9784094530414",
     "asin": "409453041X",
     "readDate": "2024/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0414/9784094530414_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0414/9784094530414_1_3.jpg",
     "highlights": []
   },
   {
@@ -2078,7 +2078,7 @@ export const books = [
     "isbn": "9784862760852",
     "asin": "4862760856",
     "readDate": "2024/08/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0852/9784862760852_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0852/9784862760852_1_3.jpg",
     "highlights": [
       {
         "text": "「悩む」＝「答えが出ない」という前提のもとに、「考えるフリ」をすること 「考える」＝「答えが出る」という前提のもとに、建設的に考えを組み立てること",
@@ -2126,7 +2126,7 @@ export const books = [
     "isbn": "9784802512480",
     "asin": "4802512481",
     "readDate": "2024/08/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2480/9784802512480_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2480/9784802512480_1_3.jpg",
     "highlights": [
       {
         "text": "「デザインシステム」は一般的に、「デザインの再現性を高め、一貫した製品体験を効率よく表現すること」を目的に導入される「ドキュメントやリソース群のこと」と説明されます。",
@@ -2354,7 +2354,7 @@ export const books = [
     "isbn": "9784163916873",
     "asin": "4163916873",
     "readDate": "2024/07/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784163916873_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784163916873_1_8.jpg",
     "highlights": [
       {
         "text": "近年、情報番組のコメンテーターは流行の職業だった。本業で少しでも実績があれば、それを肩書としてコメンテーターのポジションを得ることが出来る。大衆は権威に弱いため、一度テレビで顔が売れればさらに権威が増す。基本は井戸端会議なので、専門知識などなくても務まった。場の空気を読み、少し本音をまぶし、少し面白いことを言う。その 匙加減がうまい人間が生き残り、コメントで禄を 食む。要するに新手のテレビタレントなのである。",
@@ -2386,7 +2386,7 @@ export const books = [
     "isbn": "9784150506094",
     "asin": "4150506094",
     "readDate": "2024/07/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6094/9784150506094_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6094/9784150506094_1_2.jpg",
     "highlights": [
       {
         "text": "それを解決したのが、東南アジアのジャングルに生息するグッタペルカ（ガタパチャ）の木から採れる同名のゴム状の樹脂だ。グッタペルカの特質の１つは、常温では固いが温水に浸けると柔らかくなってどのようにでも変形できることだった。ヴィクトリア朝時代にはこれが現在のプラスチックのように使われていた。人形やチェスの駒、ラッパ形補聴器などはすべてこの材料で作られていた。それは高価ではあったが、ケーブルを絶縁するには理想的な材料だった。",
@@ -2414,7 +2414,7 @@ export const books = [
     "isbn": "9784798629704",
     "asin": "4798629707",
     "readDate": "2024/07/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784798629704_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784798629704_1_3.jpg",
     "highlights": []
   },
   {
@@ -2425,7 +2425,7 @@ export const books = [
     "isbn": "9784396344740",
     "asin": "4396344740",
     "readDate": "2024/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4740/9784396344740.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4740/9784396344740.jpg",
     "highlights": [
       {
         "text": "「やはり、 利根川じゃな」 どさりと 床几 に腰をおろした。野外で昼めしを食うつもりなのだ。 米を 炊くにおいがして、従者が竹皮のつつみを持ってきた。つつみをひらくと、大きなにぎりめしが六個。うなぎの なれ ずし が 添えられている。ぶつ切りにしたうなぎを酒にひたして塩漬けしたものだが、やわらかいから、忠次は骨まで食べてしまう。 「うん。やはり野外で食うめしはうまい」 五分ほどでぺろりと平らげてしまうと、 「父上」 となりの床几でちょこんと膝をそろえ、忠次とおなじ大きさのにぎりめしを手にしつつ、八歳の長男・熊蔵が、 「なぜ利根川なのですか。この関東には、ほかに無数の川がありますのに」 「利根川こそが、江戸の地を水びたしにしている元凶なのだ」 「なぜです」 「流量が多く、江戸 湊（東京湾）にそそぐ河口が広すぎるからだ」 忠次は、説明した。 そもそも利根川は上野国の北部、 水上（群馬県利根郡みなかみ町）の山ふかくを水源としている。はじめ南東へ、やがて南へ流れて江戸湊にそそぐ、というのが大ざっぱな流路だった。くりかえすが、 東京湾 に そそいでいる。二十一世紀の現在とはまったくちがう。 「河口は江戸城の北東方、 関屋（ 足立区 千住 関屋町付近）にある。周囲はいちめん湿地となり、海の水とまじりあい、人のあゆみを 拒んでいる。米も、みのらぬ。畑にもならぬ。江戸で雨がふらずとも、北関東でふれば手のつけられぬ水が押し寄せる。この問題を解決せねば、江戸は永遠に未開のままじゃ」 「ならば、河口を移せばいい」",
@@ -2457,7 +2457,7 @@ export const books = [
     "isbn": "9784040752518",
     "asin": "4040752511",
     "readDate": "2024/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784040752518_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784040752518_1_3.jpg",
     "highlights": []
   },
   {
@@ -2468,7 +2468,7 @@ export const books = [
     "isbn": "9784153400269",
     "asin": "4153400262",
     "readDate": "2024/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0269/9784153400269_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0269/9784153400269_1_3.jpg",
     "highlights": [
       {
         "text": "また、グーグルのデータセンターにおいては、通常のデータセンターで用いられるような高価なサーバを用いない。データセンターで使われることを想定したサーバは主要な部品の質が高く、二重化などがされているため、壊れにくい。その分値段が高い。グーグルでは、サーバは壊れるものと割り切り、低品質のサーバを大量に調達し、次々と入れ替えていくという方法をとってコストを抑えているという。これはしかし、一部のサーバが壊れても全体が稼働し続けるというシステムを作り上げる技術力が可能にした、発想の転換である。",
@@ -2500,7 +2500,7 @@ export const books = [
     "isbn": "9784153400153",
     "asin": "4153400157",
     "readDate": "2024/07/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0153/9784153400153_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0153/9784153400153_1_2.jpg",
     "highlights": []
   },
   {
@@ -2511,7 +2511,7 @@ export const books = [
     "isbn": "9784296001866",
     "asin": "4296001868",
     "readDate": "2024/07/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1866/9784296001866_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1866/9784296001866_1_2.jpg",
     "highlights": [
       {
         "text": "「私は人が生きていくうえで最も大切なことは使命感を持つことだと思います。そのためにはまず、自分は何者なのか、そのことを深く考える必要があると思います」 「自分にとって何が最も大切なことなのか、絶対に譲ることができないものはなんなのか、そこを突き詰めて自らの強みを発見し、生かす。自分にしかできない、自分の人生を思いっきり生きてほしい。明確な意識があるのとないのとでは、同じ人生を送っても成果は１００倍、１０００倍あるいは１万倍も違うのではないかと私は思います」",
@@ -2579,7 +2579,7 @@ export const books = [
     "isbn": "9784822255077",
     "asin": "4822255077",
     "readDate": "2024/07/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5077/9784822255077.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5077/9784822255077.jpg",
     "highlights": []
   },
   {
@@ -2590,7 +2590,7 @@ export const books = [
     "isbn": "9784873118888",
     "asin": "4873118883",
     "readDate": "2024/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8888/9784873118888.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8888/9784873118888.jpg",
     "highlights": []
   },
   {
@@ -2601,7 +2601,7 @@ export const books = [
     "isbn": "9784065227381",
     "asin": "4065227380",
     "readDate": "2024/07/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7381/9784065227381.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7381/9784065227381.jpg",
     "highlights": [
       {
         "text": "モンテヴェルディ自身は「和音」や「属七」といった用語をまったく使ってはいないが、この「属七の和音／ドミナント・セブンス」の特別な扱いを可能にしたのが、実は今から400年前のモンテヴェルディであった。",
@@ -2669,7 +2669,7 @@ export const books = [
     "isbn": "9784153400191",
     "asin": "415340019X",
     "readDate": "2024/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0191/9784153400191_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0191/9784153400191_1_2.jpg",
     "highlights": [
       {
         "text": "文明社会がますます進み、あれもこれも障害特性とみなされ、〝人間の標準規格〟の基準が厳しくなった未来にはもっと多くの人が治療や支援を必要とするでしょう。そうした果てに、誰もが能力向上のための服薬を求めるようになり、子どもが不適応を起こさないよう遺伝子操作が行われるのが当然の未来が到来したとして……それは肯定して構わないものでしょうか。",
@@ -2725,7 +2725,7 @@ export const books = [
     "isbn": "9784065309506",
     "asin": "4065309506",
     "readDate": "2024/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9506/9784065309506_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9506/9784065309506_1_2.jpg",
     "highlights": []
   },
   {
@@ -2736,7 +2736,7 @@ export const books = [
     "isbn": "9784492047354",
     "asin": "4492047352",
     "readDate": "2024/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7354/9784492047354_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7354/9784492047354_1_7.jpg",
     "highlights": [
       {
         "text": "みんなを等しく便利にした会社の創業者が、結果的に大金持ちになったんや」 ボスの説明に、七海がため息をつく。 「そういうことでしたか。格差を縮めるサービスを提供しているのに、お金持ちだという事実だけが切り出されていたんですね」 「もちろん、金銭的な格差も小さいほうがええで。せやけど、その中身を見ないでむやみに批判するのはあかん。自分の立場を利用してずるくもうけるお金持ちと、みんなの 抱える問題を解決してくれたお金持ちとでは意味が違うんや」",
@@ -2760,7 +2760,7 @@ export const books = [
     "isbn": "9784839976156",
     "asin": "4839976155",
     "readDate": "2024/06/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6156/9784839976156_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6156/9784839976156_1_4.jpg",
     "highlights": []
   },
   {
@@ -2771,7 +2771,7 @@ export const books = [
     "isbn": "9784815618667",
     "asin": "4815618666",
     "readDate": "2024/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8667/9784815618667_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8667/9784815618667_1_3.jpg",
     "highlights": []
   },
   {
@@ -2782,7 +2782,7 @@ export const books = [
     "isbn": "9784153400238",
     "asin": "4153400238",
     "readDate": "2024/05/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0238/9784153400238_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0238/9784153400238_1_2.jpg",
     "highlights": [
       {
         "text": "また考え方として最も影響を受けたのは、スタニスワフ・レムの『ソラリス』や『砂漠の惑星』です。一つひとつは非力で小さな虫みたいなロボットが、集まることで全体として大きな力をもつ、あるいは海が知性をもってしまうといった概念には、非常にアンチヒューマノイド的なところがあって。たとえばアシモフの『われはロボット』は完全にヒューマノイド的な機械の世界ですが、『ソラリス』がそれとは全く異なる世界を提示していることに衝撃を受けた。人間以外の知性体がいるという世界観には非常に影響を受けましたね。",
@@ -2838,7 +2838,7 @@ export const books = [
     "isbn": "9784334039899",
     "asin": "4334039898",
     "readDate": "2024/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9899/9784334039899.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9899/9784334039899.jpg",
     "highlights": [
       {
         "text": "ちなみに、バッタとイナゴは相変異を示すか示さないかで区別されている。相変異を示すものがバッタ（ust）、示さないものがイナゴ（Grasshopper）と呼ばれる。日本では、オンブバッタやショウリョウバッタなどと呼ばれるが、厳密にはイナゴの仲間である。ustの由来はラテン語の「焼野原」だ。彼らが過ぎ去った後は、緑という緑が全て消えることからきている。",
@@ -2862,7 +2862,7 @@ export const books = [
     "isbn": "9784274229497",
     "asin": "4274229491",
     "readDate": "2024/05/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9497/9784274229497_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9497/9784274229497_1_3.jpg",
     "highlights": []
   },
   {
@@ -2873,7 +2873,7 @@ export const books = [
     "isbn": "9784087213126",
     "asin": "4087213129",
     "readDate": "2024/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3126/9784087213126_1_8.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3126/9784087213126_1_8.jpg",
     "highlights": [
       {
         "text": "『痴人の愛』は、元はといえば「大阪朝日新聞」の連載小説である。当時の新聞の主なターゲットは、新中間層、つまりは毎日通勤するサラリーマンだった（山本武利『近代日本の新聞読者層』）。だとすれば、「田舎から出てきた真面目なサラリーマンが、カフェで働く美少女を引き取る」というあらすじは、まさに谷崎潤一郎がサラリーマンに向けて書いた妄想物語そのものだったのではないだろうか。",
@@ -2941,7 +2941,7 @@ export const books = [
     "isbn": "9784296070787",
     "asin": "4296070789",
     "readDate": "2024/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0787/9784296070787_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0787/9784296070787_1_2.jpg",
     "highlights": []
   },
   {
@@ -2952,7 +2952,7 @@ export const books = [
     "isbn": "9784061498075",
     "asin": "406149807X",
     "readDate": "2024/04/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8075/9784061498075.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8075/9784061498075.jpg",
     "highlights": []
   },
   {
@@ -2963,7 +2963,7 @@ export const books = [
     "isbn": "9784826902434",
     "asin": "4826902433",
     "readDate": "2024/04/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2434/9784826902434_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2434/9784826902434_1_2.jpg",
     "highlights": []
   },
   {
@@ -2974,7 +2974,7 @@ export const books = [
     "isbn": "9784049155983",
     "asin": "4049155982",
     "readDate": "2024/04/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5983/9784049155983_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5983/9784049155983_1_4.jpg",
     "highlights": []
   },
   {
@@ -2985,7 +2985,7 @@ export const books = [
     "isbn": "9784062883184",
     "asin": "406288318X",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3184/9784062883184.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3184/9784062883184.jpg",
     "highlights": [
       {
         "text": "主語が一人称で書かれているのは、ドイツ文学によく見られる「教養小説」（主人公の自己形成の過程を描いた小説） のスタイルだ。カリスマ的指導者にふさわしくない過去は書き換えられているため、実際はかなり優柔不断で自堕落でもあったヒトラーの実像は伝わってこない。反対に、早くから政治意識に目覚め、生来の弁舌の才をもって政治家への道を歩む、偽りのヒトラー像が提示される。現代の読者がこの本をひもとくときは、そのことに注意する必要があるだろう。",
@@ -3033,7 +3033,7 @@ export const books = [
     "isbn": "9784103145363",
     "asin": "4103145366",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784103145363_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784103145363_1_2.jpg",
     "highlights": [
       {
         "text": "さても読者の皆様方よ。コロナを 巫山戯 て書きました。お怒りでしたらお詫びをしますが、作者の言い分申し上げます。そもそもわれわれ日本人、生真面目過ぎていけません。苦しむ人の多いなか、コロナで冗談言うとは何ごと、不謹慎も甚だしいと、眼を三角にするお方、これぞまことの日本人、ほんとにほんとにご苦労さん、言い返す気は御座いませんが、これはあくまで世間の常識一般人の考えで、文学者まで追随し、コロナに関する生真面目さ、こりゃまあ一体なんたるコロナ、小説家としてだらしない。あくまでわたしの考えですが、文学やるなら常識捨てて、世間の糾弾身に引き受けて、何でも書くのがまともな作家、ここは良識退けて、不真面目さをこそ追究せねば、なぜになったか文学者、純文学誌もなさけない、コロナとなれば及び腰、先生これはやめましょう。なんの小生平気の平左、言われりゃまだ書く反骨精神、笑って続けるコロちゃんづくし。コロナ、コロナ、どうしてあなたはコロナなの。コロナ切なや、遣る瀬なや。コロナ、コロナ、コロナ苦いかしょっぱいか。コロナ、コロナで半年暮らす、後の半年ゃ寝て暮らす。コロナ居良いか住み良いか。",
@@ -3053,7 +3053,7 @@ export const books = [
     "isbn": "9784820729631",
     "asin": "4820729632",
     "readDate": "2024/04/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9631/9784820729631_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9631/9784820729631_1_2.jpg",
     "highlights": []
   },
   {
@@ -3064,7 +3064,7 @@ export const books = [
     "isbn": "9784569692920",
     "asin": "4569692923",
     "readDate": "2024/04/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5696/56969292.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5696/56969292.jpg",
     "highlights": []
   },
   {
@@ -3075,7 +3075,7 @@ export const books = [
     "isbn": "9784822233488",
     "asin": "4822233480",
     "readDate": "2024/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3488/9784822233488.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3488/9784822233488.jpg",
     "highlights": []
   },
   {
@@ -3086,7 +3086,7 @@ export const books = [
     "isbn": "9784049153491",
     "asin": "4049153491",
     "readDate": "2024/03/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3491/9784049153491_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3491/9784049153491_1_3.jpg",
     "highlights": []
   },
   {
@@ -3097,7 +3097,7 @@ export const books = [
     "isbn": "9784163917689",
     "asin": "4163917683",
     "readDate": "2024/03/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7689/9784163917689_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7689/9784163917689_1_5.jpg",
     "highlights": [
       {
         "text": "ソフトウェア開発に限らず、世界から日本を見ると「生産性の悪さ」で〝大損〟している分野が非常に多い。それは単にＤＸ（デジタルトランスフォーメーション） 化が遅れているといった次元の話ではなく、生産性の要となるマインドセット、チームビルディングにまだまだ大きな改善の余地があるのだ。",
@@ -3193,7 +3193,7 @@ export const books = [
     "isbn": "9784065348253",
     "asin": "4065348250",
     "readDate": "2024/03/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8253/9784065348253_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8253/9784065348253_1_2.jpg",
     "highlights": []
   },
   {
@@ -3204,7 +3204,7 @@ export const books = [
     "isbn": "9784480823830",
     "asin": "4480823832",
     "readDate": "2024/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3830/9784480823830_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3830/9784480823830_1_3.jpg",
     "highlights": []
   },
   {
@@ -3215,7 +3215,7 @@ export const books = [
     "isbn": "9784309412443",
     "asin": "4309412440",
     "readDate": "2024/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2443/9784309412443_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2443/9784309412443_1_3.jpg",
     "highlights": []
   },
   {
@@ -3226,7 +3226,7 @@ export const books = [
     "isbn": "9784791704415",
     "asin": "479170441X",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784791704415_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784791704415_1_2.jpg",
     "highlights": []
   },
   {
@@ -3237,7 +3237,7 @@ export const books = [
     "isbn": "9784480094254",
     "asin": "4480094253",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4254/9784480094254.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4254/9784480094254.jpg",
     "highlights": []
   },
   {
@@ -3248,7 +3248,7 @@ export const books = [
     "isbn": "9784480097187",
     "asin": "448009718X",
     "readDate": "2024/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7187/9784480097187.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7187/9784480097187.jpg",
     "highlights": []
   },
   {
@@ -3259,7 +3259,7 @@ export const books = [
     "isbn": "9784054069756",
     "asin": "4054069754",
     "readDate": "2024/02/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9756/9784054069756_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9756/9784054069756_1_5.jpg",
     "highlights": [
       {
         "text": "そもそも、不動産投資が、「大丈夫」なものでも「有利」なものでもないことは、不動産業者が自ら物件を保有するのではなく、客を探して売っている状況が雄弁に物語っている。「サラリーマンでも大家さん」「不動産投資で不労所得」といった甘言に乗るのは賢くないから、気をつけろ。",
@@ -3327,7 +3327,7 @@ export const books = [
     "isbn": "9784022952523",
     "asin": "4022952520",
     "readDate": "2024/02/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2523/9784022952523_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2523/9784022952523_1_3.jpg",
     "highlights": []
   },
   {
@@ -3338,7 +3338,7 @@ export const books = [
     "isbn": "9784798179421",
     "asin": "4798179426",
     "readDate": "2024/01/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9421/9784798179421_1_133.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9421/9784798179421_1_133.jpg",
     "highlights": [
       {
         "text": "会員特典データのご案内 本書の読者特典として、「用語集」をご提供致します。本書の理解にご活用ください。 会員特典データは、以下のサイトからダウンロードして入手いただけます。 https://www.shoeisha.co.jp/book/present/9784798179421 ※会員特典データのファイルは圧縮されています。ダウンロードしたファイルをダブルクリックすると、ファイルが解凍され、利用いただけます。 ※会員特典データのダウンロードには、SHOEISHA iD（翔泳社が運営する無料の会員制度）への会員登録が必要です。詳しくは、Webサイトをご覧ください。 ※会員特典データに関する権利は著者および株式会社翔泳社が所有しています。許可なく配布したり、Webサイトに転載したりすることはできません。 ※会員特典データの提供は予告なく終了することがあります。予めご了承ください。 ※会員特典データの提供にあたっては正確な記述につとめましたが、著者や出版社などのいずれも、その内容に対してなんらかの保証をするものではなく、内容やサンプルに基づくいかなる運用結果に関してもいっさいの責任を負いません。",
@@ -3366,7 +3366,7 @@ export const books = [
     "isbn": "9784101035413",
     "asin": "4101035415",
     "readDate": "2024/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5413/9784101035413_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5413/9784101035413_1_2.jpg",
     "highlights": [
       {
         "text": "我々は妥協を重ねながら生きている。 何かやりたいことをあきらめたり、何かやるべきことから眼を 背けているだけではない。 どういうことなのか。なぜこうなってしまうのか。何か違う、いや、そうじゃないんだ……。そのように感じられる何ごとかについて、「まぁ、いいか」と自分に言い聞かせながら、あるいはむしろ、自分にそう言い聞かせるよう 心がけながら 生きている。 この本は、そうした妥協に 抗いながら書かれた。自分が感じてきた、 曖昧 な、ボンヤリとした何かに姿形を与えるには、それが必要だった。",
@@ -3506,7 +3506,7 @@ export const books = [
     "isbn": "9784799320235",
     "asin": "4799320238",
     "readDate": "2023/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0235/9784799320235_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0235/9784799320235_1_2.jpg",
     "highlights": []
   },
   {
@@ -3517,7 +3517,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2023/12/18",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2367992/3f526908-04c9-4594-831d-d6d875b57a32.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2367992/3f526908-04c9-4594-831d-d6d875b57a32.png",
     "highlights": []
   },
   {
@@ -3528,7 +3528,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2023/12/13",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368019/c9f43e45-c909-4424-a625-c8c4e9b25130.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368019/c9f43e45-c909-4424-a625-c8c4e9b25130.png",
     "highlights": []
   },
   {
@@ -3539,7 +3539,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2023/11/15",
-    "thumnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368045/ae67fc6e-8f77-4024-bf8a-3e9867c85409.png",
+    "thumbnailImage": "https://booth.pximg.net/a6bb6149-3c80-4a32-af82-d43ef5505047/i/2368045/ae67fc6e-8f77-4024-bf8a-3e9867c85409.png",
     "highlights": []
   },
   {
@@ -3550,7 +3550,7 @@ export const books = [
     "isbn": "9784047376915",
     "asin": "4047376914",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6915/9784047376915_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6915/9784047376915_1_2.jpg",
     "highlights": []
   },
   {
@@ -3561,7 +3561,7 @@ export const books = [
     "isbn": "9784047373112",
     "asin": "4047373117",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3112/9784047373112_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3112/9784047373112_1_3.jpg",
     "highlights": []
   },
   {
@@ -3572,7 +3572,7 @@ export const books = [
     "isbn": "9784047358782",
     "asin": "4047358789",
     "readDate": "2023/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8782/9784047358782.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8782/9784047358782.jpg",
     "highlights": []
   },
   {
@@ -3583,7 +3583,7 @@ export const books = [
     "isbn": "9784153400146",
     "asin": "4153400149",
     "readDate": "2023/10/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0146/9784153400146_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0146/9784153400146_1_2.jpg",
     "highlights": []
   },
   {
@@ -3594,7 +3594,7 @@ export const books = [
     "isbn": "9784153400092",
     "asin": "4153400092",
     "readDate": "2023/10/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784153400092_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784153400092_1_2.jpg",
     "highlights": []
   },
   {
@@ -3605,7 +3605,7 @@ export const books = [
     "isbn": "9784480432933",
     "asin": "4480432930",
     "readDate": "2023/10/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2933/9784480432933.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2933/9784480432933.jpg",
     "highlights": []
   },
   {
@@ -3616,7 +3616,7 @@ export const books = [
     "isbn": "9784041141861",
     "asin": "4041141869",
     "readDate": "2023/10/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1861/9784041141861_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1861/9784041141861_1_3.jpg",
     "highlights": []
   },
   {
@@ -3627,7 +3627,7 @@ export const books = [
     "isbn": "9784582766721",
     "asin": "4582766722",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6721/9784582766721.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6721/9784582766721.jpg",
     "highlights": []
   },
   {
@@ -3638,7 +3638,7 @@ export const books = [
     "isbn": "9784022518378",
     "asin": "4022518375",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8378/9784022518378_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8378/9784022518378_1_7.jpg",
     "highlights": [
       {
         "text": "答えがわからない。押したのはいいけれど思い出せない。問題文の先を予測してみたが見当違いだった。そんなことは頻繁にある。でも僕は恥ずかしがらず、堂々と誤答を口にした。学校のテストで空欄を作ることがもったいないように、クイズをしているのに何も答えないのはもったいない。間違っていると思っていても、とりあえず口に出してみる。間違っているのは誤答することではなく、恥ずかしがって何も答えないことだ。 気がつくと、クイズの外でも「恥ずかしい」と思うことがあまりなくなっていた。クイズも現実世界も同じだ。なんでもやってみるに越したことはない。誰かに笑われたって構わない。恥ずかしいという気持ちのせいで自分の可能性を閉ざしてしまうことの方がもったいない。",
@@ -3658,7 +3658,7 @@ export const books = [
     "isbn": "9784087520279",
     "asin": "4087520277",
     "readDate": "2023/10/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0875/08752027.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0875/08752027.jpg",
     "highlights": [
       {
         "text": "これは哲学者のマッグの書いた「 阿呆 の言葉」の中の何章かです。―― × 阿呆はいつも彼以外のものを阿呆であると信じている。 × 我々の自然を愛するのは自然は我々を憎んだり 嫉妬 したりしないためもないことはない。 × もっとも賢い生活は一時代の習慣を 軽蔑 しながら、しかもそのまた習慣を少しも破らないように暮らすことである。 × 我々のもっとも誇りたいものは我々の持っていないものだけである。 × 何びとも偶像を破壊することに異存を持っているものはない。同時にまた何びとも偶像になることに異存を持っているものはない。しかし偶像の台座の上に安んじてすわっていられるものはもっとも神々に恵まれたもの、――阿呆か、悪人か、英雄かである。（クラバックはこの章の上へ 爪 の 痕 をつけていました。） × 我々の生活に必要な思想は三千年 前 に尽きたかもしれない。我々はただ古い 薪 に新しい炎を加えるだけであろう。 × 我々の特色は我々自身の意識を超越するのを常としている。 × 幸福は苦痛を伴い、平和は 倦怠 を伴うとすれば、――？ × 自己を弁護することは他人を弁護することよりも困難である。疑うものは弁護士を見よ。 × 矜誇［＃ルビの「きょうか」はママ］、愛欲、疑惑――あらゆる罪は三千年来、この三者から発している。同時にまたおそらくはあらゆる徳も。 × 物質的欲望を減ずることは必ずしも平和をもたらさない。我々は平和を得るためには精神的欲望も減じなければならぬ。（クラバックはこの章の上にも 爪 の 痕 を残していました。） × 我々は人間よりも不幸である。人間は 河童 ほど進化… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -3674,7 +3674,7 @@ export const books = [
     "isbn": "9784798068169",
     "asin": "4798068160",
     "readDate": "2023/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8169/9784798068169_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8169/9784798068169_1_4.jpg",
     "highlights": []
   },
   {
@@ -3685,7 +3685,7 @@ export const books = [
     "isbn": "9784569820934",
     "asin": "456982093X",
     "readDate": "2023/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0934/9784569820934_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0934/9784569820934_1_2.jpg",
     "highlights": [
       {
         "text": "多くの人は「感情的な自分」を「自分自身」だと思い込んでいますが、それは「ゴミが散らかった部屋」を「普通」だと思い込んでいる汚部屋の住人と同じ心理に陥っています。その状態では、なかなか自分が感情的になっている、ということに気づくことができないでしょう。「怒っていること」が当たり前の状態で何年も、何十年も過ごして来た人は、自分が怒っているということに気づくことができなくなるのです。 これが、「心の基準点」を明るく、静かな状態に保っておいたほうがいい理由です。そして、「体質改善を目指す行」というのは、この「心の基準点」をできるだけ高いところに保つために行うものです。明るく、爽やかで、深い呼吸をして心が落ち着いた状態にある自分を「基準」にしておく。そうすれば日常の中で、小さな怒り、小さなイライラ、小さな不安が生じたときにすぐ気づくことができるし、小さい段階で見つけることによって、容易に払えるようになるのです。",
@@ -3705,7 +3705,7 @@ export const books = [
     "isbn": "9784150506025",
     "asin": "4150506027",
     "readDate": "2023/10/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6025/9784150506025_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6025/9784150506025_1_3.jpg",
     "highlights": [
       {
         "text": "不平等な社会で頂点に立つ人びとは、自分の成功は道徳的に正当なものだと思い込みたがる。能力主義の社会において、これは次のことを意味する。つまり、勝者は自らの才能と努力によって成功を勝ち取ったと信じなければならないということだ。 逆説的だが、これこそ不正に手を染める親が子供に与えたかった贈り物だ。彼らの本当の気がかりが、子供を裕福に暮らせるようにしてやることに尽きるとすれば、子供に信託ファンドを与えておけばよかったはずだ。だが、彼らはほかの何かを望んでいた。それは、名門大学への入学が与えてくれる能力主義の威信である。",
@@ -3729,7 +3729,7 @@ export const books = [
     "isbn": "9784569673820",
     "asin": "4569673821",
     "readDate": "2023/09/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3820/9784569673820.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3820/9784569673820.jpg",
     "highlights": [
       {
         "text": "当たり前の議論が通らなくなるのは、どこかで皆さんが遠慮するからです。社会が一つの方向に漂流してしまうときこそ、それをくい止めるのが宗教の役割なんです",
@@ -3765,7 +3765,7 @@ export const books = [
     "isbn": "9784152102133",
     "asin": "4152102136",
     "readDate": "2023/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2133/9784152102133_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2133/9784152102133_1_2.jpg",
     "highlights": []
   },
   {
@@ -3776,7 +3776,7 @@ export const books = [
     "isbn": "9784150315375",
     "asin": "415031537X",
     "readDate": "2023/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5375/9784150315375_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5375/9784150315375_1_3.jpg",
     "highlights": [
       {
         "text": "信仰とは 生 への不安感を解消し安寧を得るための手段であり、なかでも他者を推す＝祀るロールは人生をやり過ごす効果的な酩酊ツールです。その感情が酩酊であると分かっていても、全ての信仰を棄教して生きるには人生はあまりに長く、全てに醒めて生きるメリットはあまりに少ない。人間は多かれ少なかれ何らかの存在に酩酊して生きており、それはアイドルのような信仰される側の存在であっても同じである場合が多いです。",
@@ -3792,7 +3792,7 @@ export const books = [
     "isbn": "9784866995076",
     "asin": "4866995076",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5076/9784866995076_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5076/9784866995076_1_2.jpg",
     "highlights": []
   },
   {
@@ -3803,7 +3803,7 @@ export const books = [
     "isbn": "9784866993997",
     "asin": "4866993995",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3997/9784866993997_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3997/9784866993997_1_2.jpg",
     "highlights": []
   },
   {
@@ -3814,7 +3814,7 @@ export const books = [
     "isbn": "9784866992150",
     "asin": "4866992158",
     "readDate": "2023/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2150/9784866992150.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2150/9784866992150.jpg",
     "highlights": []
   },
   {
@@ -3825,7 +3825,7 @@ export const books = [
     "isbn": "9784864727327",
     "asin": "4864727325",
     "readDate": "2023/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7327/9784864727327.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7327/9784864727327.jpg",
     "highlights": []
   },
   {
@@ -3836,7 +3836,7 @@ export const books = [
     "isbn": "9784049148671",
     "asin": "4049148676",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8671/9784049148671_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8671/9784049148671_1_2.jpg",
     "highlights": []
   },
   {
@@ -3847,7 +3847,7 @@ export const books = [
     "isbn": "9784049139365",
     "asin": "4049139367",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9365/9784049139365_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9365/9784049139365_1_2.jpg",
     "highlights": []
   },
   {
@@ -3858,7 +3858,7 @@ export const books = [
     "isbn": "9784094531268",
     "asin": "4094531262",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1268/9784094531268_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1268/9784094531268_1_3.jpg",
     "highlights": []
   },
   {
@@ -3869,7 +3869,7 @@ export const books = [
     "isbn": "9784049150148",
     "asin": "404915014X",
     "readDate": "2023/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0148/9784049150148_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0148/9784049150148_1_2.jpg",
     "highlights": []
   },
   {
@@ -3880,7 +3880,7 @@ export const books = [
     "isbn": "9784049144963",
     "asin": "4049144964",
     "readDate": "2023/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4963/9784049144963_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4963/9784049144963_1_6.jpg",
     "highlights": []
   },
   {
@@ -3891,7 +3891,7 @@ export const books = [
     "isbn": "9784049144956",
     "asin": "4049144956",
     "readDate": "2023/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4956/9784049144956_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4956/9784049144956_1_4.jpg",
     "highlights": [
       {
         "text": "改めて振り返って。この『あした、 裸足 でこい。』４巻は、自分の中でもちょっと特別な、チャレンジもある巻だったなと思います。 ついに 坂本 自身が自分の生き方に向き合う。新たな小惑星を探す。 外側だけを見れば、シリーズ後半にふさわしいイベントが目白押しです。 自分でも、書いていてとても楽しかった。 けれど多分、僕がこの巻で一番 描きたかったのは、 二 斗 と 坂本 の関係の変化だったんだろうなと思います。 持っている能力ゆえに、孤独に戦っていた 二 斗。 凡人である 坂本 が、本当の意味でその隣に立つまでが、この４巻のテーマだったかなと。 内容について多くは触れませんが、そこを 描きつつ皆さんにも楽しんでもらえそうな話にする、というのが、今回僕にとって大きな挑戦だったように思う。 どうでしたかね？ 楽しんでもらえたかな、伝わったかな。 挑戦の結果やいかに……。 僕自身としては、このうえなく 良い形で描けたんじゃないかと自負しています。 そうそう、今回執筆中にキャラが勝手に動きまくったのもうれしかったですね。 もちろん、原稿作業前にプロットは立てますし、大枠でストーリーは決めています。 ただこの４巻では 坂本 も 二 斗 も 真琴 も、ゲストキャラの 七森 さえも、いきなりプロットと違う形で感情を発露させまくってきたんだよな。 笑ったり怒ったりバチバチしたり。 こういうの、予想外でびっくりしますし本当に楽しいんです。 特に大きかったのは 真琴 ですね。 読んでくれた方は分かると思いますが、面接シーン。 あそこ、あんな風にするつもり全然なかったんです。もっと普通に色々匂わせる程度のつもりだったのに、 真琴 が勝手に超ストレートに言ってしまった。ああいうの、小説家 冥利 に尽きる瞬間です。 ということで、『あした、 裸足 でこい… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -3911,7 +3911,7 @@ export const books = [
     "isbn": "9784152102157",
     "asin": "4152102152",
     "readDate": "2023/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2157/9784152102157_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2157/9784152102157_1_2.jpg",
     "highlights": [
       {
         "text": "ジラールは、私たちが欲しがるもののほとんどは、 模倣 によるものであって、内在するものではないとした。人間は──真似ることを通して──ほかの人が欲しがるものと同じものを 欲しがることを学ぶ。同じ言語を話し、同じ文化的規範によって行動することを学ぶのと同じである。真似は、社会において人々が 公 に認める以上に大きな役割を果たしている。",
@@ -3979,7 +3979,7 @@ export const books = [
     "isbn": "9784845921423",
     "asin": "4845921421",
     "readDate": "2023/08/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1423/9784845921423_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1423/9784845921423_1_3.jpg",
     "highlights": []
   },
   {
@@ -3990,7 +3990,7 @@ export const books = [
     "isbn": "9784845637966",
     "asin": "4845637960",
     "readDate": "2023/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7966/9784845637966_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7966/9784845637966_1_5.jpg",
     "highlights": []
   },
   {
@@ -4001,7 +4001,7 @@ export const books = [
     "isbn": "9784003315811",
     "asin": "4003315812",
     "readDate": "2023/08/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5811/9784003315811_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5811/9784003315811_1_3.jpg",
     "highlights": [
       {
         "text": "英雄とか偉人とかいわれている人々の中で、本当に尊敬が出来るのは、人類の進歩に役立った人だけだ。そして、彼らの非凡な事業のうち、真に値打のあるものは、ただこの流れに沿って行われた事業だけだ。（",
@@ -4017,7 +4017,7 @@ export const books = [
     "isbn": "9784065241271",
     "asin": "4065241278",
     "readDate": "2023/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1271/9784065241271_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1271/9784065241271_1_2.jpg",
     "highlights": []
   },
   {
@@ -4028,7 +4028,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2023/07/29",
-    "thumnailImage": "https://m.media-amazon.com/images/I/514RatodeeL._AC_SL1500_.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/514RatodeeL._AC_SL1500_.jpg",
     "highlights": [
       {
         "text": "特別な才能がある 素敵な音楽を作ったり、人を感動させる物語が書けたり、生活に役立つ発明が出来たり、容姿端麗で写真を撮るだけでお金になったりという、そんな銀のスプーンを最初からくわえて生まれてきた、とんでもなくラッキーな方は、その才能によってリッチになれます。",
@@ -4052,7 +4052,7 @@ export const books = [
     "isbn": "9784811808505",
     "asin": "4811808509",
     "readDate": "2023/07/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784811808505_1_77.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784811808505_1_77.jpg",
     "highlights": []
   },
   {
@@ -4063,7 +4063,7 @@ export const books = [
     "isbn": "9784046058683",
     "asin": "4046058684",
     "readDate": "2023/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8683/9784046058683_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8683/9784046058683_1_2.jpg",
     "highlights": []
   },
   {
@@ -4074,7 +4074,7 @@ export const books = [
     "isbn": "9784087212686",
     "asin": "4087212688",
     "readDate": "2023/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2686/9784087212686_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2686/9784087212686_1_7.jpg",
     "highlights": [
       {
         "text": "タイアップの話が進む中で、電通は『ラピュタ』に関するキャラクターや映像の使用について、細かな条件をリストアップした契約書を用意してきた。しかし高畑は、この契約書の記載項目をほぼすべて却下。許可するのは、『天空の城ラピュタ』というロゴのみとし、そのほかのキャラクターの絵や映像については、都度協議して使用を検討することを条件とした。高畑がこのような厳しい条件を提示した背景には、企業とタイアップをすることによって、それまで商業主義に侵されなかった映画の自由が失われることへの危惧、そして、『ラピュタ』をその第一号作品にするべきではないという考えがあったという。",
@@ -4106,7 +4106,7 @@ export const books = [
     "isbn": "9784001140125",
     "asin": "4001140128",
     "readDate": "2023/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0125/9784001140125.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0125/9784001140125.jpg",
     "highlights": [
       {
         "text": "「ああわたくしもそれをもとめている。おまえはおまえの 切符 をしっかりもっておいで。そして一しんに 勉強 しなけぁいけない。おまえは 化学 をならったろう、水は 酸素 と 水素 からできているということを知っている。いまはたれだってそれを 疑 やしない。 実験 してみるとほんとうにそうなんだから。けれども 昔 はそれを 水銀 と 塩 でできていると 言ったり、 水銀 と 硫黄 でできていると 言ったりいろいろ 議論 したのだ。みんながめいめいじぶんの 神さまがほんとうの神さまだというだろう、けれどもお互いほかの 神さまを 信ずる人たちのしたことでも 涙 がこぼれるだろう。それからぼくたちの心がいいとかわるいとか 議論 するだろう。そして 勝負 がつかないだろう。けれども、もしおまえがほんとうに 勉強 して 実験 でちゃんとほんとうの考えと、うその考えとを分けてしまえば、その 実験 の 方法 さえきまれば、もう 信仰 も 化学 と同じようになる。けれども、ね、ちょっとこの本をごらん、いいかい、これは 地理 と 歴史 の 辞典 だよ。",
@@ -4122,7 +4122,7 @@ export const books = [
     "isbn": "9784063765786",
     "asin": "4063765784",
     "readDate": "2023/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784063765786.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784063765786.jpg",
     "highlights": []
   },
   {
@@ -4133,7 +4133,7 @@ export const books = [
     "isbn": "9784334034252",
     "asin": "433403425X",
     "readDate": "2023/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403425.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403425.jpg",
     "highlights": []
   },
   {
@@ -4144,7 +4144,7 @@ export const books = [
     "isbn": "9784046055477",
     "asin": "4046055472",
     "readDate": "2023/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5477/9784046055477_1_10.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5477/9784046055477_1_10.jpg",
     "highlights": []
   },
   {
@@ -4155,7 +4155,7 @@ export const books = [
     "isbn": "9784144072260",
     "asin": "4144072266",
     "readDate": "2023/07/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2260/9784144072260.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2260/9784144072260.jpg",
     "highlights": []
   },
   {
@@ -4166,7 +4166,7 @@ export const books = [
     "isbn": "9784198654825",
     "asin": "4198654824",
     "readDate": "2023/07/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4825/9784198654825_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4825/9784198654825_1_3.jpg",
     "highlights": [
       {
         "text": "日々の運動習慣に加えて、予防医療も重要だ。日本はこの予防医療の考えがかなり遅れている。大半の病気は、事前の対処次第でいくらでも回避できるのだ。 たとえば日本人に多い胃がん。日本人がかかる胃がんのうち、 98％はピロリ菌感染によるものだ。このピロリ菌は薬を飲めば簡単に除去できる。ちょっとした手間と出費だけで胃がんリスクは激減するのだが、まだまだみんなのピロリ菌に対する認識が低い。 「万病の元」と言われている歯周病もそうだ。海外に比べて日本人は歯周病を軽視しすぎだ。歯周病は口臭の原因になるだけではない。心筋梗塞や脳梗塞など血管系疾患に直結する。だから海外ではデンタルケアに対する意識が高く、幼いころから徹底的に教育されている。 ところが日本はどうだろう。定期的に歯科医に行き、歯石などをクリーニングしている人はどれだけいるだろうか。歯周病になってから、いざ事態が深刻になってから、あわてて手間と治療費を注ぎ込むなんて馬鹿げている。 残念ながら、生命保険や医療保険は、災いを避けてくれる魔除けのお守りではない。 山崎さんが言うように、いざというときは公的医療保険制度が使えるのだからそっちはそれで十分だ。それより習慣的な運動や予防医療にお金を使うべきだ。",
@@ -4198,7 +4198,7 @@ export const books = [
     "isbn": "9784198627058",
     "asin": "4198627053",
     "readDate": "2023/06/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7058/9784198627058.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7058/9784198627058.jpg",
     "highlights": []
   },
   {
@@ -4209,7 +4209,7 @@ export const books = [
     "isbn": "9784478107041",
     "asin": "4478107041",
     "readDate": "2023/06/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784478107041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784478107041.jpg",
     "highlights": []
   },
   {
@@ -4220,7 +4220,7 @@ export const books = [
     "isbn": "9784620326122",
     "asin": "4620326127",
     "readDate": "2023/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6122/9784620326122.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6122/9784620326122.jpg",
     "highlights": []
   },
   {
@@ -4231,7 +4231,7 @@ export const books = [
     "isbn": "9784041061763",
     "asin": "4041061768",
     "readDate": "2023/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1763/9784041061763.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1763/9784041061763.jpg",
     "highlights": []
   },
   {
@@ -4242,7 +4242,7 @@ export const books = [
     "isbn": "9784334046002",
     "asin": "4334046002",
     "readDate": "2023/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6002/9784334046002_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6002/9784334046002_1_3.jpg",
     "highlights": [
       {
         "text": "大学生の彼らは趣味や娯楽について、てっとり早く、短時間で、「何かをモノにしたい」「何かのエキスパートになりたい」と思っている。彼らはオタクに〝憧れている〟のだそうだ。 ところが、彼らは",
@@ -4286,7 +4286,7 @@ export const books = [
     "isbn": "9784087212334",
     "asin": "4087212335",
     "readDate": "2023/05/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2334/9784087212334_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2334/9784087212334_1_4.jpg",
     "highlights": [
       {
         "text": "彼らの行動の裏側にあるのは、個人として培った上昇志向だけではないように思える。そこに潜んでいるのは、ビジネスパーソンの中に「新自由主義」が内面化され、絶えずＳＮＳなどで周囲との比較を強いられて、なおかつ社会の中で生き残るために「うまくやる」ことが求められた結果として、終わりなき成長に駆り立てられる……という時代精神ではないだろうか。",
@@ -4330,7 +4330,7 @@ export const books = [
     "isbn": "9784086314800",
     "asin": "4086314800",
     "readDate": "2023/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784086314800_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784086314800_1_5.jpg",
     "highlights": []
   },
   {
@@ -4341,7 +4341,7 @@ export const books = [
     "isbn": "9784798627601",
     "asin": "4798627607",
     "readDate": "2023/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7601/9784798627601_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7601/9784798627601_1_4.jpg",
     "highlights": []
   },
   {
@@ -4352,7 +4352,7 @@ export const books = [
     "isbn": "9784569534077",
     "asin": "4569534074",
     "readDate": "2023/03/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4077/9784569534077.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4077/9784569534077.jpg",
     "highlights": []
   },
   {
@@ -4363,7 +4363,7 @@ export const books = [
     "isbn": "9784061385498",
     "asin": "4061385496",
     "readDate": "2023/02/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5498/9784061385498.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5498/9784061385498.jpg",
     "highlights": []
   },
   {
@@ -4374,7 +4374,7 @@ export const books = [
     "isbn": "9784763140142",
     "asin": "4763140140",
     "readDate": "2023/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784763140142_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784763140142_1_2.jpg",
     "highlights": []
   },
   {
@@ -4385,7 +4385,7 @@ export const books = [
     "isbn": "9784798068534",
     "asin": "4798068535",
     "readDate": "2023/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8534/9784798068534_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8534/9784798068534_1_5.jpg",
     "highlights": []
   },
   {
@@ -4396,7 +4396,7 @@ export const books = [
     "isbn": "9784062176200",
     "asin": "4062176203",
     "readDate": "2023/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6200/9784062176200.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6200/9784062176200.jpg",
     "highlights": [
       {
         "text": "私が研究者からマッキンゼーへと転職して、初めてのプロジェクトを担当してから現在にいたるまで、チームづくりにおいて非常に役立っているコンセプトがある。 それこそが「チームアプローチによる問題解決」だ（以下、「チームアプローチ」と記す）。「チームアプローチ」とは端的にいえば、「よいチーム」を継続的に、システマチックに何度でも再現するために考え出された組織づくりの概念である。 この「チームアプローチ」に関しては、マッキンゼーのパートナーであったジョン・Ｒ・カッツェンバックとダグラス・Ｋ・スミスが、『「高業績チーム」の知恵─企業を革新する自己実現型組織』（ダイヤモンド社刊） に詳しく記している。 カッツェンバックらは、さまざまなプロジェクトのケーススタディを通じて、「まあまあ」よい成果ではなく、「抜きんでた」成果をあげたチームには、共通の特徴があることを発見した。 「よいチーム」はたいていの場合、 1 少人数である 2 メンバーが互いに補完的なスキルを有する 3 共通の目的とその達成に責任を持つ 4 問題解決のためのアプローチの方法を共有している 5 メンバーの相互責任がある という５つの大きな共通点を持つことを見出した。 この５つの共通する特徴を、チームづくりに活かすというのがチームアプローチの基本的な考え方である。",
@@ -4416,7 +4416,7 @@ export const books = [
     "isbn": "9784094530612",
     "asin": "4094530614",
     "readDate": "2023/02/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0612/9784094530612_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0612/9784094530612_1_3.jpg",
     "highlights": []
   },
   {
@@ -4427,7 +4427,7 @@ export const books = [
     "isbn": "9784065296028",
     "asin": "4065296021",
     "readDate": "2023/02/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6028/9784065296028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6028/9784065296028.jpg",
     "highlights": [
       {
         "text": "「運命がカードを切り、わたしたちが勝負する」──。ショーペンハウアーによれば、人生はいつも思いどおりにはならず、ぎりぎりの勝負の連続である（『幸福について』第五章第四八節、邦訳三二八頁）。",
@@ -4463,7 +4463,7 @@ export const books = [
     "isbn": "9784837928447",
     "asin": "4837928447",
     "readDate": "2023/02/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8447/9784837928447.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8447/9784837928447.jpg",
     "highlights": [
       {
         "text": "独学が長続きしないのも成果が出にくいのも、要するに「計画どおりに進まない」からです。 そして多くの場合、その原因は、じつは「計画を立てる」段階ですでに問題があり、その問題が放置されたことにあります。要するに、 「計画どおりに進まないのは、計画そのものが予定どおりに進むような設計になっていないから」",
@@ -4503,7 +4503,7 @@ export const books = [
     "isbn": "9784046043672",
     "asin": "4046043679",
     "readDate": "2023/02/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3672/9784046043672_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3672/9784046043672_1_7.jpg",
     "highlights": []
   },
   {
@@ -4514,7 +4514,7 @@ export const books = [
     "isbn": "9784873116303",
     "asin": "4873116309",
     "readDate": "2023/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6303/9784873116303.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6303/9784873116303.jpg",
     "highlights": []
   },
   {
@@ -4525,7 +4525,7 @@ export const books = [
     "isbn": "9784000614139",
     "asin": "4000614134",
     "readDate": "2023/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4139/9784000614139.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4139/9784000614139.jpg",
     "highlights": []
   },
   {
@@ -4536,7 +4536,7 @@ export const books = [
     "isbn": "9784046050298",
     "asin": "4046050292",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0298/9784046050298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0298/9784046050298.jpg",
     "highlights": []
   },
   {
@@ -4547,7 +4547,7 @@ export const books = [
     "isbn": "9784046053770",
     "asin": "4046053771",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3770/9784046053770_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3770/9784046053770_1_4.jpg",
     "highlights": []
   },
   {
@@ -4558,7 +4558,7 @@ export const books = [
     "isbn": "9784845636846",
     "asin": "4845636840",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784845636846_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784845636846_1_3.jpg",
     "highlights": []
   },
   {
@@ -4569,7 +4569,7 @@ export const books = [
     "isbn": "9784048932714",
     "asin": "4048932713",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2714/9784048932714.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2714/9784048932714.jpg",
     "highlights": []
   },
   {
@@ -4580,7 +4580,7 @@ export const books = [
     "isbn": "9784484212333",
     "asin": "4484212331",
     "readDate": "2023/01/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2333/9784484212333_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2333/9784484212333_1_3.jpg",
     "highlights": [
       {
         "text": "お金を持っていない人や会社を相手にしてお金儲けをする場合には、以下のどちらかの条件をクリアしている必要がある。注意しておこう。 ①トラブルのリスクを補って余りあるほど利益率が高い ②相手の数が極めて多く、販売が極めて簡単",
@@ -4596,7 +4596,7 @@ export const books = [
     "isbn": "9784480075284",
     "asin": "4480075283",
     "readDate": "2023/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5284/9784480075284_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5284/9784480075284_1_3.jpg",
     "highlights": []
   },
   {
@@ -4607,7 +4607,7 @@ export const books = [
     "isbn": "9784022518095",
     "asin": "402251809X",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8095/9784022518095_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8095/9784022518095_1_2.jpg",
     "highlights": [
       {
         "text": "当時のTwitterには「Twitterの有名人」がいた。ユーザーが少ないので、活発にツイートしてる人たちの名前とアイコンはみんなの共通認識になっていた。といっても、Twitter有名人のみんながみんな面白ツイートをしているわけでもなかった。いまTwitterで有名になろうと思ったら一芸に秀でなければいけないが、当時は「なんとなくいい感じの人」というだけで知られている人々がいたのである。あれなんだったんだろう。 できたてのプラットフォーム特有の「せまい」感じが好きだ。Twitterはもう自己顕示欲と悪口と 怨嗟 と転載猫動画が広がる汚染された果てなき荒野でしかないけど、１０年くらい前はなんとなく「果て」が感じられた。ああ、これくらいの広さなんだな、というのが、タイムラインを見ているだけで体感できたのだ。",
@@ -4683,7 +4683,7 @@ export const books = [
     "isbn": "9784049143362",
     "asin": "4049143364",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3362/9784049143362_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3362/9784049143362_1_3.jpg",
     "highlights": []
   },
   {
@@ -4694,7 +4694,7 @@ export const books = [
     "isbn": "9784049134469",
     "asin": "4049134462",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4469/9784049134469_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4469/9784049134469_1_4.jpg",
     "highlights": []
   },
   {
@@ -4705,7 +4705,7 @@ export const books = [
     "isbn": "9784040744070",
     "asin": "4040744071",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4070/9784040744070_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4070/9784040744070_1_3.jpg",
     "highlights": []
   },
   {
@@ -4716,7 +4716,7 @@ export const books = [
     "isbn": "9784040738628",
     "asin": "4040738624",
     "readDate": "2023/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8628/9784040738628.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8628/9784040738628.jpg",
     "highlights": []
   },
   {
@@ -4727,7 +4727,7 @@ export const books = [
     "isbn": "9784040736426",
     "asin": "4040736427",
     "readDate": "2023/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6426/9784040736426.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6426/9784040736426.jpg",
     "highlights": []
   },
   {
@@ -4738,7 +4738,7 @@ export const books = [
     "isbn": "9784040733791",
     "asin": "4040733797",
     "readDate": "2023/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784040733791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784040733791.jpg",
     "highlights": []
   },
   {
@@ -4749,7 +4749,7 @@ export const books = [
     "isbn": "9784040731728",
     "asin": "4040731727",
     "readDate": "2023/01/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1728/9784040731728.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1728/9784040731728.jpg",
     "highlights": []
   },
   {
@@ -4760,7 +4760,7 @@ export const books = [
     "isbn": "9784065267141",
     "asin": "4065267145",
     "readDate": "2023/01/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7141/9784065267141_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7141/9784065267141_1_2.jpg",
     "highlights": []
   },
   {
@@ -4771,7 +4771,7 @@ export const books = [
     "isbn": "9784065294383",
     "asin": "406529438X",
     "readDate": "2022/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4383/9784065294383.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4383/9784065294383.jpg",
     "highlights": [
       {
         "text": "ところが実際に経済が再開してみると、経済学者たちの予想に反して生産が回復してきません。生産がニーズに追いつかない、つまり需要が供給を上まわるというアンバランスが経済のあちこちで生じてしまい、それが物価上昇を引き起こしてしまったのです。",
@@ -4795,7 +4795,7 @@ export const books = [
     "isbn": "9784621066089",
     "asin": "4621066080",
     "readDate": "2022/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6089/9784621066089.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6089/9784621066089.jpg",
     "highlights": []
   },
   {
@@ -4806,7 +4806,7 @@ export const books = [
     "isbn": "9784910413006",
     "asin": "4910413006",
     "readDate": "2022/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3006/9784910413006.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3006/9784910413006.jpg",
     "highlights": []
   },
   {
@@ -4817,7 +4817,7 @@ export const books = [
     "isbn": "9784061385436",
     "asin": "4061385437",
     "readDate": "2022/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5436/9784061385436.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5436/9784061385436.jpg",
     "highlights": [
       {
         "text": "そもそも物語の文法の一番の基本は二つある、と考えて下さい。 一つは「欠落したものが回復する」というパターン。もう一つは「行って帰る」というパターンです。",
@@ -4873,7 +4873,7 @@ export const books = [
     "isbn": "9784040659930",
     "asin": "4040659937",
     "readDate": "2022/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9930/9784040659930_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9930/9784040659930_1_6.jpg",
     "highlights": []
   },
   {
@@ -4884,7 +4884,7 @@ export const books = [
     "isbn": "9784061385153",
     "asin": "4061385151",
     "readDate": "2022/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5153/9784061385153.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5153/9784061385153.jpg",
     "highlights": [
       {
         "text": "知識や情報の確認テストでいくら良い点数をとっても、いまの時代にはほとんど無意味でしょう。漢字の読み書きが典型ですが、 いまやネットで検索すれば漢字検定一級の問題であっても、誰でも 10 秒で答えが出せます。 「誰でもできること」に価値はありません。そして、「誰でもできること」しかできない人材は、いまの時代、確実に買い叩かれる運命にあります。 だから、思考力や 洞察 力、想像力を 育むかたちに大学教育も変えていかなければなりません。若手教員のあいだで双方向の授業への流れが生まれているのは、時代の変化を反映させてのことなのです。",
@@ -4960,7 +4960,7 @@ export const books = [
     "isbn": "9784041125786",
     "asin": "4041125782",
     "readDate": "2022/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784041125786_1_7.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5786/9784041125786_1_7.jpg",
     "highlights": []
   },
   {
@@ -4971,7 +4971,7 @@ export const books = [
     "isbn": "9784798625577",
     "asin": "4798625574",
     "readDate": "2022/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5577/9784798625577_1_22.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5577/9784798625577_1_22.jpg",
     "highlights": []
   },
   {
@@ -4982,7 +4982,7 @@ export const books = [
     "isbn": "9784065212899",
     "asin": "4065212898",
     "readDate": "2022/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2899/9784065212899.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2899/9784065212899.jpg",
     "highlights": [
       {
         "text": "日本における製作委員会が悪く機能してしまったときの事例と似ているように僕は思える。製作委員会というシステム自体は決して悪い存在ではない。おもちゃやグッズなどを作って、それらを売ることに特化していればいいのだが、それが考えなくストーリーのクリエイティブに混ざってしまったら、悪い化学変化を起こすことはないともいえない。両方のメリットである最大公約数を探していかないといけないのだが、「どちらを取るのか」というような、片方のことしか考えない発想になるのは、作品に悪い影響を及ぼしがちだ。僕は現場クリエイターとしての立場の人間だが、おもちゃやグッズの売上げなんて関係ないと思っているクリエイターなどほとんどいないと思っている。重要なのは、どちらかに偏りすぎると、すごく歪なものになっていくということだ。プロデューサーがそのバランスを取ることは、とても大事なことだろう。",
@@ -5002,7 +5002,7 @@ export const books = [
     "isbn": "9784094530872",
     "asin": "4094530878",
     "readDate": "2022/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0872/9784094530872_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0872/9784094530872_1_3.jpg",
     "highlights": [
       {
         "text": "「知識型マウントね！ 普通は知らない専門知識をあたかも一般常識のように語り『え？ 知らないの（笑）』とマウントを取ったあと『仕方ないな。説明するとだな──』とドヤ顔で説明してくる隠密タイプよ。他にも『 立ち上げる』『 最初から』『 論理的』『 優先順位』『 余裕』『 証拠』など面倒な横文字を使って有能アピールをするマウンティングも知識型にはあるわ。耐性のない相手をイラつかせて冷静さを奪うデバフ効果があって、ベンチャー企業に憧れる学生や自称フリーランスエンジニアの人間に多い。 因みにこの手の人の口癖は『生産性が悪い』よ！」",
@@ -5018,7 +5018,7 @@ export const books = [
     "isbn": "9784061385016",
     "asin": "4061385011",
     "readDate": "2022/09/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5016/9784061385016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5016/9784061385016.jpg",
     "highlights": [
       {
         "text": "世の中を変えるためには、知識を持っているだけではダメです。もちろん、知識すら持っていないのは論外。 日頃から、知識を判断、判断を行動につなげる意識を強く持ってください。",
@@ -5078,7 +5078,7 @@ export const books = [
     "isbn": "9784061385207",
     "asin": "4061385208",
     "readDate": "2022/08/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5207/9784061385207.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5207/9784061385207.jpg",
     "highlights": []
   },
   {
@@ -5089,7 +5089,7 @@ export const books = [
     "isbn": "9784065228098",
     "asin": "4065228093",
     "readDate": "2022/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8098/9784065228098.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8098/9784065228098.jpg",
     "highlights": []
   },
   {
@@ -5100,7 +5100,7 @@ export const books = [
     "isbn": "9784865280968",
     "asin": "4865280960",
     "readDate": "2022/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0968/9784865280968_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0968/9784865280968_1_2.jpg",
     "highlights": [
       {
         "text": "今日「インターセクショナリティ」という語は、Twitter上でのおぞましい言い争いを、つまり人々がたがいに喧嘩しているだけの、あるいはそんな感じのどうしようもないことを意味するだけになりました。これは物事が適切に「 交差」していないことを示しています。すなわち、集団意識の統合が強まるというよりも、各集団間でのアイデンティティ闘争があるだけなのです。",
@@ -5140,7 +5140,7 @@ export const books = [
     "isbn": "9784049144611",
     "asin": "4049144611",
     "readDate": "2022/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4611/9784049144611_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4611/9784049144611_1_4.jpg",
     "highlights": []
   },
   {
@@ -5151,7 +5151,7 @@ export const books = [
     "isbn": "9784049141405",
     "asin": "404914140X",
     "readDate": "2022/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1405/9784049141405_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1405/9784049141405_1_4.jpg",
     "highlights": []
   },
   {
@@ -5162,7 +5162,7 @@ export const books = [
     "isbn": "9784049139419",
     "asin": "4049139413",
     "readDate": "2022/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9419/9784049139419_1_6.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9419/9784049139419_1_6.jpg",
     "highlights": []
   },
   {
@@ -5173,7 +5173,7 @@ export const books = [
     "isbn": "9784049137323",
     "asin": "4049137321",
     "readDate": "2022/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784049137323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784049137323.jpg",
     "highlights": []
   },
   {
@@ -5184,7 +5184,7 @@ export const books = [
     "isbn": "9784803009224",
     "asin": "4803009228",
     "readDate": "2022/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9224/9784803009224.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9224/9784803009224.jpg",
     "highlights": []
   },
   {
@@ -5195,7 +5195,7 @@ export const books = [
     "isbn": "9784152099679",
     "asin": "4152099674",
     "readDate": "2022/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9679/9784152099679.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9679/9784152099679.jpg",
     "highlights": [
       {
         "text": "科学者は超オタクだと思われることが多いのですが、科学の哲学的基盤は実際、まったくのパンクロック的無秩序です。具体的には、それは次のようなものからなっています。決して権威を尊重するな。誰のどんな言葉も決してうのみにするな。そして、自分が知っていると思うものすべてを、自分で正しいと確認するか、間違っていると否定するために検証せよ。",
@@ -5227,7 +5227,7 @@ export const books = [
     "isbn": "9784094530858",
     "asin": "4094530851",
     "readDate": "2022/08/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0858/9784094530858_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0858/9784094530858_1_3.jpg",
     "highlights": []
   },
   {
@@ -5238,7 +5238,7 @@ export const books = [
     "isbn": "9784575244670",
     "asin": "4575244678",
     "readDate": "2022/08/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4670/9784575244670_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4670/9784575244670_1_3.jpg",
     "highlights": []
   },
   {
@@ -5249,7 +5249,7 @@ export const books = [
     "isbn": "9784041119327",
     "asin": "4041119324",
     "readDate": "2022/08/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9327/9784041119327_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9327/9784041119327_1_3.jpg",
     "highlights": []
   },
   {
@@ -5260,7 +5260,7 @@ export const books = [
     "isbn": "9784198653880",
     "asin": "4198653887",
     "readDate": "2022/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784198653880_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3880/9784198653880_1_3.jpg",
     "highlights": []
   },
   {
@@ -5271,7 +5271,7 @@ export const books = [
     "isbn": "9784023318786",
     "asin": "4023318787",
     "readDate": "2022/08/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8786/9784023318786_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8786/9784023318786_1_3.jpg",
     "highlights": []
   },
   {
@@ -5282,7 +5282,7 @@ export const books = [
     "isbn": "9784065244555",
     "asin": "4065244552",
     "readDate": "2022/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4555/9784065244555_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4555/9784065244555_1_2.jpg",
     "highlights": [
       {
         "text": "「なんなら俺のオンラインサロンにチャンネル登録しろ」 「貝木さん、オンラインサロンを開催してるの？ チャンネル登録されてるの？」 「ああ。詐欺師志望の有望な若者が多く集まってくるので、そういう奴らから金を巻き上げるという善行をおこなっている」",
@@ -5306,7 +5306,7 @@ export const books = [
     "isbn": "9784065244548",
     "asin": "4065244544",
     "readDate": "2022/08/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4548/9784065244548_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4548/9784065244548_1_2.jpg",
     "highlights": [
       {
         "text": "「コロナ禍を物語に取り入れるかどうかっていうのは意見の分かれるところだよね。現実が舞台である以上、あたかもコロナウイルスが存在しないがごとく描くのはともすると欺瞞であるかのようだけれど、読む人によっては、パンデミックが小説にまで侵食してきたと、暗い気持ちになることもあるだろう。読書を楽しんでいるときくらい、自粛ではなく自由でありたいと思うのは当然だ。そんなかたにお勧めなのが下巻だよ」",
@@ -5322,7 +5322,7 @@ export const books = [
     "isbn": "9784815610159",
     "asin": "4815610150",
     "readDate": "2022/08/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0159/9784815610159_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0159/9784815610159_1_2.jpg",
     "highlights": []
   },
   {
@@ -5333,7 +5333,7 @@ export const books = [
     "isbn": "9784815609252",
     "asin": "481560925X",
     "readDate": "2022/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9252/9784815609252_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9252/9784815609252_1_2.jpg",
     "highlights": [
       {
         "text": "「人間関係ってのは面倒で、一人でいるぼっちは楽だ。これは絶対的な真理。でも、面倒なことをひたすら回避して生きていても、どこにも行けない気がするんだよな。うまく言えないけど、面倒なことも人生に必要だっていうか、この面倒くささもどこかにつながってるっていうか。花見辻と過ごしてて、そんな風に思った」",
@@ -5349,7 +5349,7 @@ export const books = [
     "isbn": "9784065211588",
     "asin": "4065211581",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1588/9784065211588.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1588/9784065211588.jpg",
     "highlights": [
       {
         "text": "「関係性の放棄ですからね。自分のための、己のための自己犠牲でもあるのです。己への献身であり、献心ですよ。お前とまともに話すつもりはないと、宣言しているようなものです。前向きに検討しますとか善処しますとか、そんな言い逃れと同じですよ。謝ってるんだからもういいだろめんどくせえという本音が透けて見えます」",
@@ -5369,7 +5369,7 @@ export const books = [
     "isbn": "9784063650389",
     "asin": "4063650383",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0389/9784063650389.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0389/9784063650389.jpg",
     "highlights": []
   },
   {
@@ -5380,7 +5380,7 @@ export const books = [
     "isbn": "9784063650228",
     "asin": "4063650227",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0228/9784063650228.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0228/9784063650228.jpg",
     "highlights": []
   },
   {
@@ -5391,7 +5391,7 @@ export const books = [
     "isbn": "9784150505257",
     "asin": "415050525X",
     "readDate": "2022/07/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5257/9784150505257.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5257/9784150505257.jpg",
     "highlights": [
       {
         "text": "いくら自分探しをしたところで、単一の真の自己などというものは存在しない。自分自身の内にも、ほかの人の内にもない。心理学者であり哲学者であったウィリアム・ジェームズ（一八四二～一九一〇）はかつて、〝人は、自分を知る人の数と同じだけの社会的自己をもつ〟と書いた。驚くほど孔子的な意見だ。人にはそれぞれ無数の役割があり、役割同士が対立することも多いうえ、それをあやつる手綱さばきを教えてくれる規範もない。礼の実践だけが手綱さばきを身につける助けになる。",
@@ -5423,7 +5423,7 @@ export const books = [
     "isbn": "9784797341379",
     "asin": "4797341378",
     "readDate": "2022/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1379/9784797341379.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1379/9784797341379.jpg",
     "highlights": []
   },
   {
@@ -5434,7 +5434,7 @@ export const books = [
     "isbn": "9784046049872",
     "asin": "4046049871",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9872/9784046049872.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9872/9784046049872.jpg",
     "highlights": []
   },
   {
@@ -5445,7 +5445,7 @@ export const books = [
     "isbn": "9784535574755",
     "asin": "4535574758",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -5456,7 +5456,7 @@ export const books = [
     "isbn": "9784822286583",
     "asin": "4822286584",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6583/9784822286583.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6583/9784822286583.jpg",
     "highlights": []
   },
   {
@@ -5467,7 +5467,7 @@ export const books = [
     "isbn": "9784098253111",
     "asin": "4098253119",
     "readDate": "2022/07/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3111/9784098253111.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3111/9784098253111.jpg",
     "highlights": [
       {
         "text": "僕らの心は一瞬で変わり続けているため、真実を正しく映し出せていない可能性が高い。だとすれば、心に生じた感情が「本物」ではない可能性もまた大きい、ということになります。僕らはしばしば、心のなかに生じた「怒り」や「妬み」といった感情を、実体として、かなりのリアリティをもってとらえてしまいがちです。しかし、もし心が「一瞬で変わる」のであれば、それらはすべて実体のない、幻にすぎないものだということになります。",
@@ -5523,7 +5523,7 @@ export const books = [
     "isbn": "9784048930659",
     "asin": "4048930656",
     "readDate": "2022/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0659/9784048930659.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0659/9784048930659.jpg",
     "highlights": [
       {
         "text": "巨大な課題管理システムにある膨大な要件文書を扱いながら、システムを「動かす」ために 死に物狂い になっている。彼らが作り出すコードは、きれいではないかもしれないが、それでも動く。何かを「一度だけ」動かすのは、それほど難しいことではないからだ。",
@@ -5599,7 +5599,7 @@ export const books = [
     "isbn": "9784094530728",
     "asin": "409453072X",
     "readDate": "2022/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0728/9784094530728_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0728/9784094530728_1_3.jpg",
     "highlights": []
   },
   {
@@ -5610,7 +5610,7 @@ export const books = [
     "isbn": "9784761275457",
     "asin": "4761275456",
     "readDate": "2022/07/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784761275457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784761275457.jpg",
     "highlights": []
   },
   {
@@ -5621,7 +5621,7 @@ export const books = [
     "isbn": "9784478109687",
     "asin": "4478109680",
     "readDate": "2022/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9687/9784478109687.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9687/9784478109687.jpg",
     "highlights": [
       {
         "text": "金を無駄にするのを恐れて機会を逃がすのはナンセンスだ。 金を浪費することより、人生を無駄にしてしまうことのほうが、はるかに大きな問題ではないだろうか。",
@@ -5677,7 +5677,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2022/07/16",
-    "thumnailImage": "https://m.media-amazon.com/images/I/518NDBA1+SL.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/518NDBA1+SL.jpg",
     "highlights": []
   },
   {
@@ -5688,7 +5688,7 @@ export const books = [
     "isbn": "9784152101334",
     "asin": "4152101334",
     "readDate": "2022/07/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1334/9784152101334.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1334/9784152101334.jpg",
     "highlights": []
   },
   {
@@ -5699,7 +5699,7 @@ export const books = [
     "isbn": "9784074143511",
     "asin": "4074143518",
     "readDate": "2022/07/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784074143511.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784074143511.jpg",
     "highlights": []
   },
   {
@@ -5710,7 +5710,7 @@ export const books = [
     "isbn": "9784334032913",
     "asin": "4334032915",
     "readDate": "2022/06/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2913/9784334032913.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2913/9784334032913.jpg",
     "highlights": []
   },
   {
@@ -5721,7 +5721,7 @@ export const books = [
     "isbn": "9784297127831",
     "asin": "4297127830",
     "readDate": "2022/06/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7831/9784297127831_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7831/9784297127831_1_3.jpg",
     "highlights": [
       {
         "text": "コンストラクタでは、 0 ～ 999 の範囲外は不正な値として弾くロジックになっています。不正な値が紛れ込まないようにしかけをしておくと、バグ化しない頑強なクラス構造になります。",
@@ -5949,7 +5949,7 @@ export const books = [
     "isbn": "9784121006240",
     "asin": "4121006240",
     "readDate": "2022/06/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6240/9784121006240.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6240/9784121006240.jpg",
     "highlights": [
       {
         "text": "いったい読者はこの文書に何を期待しているはずかと，一瞬，反省してみることを勧める．",
@@ -5989,7 +5989,7 @@ export const books = [
     "isbn": "9784167105587",
     "asin": "4167105586",
     "readDate": "2022/05/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16710558.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16710558.jpg",
     "highlights": []
   },
   {
@@ -6000,7 +6000,7 @@ export const books = [
     "isbn": "9784798046143",
     "asin": "4798046140",
     "readDate": "2022/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6143/9784798046143.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6143/9784798046143.jpg",
     "highlights": [
       {
         "text": "ソフトウェアにおいて、その選択の多様性を受容します。 ソフトウェアに関わるすべての場面において、「唯一の正しい方法」というのは存在しません。「唯一の正しい方法がある」とする、すべての主張を信用してはいけません。",
@@ -6024,7 +6024,7 @@ export const books = [
     "isbn": "9784797390575",
     "asin": "4797390573",
     "readDate": "2022/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0575/9784797390575.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0575/9784797390575.jpg",
     "highlights": []
   },
   {
@@ -6035,7 +6035,7 @@ export const books = [
     "isbn": "9784815610258",
     "asin": "4815610258",
     "readDate": "2022/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784815610258_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0258/9784815610258_1_3.jpg",
     "highlights": []
   },
   {
@@ -6046,7 +6046,7 @@ export const books = [
     "isbn": "9784094530605",
     "asin": "4094530606",
     "readDate": "2022/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0605/9784094530605_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0605/9784094530605_1_3.jpg",
     "highlights": []
   },
   {
@@ -6057,7 +6057,7 @@ export const books = [
     "isbn": "9784094530223",
     "asin": "4094530223",
     "readDate": "2022/05/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0223/9784094530223_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0223/9784094530223_1_3.jpg",
     "highlights": []
   },
   {
@@ -6068,7 +6068,7 @@ export const books = [
     "isbn": "9784094518993",
     "asin": "4094518991",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784094518993.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784094518993.jpg",
     "highlights": []
   },
   {
@@ -6079,7 +6079,7 @@ export const books = [
     "isbn": "9784094518665",
     "asin": "4094518665",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8665/9784094518665.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8665/9784094518665.jpg",
     "highlights": []
   },
   {
@@ -6090,7 +6090,7 @@ export const books = [
     "isbn": "9784094518412",
     "asin": "409451841X",
     "readDate": "2022/05/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784094518412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784094518412.jpg",
     "highlights": []
   },
   {
@@ -6101,7 +6101,7 @@ export const books = [
     "isbn": "9784094518160",
     "asin": "4094518169",
     "readDate": "2022/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8160/9784094518160.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8160/9784094518160.jpg",
     "highlights": []
   },
   {
@@ -6112,7 +6112,7 @@ export const books = [
     "isbn": "9784094517965",
     "asin": "4094517960",
     "readDate": "2022/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7965/9784094517965.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7965/9784094517965.jpg",
     "highlights": [
       {
         "text": "「手を 繫 いだら、停滞してしまうから」 だからもしも、と顔を上げて、 「もしもこんな時間がずっと続けばいいと願っているのなら」 切っ先を向けるように言い放つ。 「──そんなのは偽物の恋だと思います」",
@@ -6140,7 +6140,7 @@ export const books = [
     "isbn": "9784046813619",
     "asin": "404681361X",
     "readDate": "2022/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3619/9784046813619_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3619/9784046813619_1_3.jpg",
     "highlights": []
   },
   {
@@ -6151,7 +6151,7 @@ export const books = [
     "isbn": "9784046810014",
     "asin": "4046810017",
     "readDate": "2022/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0014/9784046810014_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0014/9784046810014_1_3.jpg",
     "highlights": []
   },
   {
@@ -6162,7 +6162,7 @@ export const books = [
     "isbn": "9784062817400",
     "asin": "4062817403",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7400/9784062817400.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7400/9784062817400.jpg",
     "highlights": []
   },
   {
@@ -6173,7 +6173,7 @@ export const books = [
     "isbn": "9784046806079",
     "asin": "4046806079",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784046806079_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784046806079_1_5.jpg",
     "highlights": []
   },
   {
@@ -6184,7 +6184,7 @@ export const books = [
     "isbn": "9784046803269",
     "asin": "4046803266",
     "readDate": "2022/05/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3269/9784046803269.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3269/9784046803269.jpg",
     "highlights": []
   },
   {
@@ -6195,7 +6195,7 @@ export const books = [
     "isbn": "9784040647265",
     "asin": "4040647262",
     "readDate": "2022/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7265/9784040647265.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7265/9784040647265.jpg",
     "highlights": []
   },
   {
@@ -6206,7 +6206,7 @@ export const books = [
     "isbn": "9784873119823",
     "asin": "4873119820",
     "readDate": "2022/04/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9823/9784873119823_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9823/9784873119823_1_3.jpg",
     "highlights": []
   },
   {
@@ -6217,7 +6217,7 @@ export const books = [
     "isbn": "9784344984028",
     "asin": "4344984021",
     "readDate": "2022/04/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784344984028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784344984028.jpg",
     "highlights": []
   },
   {
@@ -6228,7 +6228,7 @@ export const books = [
     "isbn": "9784094530100",
     "asin": "409453010X",
     "readDate": "2022/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0100/9784094530100_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0100/9784094530100_1_2.jpg",
     "highlights": []
   },
   {
@@ -6239,7 +6239,7 @@ export const books = [
     "isbn": "9784094518870",
     "asin": "4094518878",
     "readDate": "2022/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8870/9784094518870.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8870/9784094518870.jpg",
     "highlights": []
   },
   {
@@ -6250,7 +6250,7 @@ export const books = [
     "isbn": "9784101024028",
     "asin": "4101024022",
     "readDate": "2022/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784101024028.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4028/9784101024028.jpg",
     "highlights": []
   },
   {
@@ -6261,7 +6261,7 @@ export const books = [
     "isbn": "9784408551227",
     "asin": "4408551228",
     "readDate": "2022/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1227/9784408551227.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1227/9784408551227.jpg",
     "highlights": []
   },
   {
@@ -6272,7 +6272,7 @@ export const books = [
     "isbn": "9784799315323",
     "asin": "4799315323",
     "readDate": "2022/02/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5323/9784799315323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5323/9784799315323.jpg",
     "highlights": [
       {
         "text": "次に、議事録で必ず盛り込むべき項目を挙げましょう。 ・日時 ・場所 ・参加者 ・本日のアジェンダ（論点・議題） 以上は当たり前ですね。重要なのは、次の４つです。 ・決まったこと ・決まらなかったこと（次に持ち越したこと） ・確認が必要なこと ・次回に向けてのＴＯＤＯ（誰がいつまでに）",
@@ -6288,7 +6288,7 @@ export const books = [
     "isbn": "9784761275075",
     "asin": "4761275073",
     "readDate": "2022/02/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5075/9784761275075.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5075/9784761275075.jpg",
     "highlights": [
       {
         "text": "取引や投資をするときは記録を取る。これは私がファンドで働き始めたとき、先輩にアドバイスされたことです。 たとえば、新たに株式を購入したら、購入した理由を書きます。それと同時に、前もって売る理由も書いておきます。「こうなったら売る」というルールを記しておくのです。 あるいは「こうなったら、自分の判断が間違っていたので売る」と損切りのルールも書いておきます。 これがないと、 自分が間違えても「自分は正しい」と都合よく解釈してしまいます。 そう、自分に嘘をついてしまうのです。結果、失敗から学ぶことができないので何度も同じ間違いをしてしまいますし、感情のコントロールもできなくなります。 書く方法は手書きである必要はありません。私はPCで管理していて、定期的に見返すようにしています。過去の自分と対話するといまの自分を客観視できるので、次の判断にも生かすことができます。",
@@ -6308,7 +6308,7 @@ export const books = [
     "isbn": "9784479393818",
     "asin": "4479393811",
     "readDate": "2022/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3818/9784479393818_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3818/9784479393818_1_2.jpg",
     "highlights": []
   },
   {
@@ -6319,7 +6319,7 @@ export const books = [
     "isbn": "9784798150727",
     "asin": "479815072X",
     "readDate": "2022/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0727/9784798150727.jpg",
     "highlights": []
   },
   {
@@ -6330,7 +6330,7 @@ export const books = [
     "isbn": "9784775972304",
     "asin": "4775972308",
     "readDate": "2022/01/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2304/9784775972304.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2304/9784775972304.jpg",
     "highlights": [
       {
         "text": "１．私はこの事業を理解しているか。 ２．企業を守る経営上の堀があるおかげで、今後五年から一〇年間、同じか類似した製品を売り続けることができるか。 ３．この業界は変化が激しいか。 ４．この企業には多様な顧客基盤があるか。 ５．固定資産が少ない事業か。 ６．景気循環に大きく影響される業界か。 ７．この企業にはまだ成長の余地があるか。 ８．過去一〇年間、好景気のときも不景気のときも常に利益を出し続けてきたか。 ９．営業利益率は安定して二桁を維持しているか。 10．利益率は競合他社よりも高いか。 11．一五％以上のＲＯＩＣ（投下資本利益率）を過去一〇年にわたって維持しているか。 12．一貫して二桁の成長率で、売上高と利益を伸ばしてきたか。 13．財務基盤がしっかりしているか。 14．経営陣は自社株をかなり保有しているか。 15．経営陣の収入は似た規模の他社と比べてどうか。 16．インサイダーはこの企業の株式を買っているか。 17．内在価値やＰＥＲ（株価収益率）で測った株価は妥当か。 18．歴史的に見て、現在のバリュエーションはどうか。 19．これまでの不況期に株価はどうだったか。 20．自分の調査にどれくらいの自信があるか。",
@@ -6350,7 +6350,7 @@ export const books = [
     "isbn": "9784106105760",
     "asin": "4106105764",
     "readDate": "2021/12/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5760/9784106105760_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5760/9784106105760_1_3.jpg",
     "highlights": []
   },
   {
@@ -6361,7 +6361,7 @@ export const books = [
     "isbn": "9784106101496",
     "asin": "4106101491",
     "readDate": "2021/12/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1496/9784106101496_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1496/9784106101496_1_2.jpg",
     "highlights": []
   },
   {
@@ -6372,7 +6372,7 @@ export const books = [
     "isbn": "9784046051578",
     "asin": "4046051574",
     "readDate": "2021/12/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1578/9784046051578_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1578/9784046051578_1_3.jpg",
     "highlights": []
   },
   {
@@ -6383,7 +6383,7 @@ export const books = [
     "isbn": "9784106100611",
     "asin": "4106100614",
     "readDate": "2021/12/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0611/9784106100611_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0611/9784106100611_1_2.jpg",
     "highlights": [
       {
         "text": "反権力を声高に言っている者は、つまり俺に権力をよこせと言っているに過ぎない。決して体制そのものに異を唱えているわけではない。反権力と反体制とは別ものです。 全共闘が反体制と言っていた時は、「これは反体制じゃない、反権力だ」と私は思っていました。あいつらが勝ったら結局、「体制側」と同じことをするんじゃないかと思っていたのです。もっと平たく言えば、「俺に金を寄越せ」と言っているだけなんじゃないかと思ったのです。",
@@ -6403,7 +6403,7 @@ export const books = [
     "isbn": "9784152100719",
     "asin": "4152100710",
     "readDate": "2021/12/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0719/9784152100719_1_17.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0719/9784152100719_1_17.jpg",
     "highlights": []
   },
   {
@@ -6414,7 +6414,7 @@ export const books = [
     "isbn": "9784798149493",
     "asin": "4798149497",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9493/9784798149493.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9493/9784798149493.jpg",
     "highlights": []
   },
   {
@@ -6425,7 +6425,7 @@ export const books = [
     "isbn": "9784140883853",
     "asin": "4140883855",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3853/9784140883853.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3853/9784140883853.jpg",
     "highlights": []
   },
   {
@@ -6436,7 +6436,7 @@ export const books = [
     "isbn": "9784152100702",
     "asin": "4152100702",
     "readDate": "2021/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0702/9784152100702_1_15.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0702/9784152100702_1_15.jpg",
     "highlights": []
   },
   {
@@ -6447,7 +6447,7 @@ export const books = [
     "isbn": "9784344985148",
     "asin": "4344985141",
     "readDate": "2021/11/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5148/9784344985148.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5148/9784344985148.jpg",
     "highlights": [
       {
         "text": "①何を言ってもいい。 ②人の言うことに対して否定的な態度をとらない。 ③発言せず、ただ聞いているだけでもいい。 ④お互いに問いかけるようにする。 ⑤知識ではなく、自分の経験にそくして話す。 ⑥話がまとまらなくてもいい。 ⑦意見が変わってもいい。 ⑧分からなくなってもいい。",
@@ -6467,7 +6467,7 @@ export const books = [
     "isbn": "9784297111731",
     "asin": "429711173X",
     "readDate": "2021/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1731/9784297111731.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1731/9784297111731.jpg",
     "highlights": []
   },
   {
@@ -6478,7 +6478,7 @@ export const books = [
     "isbn": "9784144071997",
     "asin": "4144071995",
     "readDate": "2021/11/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1997/9784144071997.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1997/9784144071997.jpg",
     "highlights": []
   },
   {
@@ -6489,7 +6489,7 @@ export const books = [
     "isbn": "9784757433151",
     "asin": "4757433158",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3151/9784757433151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3151/9784757433151.jpg",
     "highlights": []
   },
   {
@@ -6500,7 +6500,7 @@ export const books = [
     "isbn": "9784492533659",
     "asin": "4492533656",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3659/9784492533659.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3659/9784492533659.jpg",
     "highlights": [
       {
         "text": "経験より現金をもらうほうがうれしいと言っていたはずなのに、実験群のほうが満足度は高かったのだ。実際、かなり高かった。現金をもらうより楽しさが 28% 増しになり、記憶に 28% 強く残り、じっくり考える機会が 15% 増えた。これはディズニーランド旅行（大人の心は今も子どものままだ）でも個人で使うバウチャーでも同じだった。",
@@ -6524,7 +6524,7 @@ export const books = [
     "isbn": "9784487811892",
     "asin": "4487811899",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1892/9784487811892.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1892/9784487811892.jpg",
     "highlights": []
   },
   {
@@ -6535,7 +6535,7 @@ export const books = [
     "isbn": "9784344985612",
     "asin": "4344985613",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5612/9784344985612.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5612/9784344985612.jpg",
     "highlights": [
       {
         "text": "日本が欧米に追いつくことを目指していた時代には、情報を輸入することに大きな価値が置かれていたのも無理はなかったかもしれません。 しかし日本が先進国化した今、海外から情報を輸入して再現することの価値は低下しています。 それどころか、日本は他の多くの国と比べても少子化や高齢化、地域の過疎化といった問題の進行が速く、「課題先進国」とさえいわれているのです。従来のように海外をモデルとし、その成功事例を模倣するというやり方では、こうした課題に対する望ましい解決策にはたどり着けないでしょう。 この点、何か新たな問題が発生し議論が生じたとき、すぐに「海外ではどう対応しているのか」「他国でいい成功事例はないのか」などと考えてしまいがちな人は注意が必要かもしれません。 日本はさまざまな課題に関して、好むと好まざるとにかかわらずフロントランナーにならざるをえない状況にあるのです。日本企業や日本人が直接、課題に向き合う必要性が高まっていることを認識する必要があるでしょう。",
@@ -6575,7 +6575,7 @@ export const books = [
     "isbn": "9784844378785",
     "asin": "4844378783",
     "readDate": "2021/11/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8785/9784844378785.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8785/9784844378785.jpg",
     "highlights": []
   },
   {
@@ -6586,7 +6586,7 @@ export const books = [
     "isbn": "9784344841253",
     "asin": "4344841255",
     "readDate": "2021/11/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1253/9784344841253.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1253/9784344841253.jpg",
     "highlights": []
   },
   {
@@ -6597,7 +6597,7 @@ export const books = [
     "isbn": "9784822280536",
     "asin": "4822280535",
     "readDate": "2021/11/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82228053.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82228053.jpg",
     "highlights": [
       {
         "text": "安全と変更 ● 変更は、あらゆるプロジェクトの成功のために（ほかのたいていの物事においても）必要不可欠である。 ● 人は安全だとわからないと変更を受け入れない。安全が保証されていないと、リスクを避けようとする。 ● リスクを避けることは、それに伴う利益をも逃すことになるため、致命的である。 ● 人は、面と向かって脅されたときはもちろん、自分に対して不当に権力が行使されるかもしれないと思ったときにも、安全ではないと感じるようになる。",
@@ -6693,7 +6693,7 @@ export const books = [
     "isbn": "9784163914411",
     "asin": "4163914412",
     "readDate": "2021/11/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4411/9784163914411_1_5.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4411/9784163914411_1_5.jpg",
     "highlights": []
   },
   {
@@ -6704,7 +6704,7 @@ export const books = [
     "isbn": "9784150300142",
     "asin": "4150300143",
     "readDate": "2021/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784150300142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0142/9784150300142.jpg",
     "highlights": []
   },
   {
@@ -6715,7 +6715,7 @@ export const books = [
     "isbn": "9784086314398",
     "asin": "4086314398",
     "readDate": "2021/10/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4398/9784086314398_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4398/9784086314398_1_4.jpg",
     "highlights": []
   },
   {
@@ -6726,7 +6726,7 @@ export const books = [
     "isbn": "9784094530315",
     "asin": "4094530312",
     "readDate": "2021/09/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0315/9784094530315_1_3.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0315/9784094530315_1_3.jpg",
     "highlights": []
   },
   {
@@ -6737,7 +6737,7 @@ export const books = [
     "isbn": "9784152100436",
     "asin": "4152100435",
     "readDate": "2021/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784152100436_1_23.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784152100436_1_23.jpg",
     "highlights": [
       {
         "text": "１ 気候大災害を防ぐには、ゼロを達成しなければならない。 ２ 太陽光や風力といったすでにある手段を、もっと早く効果的に展開する必要がある。 ３ 目標達成を可能にするブレークスルーを生み出し展開しなければならない。",
@@ -6765,7 +6765,7 @@ export const books = [
     "isbn": "9784797395457",
     "asin": "4797395451",
     "readDate": "2021/09/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784797395457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5457/9784797395457.jpg",
     "highlights": []
   },
   {
@@ -6776,7 +6776,7 @@ export const books = [
     "isbn": "9784049133721",
     "asin": "4049133725",
     "readDate": "2021/09/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3721/9784049133721.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3721/9784049133721.jpg",
     "highlights": []
   },
   {
@@ -6787,7 +6787,7 @@ export const books = [
     "isbn": "9784062920278",
     "asin": "4062920271",
     "readDate": "2021/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0278/9784062920278.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0278/9784062920278.jpg",
     "highlights": [
       {
         "text": "戦争とは、要するに「暴力的手段による政治運動の一形態」にすぎない、とマハンは強調しているが、それはプロイセンの偉大な軍人・軍政家クラウゼヴィッツの古典『戦争論』の有名な命題──「戦争とは形を変えた政治である」──を思わせるテーゼである。",
@@ -6819,7 +6819,7 @@ export const books = [
     "isbn": "9784122022874",
     "asin": "4122022878",
     "readDate": "2021/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2874/9784122022874.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2874/9784122022874.jpg",
     "highlights": [
       {
         "text": "苦しみは忘れていく。楽しみはその時限りのもの。そして失ったものもまた、忘れていく。残ったものにだけすがりつき、残余の命を保っていこうとする。まるで現実そのものではないか。",
@@ -6835,7 +6835,7 @@ export const books = [
     "isbn": "9784795403604",
     "asin": "4795403600",
     "readDate": "2021/08/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3604/9784795403604.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3604/9784795403604.jpg",
     "highlights": []
   },
   {
@@ -6846,7 +6846,7 @@ export const books = [
     "isbn": "9784873119380",
     "asin": "4873119383",
     "readDate": "2021/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9380/9784873119380_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9380/9784873119380_1_2.jpg",
     "highlights": []
   },
   {
@@ -6857,7 +6857,7 @@ export const books = [
     "isbn": "9784781620046",
     "asin": "4781620043",
     "readDate": "2021/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0046/9784781620046_1_4.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0046/9784781620046_1_4.jpg",
     "highlights": []
   },
   {
@@ -6868,7 +6868,7 @@ export const books = [
     "isbn": "9784864108454",
     "asin": "4864108455",
     "readDate": "2021/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8454/9784864108454_1_2.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8454/9784864108454_1_2.jpg",
     "highlights": []
   },
   {
@@ -6879,7 +6879,7 @@ export const books = [
     "isbn": "9784151843518",
     "asin": "4151843515",
     "readDate": "2021/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3518/9784151843518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3518/9784151843518.jpg",
     "highlights": [
       {
         "text": "記号化された人物、人物の行動が構成する命題、その命題からなる公理系、そこにいくつかの推論規則が加わって──それが推理小説──にして形式体系──にしてメタ数学だよ！」",
@@ -6911,7 +6911,7 @@ export const books = [
     "isbn": "9784152095428",
     "asin": "4152095423",
     "readDate": "2021/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5428/9784152095428.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5428/9784152095428.jpg",
     "highlights": []
   },
   {
@@ -6922,7 +6922,7 @@ export const books = [
     "isbn": "9784152095244",
     "asin": "4152095245",
     "readDate": "2021/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784152095244.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5244/9784152095244.jpg",
     "highlights": []
   },
   {
@@ -6933,7 +6933,7 @@ export const books = [
     "isbn": "9784596551450",
     "asin": "4596551456",
     "readDate": "2021/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1450/9784596551450.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1450/9784596551450.jpg",
     "highlights": [
       {
         "text": "不便は「無消費」の表れであることが多い。無消費とはすなわち、潜在的な消費者が生活のなかのある部分を進歩させたいと切望しながら、それに応えるプロダクトを買うだけの余裕がない、あるいは、存在を知らなかったり、入手する方法がなかったりする状況を指す。",
@@ -6965,7 +6965,7 @@ export const books = [
     "isbn": "9784800010834",
     "asin": "4800010837",
     "readDate": "2021/06/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0834/9784800010834.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0834/9784800010834.jpg",
     "highlights": []
   },
   {
@@ -6976,7 +6976,7 @@ export const books = [
     "isbn": "9784065195031",
     "asin": "4065195039",
     "readDate": "2021/06/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5031/9784065195031.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5031/9784065195031.jpg",
     "highlights": [
       {
         "text": "成長を続けなければならないというのは、資本主義というシステムが必然的に持たざるを得ない一つの宿命だからである。 そしてそれゆえにこそ、温暖化問題なども抜本的な解決がなされないのである。 ではどうしてそんなことになってしまうのだろうか。その最も直接的な理由をずばりと言えば、それは「金利」というものがあるからである。",
@@ -7016,7 +7016,7 @@ export const books = [
     "isbn": "9784405071940",
     "asin": "4405071942",
     "readDate": "2021/05/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1940/9784405071940.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1940/9784405071940.jpg",
     "highlights": []
   },
   {
@@ -7027,7 +7027,7 @@ export const books = [
     "isbn": "9784094518566",
     "asin": "4094518568",
     "readDate": "2021/05/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8566/9784094518566.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8566/9784094518566.jpg",
     "highlights": [
       {
         "text": "まったく、髪型をころころ変えていいのは 冴えないあの御方だけだぞ、 不遜 な奴め。",
@@ -7043,7 +7043,7 @@ export const books = [
     "isbn": "9784797365818",
     "asin": "4797365811",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5818/9784797365818.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5818/9784797365818.jpg",
     "highlights": []
   },
   {
@@ -7054,7 +7054,7 @@ export const books = [
     "isbn": "9784799214671",
     "asin": "4799214675",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4671/9784799214671.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4671/9784799214671.jpg",
     "highlights": []
   },
   {
@@ -7065,7 +7065,7 @@ export const books = [
     "isbn": "9784094060843",
     "asin": "4094060847",
     "readDate": "2021/05/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0843/9784094060843.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0843/9784094060843.jpg",
     "highlights": []
   },
   {
@@ -7076,7 +7076,7 @@ export const books = [
     "isbn": "9784152100214",
     "asin": "4152100214",
     "readDate": "2021/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0214/9784152100214.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0214/9784152100214.jpg",
     "highlights": []
   },
   {
@@ -7087,7 +7087,7 @@ export const books = [
     "isbn": "9784152100207",
     "asin": "4152100206",
     "readDate": "2021/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0207/9784152100207.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0207/9784152100207.jpg",
     "highlights": []
   },
   {
@@ -7098,7 +7098,7 @@ export const books = [
     "isbn": "9784065224403",
     "asin": "4065224403",
     "readDate": "2021/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4403/9784065224403.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4403/9784065224403.jpg",
     "highlights": []
   },
   {
@@ -7109,7 +7109,7 @@ export const books = [
     "isbn": "9784086314121",
     "asin": "4086314126",
     "readDate": "2021/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4121/9784086314121.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4121/9784086314121.jpg",
     "highlights": []
   },
   {
@@ -7120,7 +7120,7 @@ export const books = [
     "isbn": "9784086313797",
     "asin": "4086313790",
     "readDate": "2021/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3797/9784086313797.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3797/9784086313797.jpg",
     "highlights": []
   },
   {
@@ -7131,7 +7131,7 @@ export const books = [
     "isbn": "9784086313568",
     "asin": "4086313561",
     "readDate": "2021/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3568/9784086313568.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3568/9784086313568.jpg",
     "highlights": []
   },
   {
@@ -7142,7 +7142,7 @@ export const books = [
     "isbn": "9784775930793",
     "asin": "4775930796",
     "readDate": "2021/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0793/9784775930793.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0793/9784775930793.jpg",
     "highlights": []
   },
   {
@@ -7153,7 +7153,7 @@ export const books = [
     "isbn": "9784866732008",
     "asin": "4866732008",
     "readDate": "2021/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2008/9784866732008.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2008/9784866732008.jpg",
     "highlights": []
   },
   {
@@ -7164,7 +7164,7 @@ export const books = [
     "isbn": "9784334752019",
     "asin": "4334752012",
     "readDate": "2021/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2019/9784334752019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2019/9784334752019.jpg",
     "highlights": []
   },
   {
@@ -7175,7 +7175,7 @@ export const books = [
     "isbn": "9784800010643",
     "asin": "4800010640",
     "readDate": "2021/04/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784800010643.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0643/9784800010643.jpg",
     "highlights": []
   },
   {
@@ -7186,7 +7186,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2021/04/25",
-    "thumnailImage": "https://tshop.r10s.jp/book/cabinet/0611/4910019750611.jpg",
+    "thumbnailImage": "https://tshop.r10s.jp/book/cabinet/0611/4910019750611.jpg",
     "highlights": []
   },
   {
@@ -7197,7 +7197,7 @@ export const books = [
     "isbn": "9784582766714",
     "asin": "4582766714",
     "readDate": "2021/04/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6714/9784582766714.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6714/9784582766714.jpg",
     "highlights": []
   },
   {
@@ -7208,7 +7208,7 @@ export const books = [
     "isbn": "9784094530049",
     "asin": "4094530045",
     "readDate": "2021/04/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0049/9784094530049.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0049/9784094530049.jpg",
     "highlights": []
   },
   {
@@ -7219,7 +7219,7 @@ export const books = [
     "isbn": "9784150314811",
     "asin": "4150314810",
     "readDate": "2021/04/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4811/9784150314811.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4811/9784150314811.jpg",
     "highlights": []
   },
   {
@@ -7230,7 +7230,7 @@ export const books = [
     "isbn": "9784798163680",
     "asin": "4798163686",
     "readDate": "2021/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784798163680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784798163680.jpg",
     "highlights": [
       {
         "text": "最初に、プロダクトオーナーが今回のスプリントで達成したい目的を明らかにします。次に、今回のスプリントでそれを達成するために完成させるプロダクトバックログ項目を選びます。選択する項目は並べ替えてあるプロダクトバックログの上位の項目になるのが一般的です。選択するプロダクトバックログの個数は、それぞれの項目の見積りのサイズや開発チームの過去の実績（これをベロシティと呼びます）、今回のスプリントで作業に使える時間（キャパシティと呼びます）などを踏まえて仮決定します。 また、検討した内容を踏まえて今回のスプリントの目標を簡潔にまとめておきます。これを スプリントゴール と呼び、開発チームがなぜここで選択したプロダクトバックログの項目を開発するのかを理解しやすくなります。",
@@ -7250,7 +7250,7 @@ export const books = [
     "isbn": "9784775972021",
     "asin": "4775972022",
     "readDate": "2021/04/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2021/9784775972021.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2021/9784775972021.jpg",
     "highlights": [
       {
         "text": "人ができる最高のことは、ほかの人がより多くを知る手助けをすることです。 ――チャーリー・マンガー（二〇一〇年のバークシャー・ハサウェイ株主総会）",
@@ -7306,7 +7306,7 @@ export const books = [
     "isbn": "9784845910564",
     "asin": "484591056X",
     "readDate": "2021/04/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0564/9784845910564.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0564/9784845910564.jpg",
     "highlights": []
   },
   {
@@ -7317,7 +7317,7 @@ export const books = [
     "isbn": "9784862807939",
     "asin": "4862807933",
     "readDate": "2021/04/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7939/9784862807939.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7939/9784862807939.jpg",
     "highlights": []
   },
   {
@@ -7328,7 +7328,7 @@ export const books = [
     "isbn": "9784103145349",
     "asin": "410314534X",
     "readDate": "2021/04/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5349/9784103145349.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5349/9784103145349.jpg",
     "highlights": [
       {
         "text": "フレドリック・ブラウンの「電獣ヴァヴェリ」は星新一が翻訳して「ＳＦマガジン」に掲載した。地球にやってきた電気を食べる電波生物ヴァヴェリのためにすべての電気製品が使えなくなった世界。電気がなくなればヴァヴェリはいなくなるのだが、油断して電気を使うと彼らはすぐにやってきてその僅かな電気を食べてしまう。かくて社会は原始時代に戻る。輸送手段は蒸気機関車と馬車にとって代り、テレビも映画もない世界で演劇とコンサートが主流となり、燃料としてはガスが使われ、活字は手で組まれて植字機と印刷機は蒸気機関を使うことになる。そして主人公が雨の夜に稲妻を恋しがっている場面で小説は終る。こいつはまるで新型コロナではないか。感染者が一人になっても彼らはそこにいるのだ。われわれもまた、パーティや大宴会を恋しがりながら残りの生を終えるのであろうか。このコロナ騒動が終ったあとの世界はいったいどんな世界なのか。以前の世界に戻るのだろうか。あるいはそれは今までわれわれが想像もしなかったような未知の世界なのだろうか。",
@@ -7344,7 +7344,7 @@ export const books = [
     "isbn": "9784140841419",
     "asin": "4140841419",
     "readDate": "2021/04/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1408/14084141.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1408/14084141.jpg",
     "highlights": []
   },
   {
@@ -7355,7 +7355,7 @@ export const books = [
     "isbn": "9784480688767",
     "asin": "4480688765",
     "readDate": "2021/03/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8767/9784480688767.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8767/9784480688767.jpg",
     "highlights": [
       {
         "text": "重要なことは、先ほどのふたつの作品には一二〇〇年以上もの時間的隔たりがあることと、描かれた地域も技法もなにもかも異なる点です。しかしそれでもなお、描かれた人物の容貌と服装、そしてなにより鍵という特徴的なアイテムによって、彼がペテロであることを観る者は理解できるのです。こうした、固体認識のための「属性」、あるいはそれを示す要素を「アトリビュート」と呼びます。仏教用語から来た「 持物」と訳されることもあります。",
@@ -7371,7 +7371,7 @@ export const books = [
     "isbn": "9784908655142",
     "asin": "4908655146",
     "readDate": "2021/03/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5142/9784908655142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5142/9784908655142.jpg",
     "highlights": []
   },
   {
@@ -7382,7 +7382,7 @@ export const books = [
     "isbn": "9784908655074",
     "asin": "4908655073",
     "readDate": "2021/03/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5074/9784908655074.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5074/9784908655074.jpg",
     "highlights": []
   },
   {
@@ -7393,7 +7393,7 @@ export const books = [
     "isbn": "9784151300080",
     "asin": "4151300082",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130008.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130008.jpg",
     "highlights": []
   },
   {
@@ -7404,7 +7404,7 @@ export const books = [
     "isbn": "9784142231140",
     "asin": "4142231146",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1140/9784142231140.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1140/9784142231140.jpg",
     "highlights": [
       {
         "text": "私は、人それぞれの答えでよい領域と、「だれもがこう考えるしかない」という意味で共有できる領域とがあると考えています。 たとえば、「私はどうやって生きるべきか、どんな人生でありたいか」という生き方の問いはどうでしょうか。これについては、最終的に「人それぞれ」で決めていくしかありません。答えがひとつに決められたら、自由がなくなってしまいますから。",
@@ -7440,7 +7440,7 @@ export const books = [
     "isbn": "9784862762580",
     "asin": "4862762581",
     "readDate": "2021/03/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2580/9784862762580.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2580/9784862762580.jpg",
     "highlights": [
       {
         "text": "学習とはつまり理解のプロセス、メソッド、体系なのである。学習とは一つのことへの集中と計画性と内省をともなう活動であり、学習の方法がわかれば習得の度合いと効果は大きく上がる。",
@@ -7476,7 +7476,7 @@ export const books = [
     "isbn": "9784862464019",
     "asin": "4862464017",
     "readDate": "2021/03/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784862464019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784862464019.jpg",
     "highlights": []
   },
   {
@@ -7487,7 +7487,7 @@ export const books = [
     "isbn": "9784314001472",
     "asin": "431400147X",
     "readDate": "2021/03/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1472/9784314001472.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1472/9784314001472.jpg",
     "highlights": []
   },
   {
@@ -7498,7 +7498,7 @@ export const books = [
     "isbn": "9784336070999",
     "asin": "4336070997",
     "readDate": "2021/03/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0999/9784336070999.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0999/9784336070999.jpg",
     "highlights": []
   },
   {
@@ -7509,7 +7509,7 @@ export const books = [
     "isbn": "9784049129021",
     "asin": "4049129027",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9021/9784049129021.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9021/9784049129021.jpg",
     "highlights": []
   },
   {
@@ -7520,7 +7520,7 @@ export const books = [
     "isbn": "9784798124704",
     "asin": "4798124702",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4704/9784798124704.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4704/9784798124704.jpg",
     "highlights": [
       {
         "text": "ビューの使用は、原則として1段にとどめておくようにしましょう。システムの世界には、「過度に複雑な作りはシステムをダメにする」という思想があります。この思想を表現するスローガンを「 KISSの原則」と言います。それは次のようなものです。 勘どころ 58 Keep It Simple, Stupid.（単純にしておけ、このバカ）",
@@ -7536,7 +7536,7 @@ export const books = [
     "isbn": "9784041003053",
     "asin": "4041003059",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3053/9784041003053.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3053/9784041003053.jpg",
     "highlights": []
   },
   {
@@ -7547,7 +7547,7 @@ export const books = [
     "isbn": "9784041002636",
     "asin": "404100263X",
     "readDate": "2021/02/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2636/9784041002636.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2636/9784041002636.jpg",
     "highlights": []
   },
   {
@@ -7558,7 +7558,7 @@ export const books = [
     "isbn": "9784750516509",
     "asin": "4750516503",
     "readDate": "2021/02/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6509/9784750516509.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6509/9784750516509.jpg",
     "highlights": []
   },
   {
@@ -7569,7 +7569,7 @@ export const books = [
     "isbn": "9784041001431",
     "asin": "4041001439",
     "readDate": "2021/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1431/9784041001431.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1431/9784041001431.jpg",
     "highlights": []
   },
   {
@@ -7580,7 +7580,7 @@ export const books = [
     "isbn": "9784044748531",
     "asin": "4044748535",
     "readDate": "2021/02/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8531/9784044748531.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8531/9784044748531.jpg",
     "highlights": []
   },
   {
@@ -7591,7 +7591,7 @@ export const books = [
     "isbn": "9784044748456",
     "asin": "4044748454",
     "readDate": "2021/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8456/9784044748456.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8456/9784044748456.jpg",
     "highlights": []
   },
   {
@@ -7602,7 +7602,7 @@ export const books = [
     "isbn": "9784040732718",
     "asin": "4040732715",
     "readDate": "2021/02/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2718/9784040732718.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2718/9784040732718.jpg",
     "highlights": []
   },
   {
@@ -7613,7 +7613,7 @@ export const books = [
     "isbn": "9784152099099",
     "asin": "4152099097",
     "readDate": "2021/02/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9099/9784152099099.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9099/9784152099099.jpg",
     "highlights": [
       {
         "text": "だが、この状況は、スマホのおかげでがらりと変わりつつある。というのも、スマホのカメラはこれまでの50mmレンズよりもはるかに広い画角を持っているからだ。 たとえばiPhoneXは水平方向の画角が65度で、ユーザーは後ろにさがらなくても、広い範囲を写真に収めることができる（しかしこれでもまだ、ある人気撮影テーマを撮るには広さが足りない。それが虹だ。虹は空に83度にわたって広がっているので〔虹の広がりの角度は太陽光線に対してプリズムとして働く水滴の屈折率から、色の違いによる広がりはあるが、半径約42度と決まっているため、全体を見渡したときの画角は約83～84度〕、iPhoneのフレームに収まるにはほんの少し広すぎる）。 このような広角レンズは、今後ますます普及するのではないだろうか。というのも、スマホのユーザーたちは、生活のさまざまな場面を自然に見えるように撮影したり、大勢が一度に写るような自撮りをしたいと思っているからだ。従来の50mmレンズのカメラを腕を伸ばして持った状態で自撮りをするのは難しい。そしてスマホでは撮影したあとで画像を簡単にクロップする（写真の不要な部分を切り取ること。従来トリミングと言われていたことに近い） ことができるので、スマホカメラの設計としてはやや「広すぎる」ぐらいにしておいて、ユーザーにズームなりクロップなりで好きな範囲の画像に加工してもらおうという考え方は理に 適っている。",
@@ -7629,7 +7629,7 @@ export const books = [
     "isbn": "9784775971949",
     "asin": "4775971948",
     "readDate": "2021/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1949/9784775971949.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1949/9784775971949.jpg",
     "highlights": [
       {
         "text": "●コストはできるだけ抑えることが大事。これは、リスク調整済み超過リターン（アルファ）を稼ぐ最も簡単な方法。 ●同じような特徴の異なる名前の銘柄を選ぶのではなく、企業の大きさ、投資スタイル、産業の集中度などに基づいて広範にわたって分散化することが重要。 ●市場を打ち負かすのは簡単ではない。これをやれる投資家はほとんどいない。したがって、市場ポートフォリオを複製するのは良い方法かもしれない。",
@@ -7681,7 +7681,7 @@ export const books = [
     "isbn": "9784151300813",
     "asin": "4151300813",
     "readDate": "2021/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130081.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1513/15130081.jpg",
     "highlights": [
       {
         "text": "ブランチは少し軽い口調でいった。 「人間なんて、まあ、そんなものよね。しがみついてた方がいいのに、投げだしちまったり、ほっとけばいいのに、引き受けたり。人生が本当と思えないくらい、美しく感じられて、うっとりしているかと思うと――たちまち地獄の苦しみと惨めさを経験する。物事がうまくいってるときは、そのままの状態がいつまでも続くような気がするけれど、そんなことは長続きしたためしがないんだし。どん底に沈みこんで、もういっぺん浮かびあがって息をつくことなんて、できそうにないと思っていると、そうでもない――人生ってそんなものじゃないの？」",
@@ -7701,7 +7701,7 @@ export const books = [
     "isbn": "9784142231164",
     "asin": "4142231162",
     "readDate": "2021/02/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1164/9784142231164.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1164/9784142231164.jpg",
     "highlights": [
       {
         "text": "ローマ時代のサルスティウス（＊４） は神話について「これらのことは決して起こったことがないが、いつも存在している」という有名な言葉を残していますが、昔話もこれと同じです。つまり昔話は、決して起こったことがないけれども、常に存在しているリアリティを持った物語なのです。だからこそ昔話はいつ読んでもおもしろいのです。",
@@ -7725,7 +7725,7 @@ export const books = [
     "isbn": "9784791703968",
     "asin": "4791703960",
     "readDate": "2021/02/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3968/9784791703968.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3968/9784791703968.jpg",
     "highlights": []
   },
   {
@@ -7736,7 +7736,7 @@ export const books = [
     "isbn": "9784142231096",
     "asin": "414223109X",
     "readDate": "2021/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1096/9784142231096.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1096/9784142231096.jpg",
     "highlights": []
   },
   {
@@ -7747,7 +7747,7 @@ export const books = [
     "isbn": "9784094082746",
     "asin": "4094082743",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2746/9784094082746.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2746/9784094082746.jpg",
     "highlights": []
   },
   {
@@ -7758,7 +7758,7 @@ export const books = [
     "isbn": "9784094082753",
     "asin": "4094082751",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2753/9784094082753.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2753/9784094082753.jpg",
     "highlights": []
   },
   {
@@ -7769,7 +7769,7 @@ export const books = [
     "isbn": "9784480020475",
     "asin": "4480020470",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0475/9784480020475.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0475/9784480020475.jpg",
     "highlights": [
       {
         "text": "新しいことを考えるのに、すべて自分の頭から絞り出せると思ってはならない。無から有を生ずるような思考などめったにおこるものではない。すでに存在するものを結びつけることによって、新しいものが生れる。",
@@ -7813,7 +7813,7 @@ export const books = [
     "isbn": "9784150307684",
     "asin": "4150307687",
     "readDate": "2021/01/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1503/15030768.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1503/15030768.jpg",
     "highlights": [
       {
         "text": "宇宙へ出ること、別の星に住まうこと。それは人類でなくなること、宇宙に咀嚼されていくことなのかもしれない。",
@@ -7829,7 +7829,7 @@ export const books = [
     "isbn": "9784142231201",
     "asin": "4142231200",
     "readDate": "2021/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784142231201.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784142231201.jpg",
     "highlights": []
   },
   {
@@ -7840,7 +7840,7 @@ export const books = [
     "isbn": "9784142231133",
     "asin": "4142231138",
     "readDate": "2021/01/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1133/9784142231133.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1133/9784142231133.jpg",
     "highlights": []
   },
   {
@@ -7851,7 +7851,7 @@ export const books = [
     "isbn": "9784309207520",
     "asin": "4309207529",
     "readDate": "2021/01/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7520/9784309207520.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7520/9784309207520.jpg",
     "highlights": []
   },
   {
@@ -7862,7 +7862,7 @@ export const books = [
     "isbn": "9784197203284",
     "asin": "4197203284",
     "readDate": "2021/01/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3284/9784197203284.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3284/9784197203284.jpg",
     "highlights": []
   },
   {
@@ -7873,7 +7873,7 @@ export const books = [
     "isbn": "9784003750117",
     "asin": "400375011X",
     "readDate": "2021/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0037/00375011.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0037/00375011.jpg",
     "highlights": []
   },
   {
@@ -7884,7 +7884,7 @@ export const books = [
     "isbn": "9784309464992",
     "asin": "4309464998",
     "readDate": "2021/01/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4992/9784309464992.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4992/9784309464992.jpg",
     "highlights": [
       {
         "text": "三つの巨大企業は「三位一体・運命の全能の仕掛け人」というものを作り出していた。こうして、コンピュータのプログラムが「運命の書」となり、政党も天候も仕組まれたものとなった。さらに、エド・ハンマー三世がこの世に生を享けたこと自体も、特定の注文の結果なのである。そして、その特定の注文とは、また別の注文の結果に他ならない。もはや誰も自発的に生まれることもできなければ、死ぬこともできない。同様に、一人で、独力で、最後まで何かを経験するなどということも、もはや誰にもできないのだ。なぜならば、人間の思考、恐怖、努力、痛み──このどれ一つをとっても、コンピュータによる代数計算の連鎖の小さな一コマだからである。完全に「仕組まれた」生活からは取引の対象とならない価値が排除されてしまう以上、罪と罰、道徳的責任、善と悪といった概念はもはや空疎なものに過ぎない。人間のあらゆる特徴を百パーセント利用し、それを確かなシステムの中に組み入れることによって作り出されたこのコンピュータ天国。ここに何か問題があるとすれば、それはただ一つ、この世界がまさにそんな風に仕組まれていることを住民たちが知らないということだろう。",
@@ -7904,7 +7904,7 @@ export const books = [
     "isbn": "9784480064424",
     "asin": "4480064427",
     "readDate": "2020/12/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4424/9784480064424.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4424/9784480064424.jpg",
     "highlights": []
   },
   {
@@ -7915,7 +7915,7 @@ export const books = [
     "isbn": "9784041098516",
     "asin": "4041098513",
     "readDate": "2020/12/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8516/9784041098516.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8516/9784041098516.jpg",
     "highlights": []
   },
   {
@@ -7926,7 +7926,7 @@ export const books = [
     "isbn": "9784532357856",
     "asin": "4532357853",
     "readDate": "2020/12/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7856/9784532357856.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7856/9784532357856.jpg",
     "highlights": []
   },
   {
@@ -7937,7 +7937,7 @@ export const books = [
     "isbn": "9784791703944",
     "asin": "4791703944",
     "readDate": "2020/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3944/9784791703944.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3944/9784791703944.jpg",
     "highlights": []
   },
   {
@@ -7948,7 +7948,7 @@ export const books = [
     "isbn": "9784873118161",
     "asin": "4873118166",
     "readDate": "2020/11/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8161/9784873118161.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8161/9784873118161.jpg",
     "highlights": []
   },
   {
@@ -7959,7 +7959,7 @@ export const books = [
     "isbn": "9784815602505",
     "asin": "4815602506",
     "readDate": "2020/11/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2505/9784815602505.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2505/9784815602505.jpg",
     "highlights": []
   },
   {
@@ -7970,7 +7970,7 @@ export const books = [
     "isbn": "9784296105359",
     "asin": "4296105353",
     "readDate": "2020/10/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5359/9784296105359.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5359/9784296105359.jpg",
     "highlights": [
       {
         "text": "みずほＦＧの経営トップは勘定系システムの刷新を現場任せにして、情報システムのことを理解せず、必要な資金や人員を投入する決断ができなかった。情報システムの開発に際して業務部門が情報システム部門に全面的に協力したり、関係各所の利害を調整したりできるようリーダーシップを発揮することも怠った。経営陣のＩＴ軽視、ＩＴ理解不足が、大規模システム障害の根本的な原因だった。",
@@ -7994,7 +7994,7 @@ export const books = [
     "isbn": "9784106108204",
     "asin": "4106108208",
     "readDate": "2020/10/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8204/9784106108204.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8204/9784106108204.jpg",
     "highlights": [
       {
         "text": "ここに述べた実際の声は、大きく次の二つにまとめられるかと思います。一つは自己への気づきであり、もう一つは自己評価の向上です。",
@@ -8018,7 +8018,7 @@ export const books = [
     "isbn": "9784140886298",
     "asin": "4140886293",
     "readDate": "2020/10/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6298/9784140886298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6298/9784140886298.jpg",
     "highlights": []
   },
   {
@@ -8029,7 +8029,7 @@ export const books = [
     "isbn": "9784122069299",
     "asin": "4122069297",
     "readDate": "2020/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9299/9784122069299.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9299/9784122069299.jpg",
     "highlights": [
       {
         "text": "現代の世界にすでに存在する膨大な悪意の量をさらにふやしたければ、ユダヤ人対アラブ人、ドイツ人対チェコ人、インド人対イギリス人、ロシア人対ポーランド人、イタリア人対ユーゴスラヴィア人対抗の、一連のサッカーの試合をおこない、どの試合もさまざまな人種のまじった十万の観客に見せるのが一番だろう。むろん、スポーツが国際的対立の大きな原因の一つだなどと言うつもりはない。大規模なスポーツは、それ自体で、ナショナリズムを生んだ諸原因の一つの結果にすぎないと思うまでだ。それでも、全国代表のレッテルを貼った十一人のチームを派遣して他国のチームと戦わせ、どこの国にも、負けたほうの国は「面目を失う」という気持ちを抱かせておいたのでは、事態がますます悪化することは確実である。",
@@ -8065,7 +8065,7 @@ export const books = [
     "isbn": "9784150118266",
     "asin": "4150118264",
     "readDate": "2020/10/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8266/9784150118266.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8266/9784150118266.jpg",
     "highlights": []
   },
   {
@@ -8076,7 +8076,7 @@ export const books = [
     "isbn": "9784003246016",
     "asin": "4003246012",
     "readDate": "2020/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784003246016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784003246016.jpg",
     "highlights": []
   },
   {
@@ -8087,7 +8087,7 @@ export const books = [
     "isbn": "9784297111533",
     "asin": "4297111535",
     "readDate": "2020/09/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1533/9784297111533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1533/9784297111533.jpg",
     "highlights": [
       {
         "text": "本を読んで「よかった」「よくなかった」だけでなく、本が自分にどのように変化を及ぼしたかを考え抜く。そして、それを言葉にしてアウトプットする。そうすることで、ほかの人が受けた変化に敏感になれる。その変化を軸に、自分が築いてきた壁や井戸を乗り越え、より広く遠いところまで行ける先達を見つけることができるのだ。 わたしが書評を続けているのは、だれかに読んでもらうためでもあるのはもちろんだが、それはむしろ副次的なものなのかもしれない。ほかのだれよりも、まず自分が読み、自分がどう変化したかに自覚的になるために書いているのだ。",
@@ -8115,7 +8115,7 @@ export const books = [
     "isbn": "9784086310857",
     "asin": "4086310856",
     "readDate": "2020/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0857/9784086310857.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0857/9784086310857.jpg",
     "highlights": []
   },
   {
@@ -8126,7 +8126,7 @@ export const books = [
     "isbn": "9784065138243",
     "asin": "4065138248",
     "readDate": "2020/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8243/9784065138243.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8243/9784065138243.jpg",
     "highlights": []
   },
   {
@@ -8137,7 +8137,7 @@ export const books = [
     "isbn": "9784065175361",
     "asin": "4065175364",
     "readDate": "2020/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5361/9784065175361.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5361/9784065175361.jpg",
     "highlights": []
   },
   {
@@ -8148,7 +8148,7 @@ export const books = [
     "isbn": "9784641164048",
     "asin": "4641164045",
     "readDate": "2020/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4048/9784641164048.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4048/9784641164048.jpg",
     "highlights": []
   },
   {
@@ -8159,7 +8159,7 @@ export const books = [
     "isbn": "9784041308257",
     "asin": "4041308259",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "人々は、やたらに未来に 薔薇色 の幻影を描く。だが、未来には 混沌 と崩壊しかないと悟った時、 過去に達成されたもの の中にこそ、 完璧 の域にまでみがき上げられた、たしかな法悦がある事に気づくだろう。──私のように……",
@@ -8175,7 +8175,7 @@ export const books = [
     "isbn": "9784860112608",
     "asin": "4860112601",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2608/9784860112608.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2608/9784860112608.jpg",
     "highlights": []
   },
   {
@@ -8186,7 +8186,7 @@ export const books = [
     "isbn": "9784480067241",
     "asin": "4480067248",
     "readDate": "2020/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7241/9784480067241.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7241/9784480067241.jpg",
     "highlights": []
   },
   {
@@ -8197,7 +8197,7 @@ export const books = [
     "isbn": "9784041065815",
     "asin": "404106581X",
     "readDate": "2020/08/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5815/9784041065815.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5815/9784041065815.jpg",
     "highlights": [
       {
         "text": "「これからの世界は、いったいどうなって行くんでしょうね？」 「さあ……」田口三佐は、ふいに妙な質問を出されて、ちょっと言葉につまった。 「どうなるって──あまりかわらんだろうね。もう戦争も大恐慌もなく……」 そういいかけて、彼はふとおどろいた。なるほど！──もう ずいぶん長い間、なにごともなくすごして来たのだ。何度か危機が叫ばれ、何度も寸前で回避された。大国の経済破綻が、世界市場をくつがえすかと思われた瞬間さえあったが、それも結局はやや長期にわたる不景気という形で回避された。──噂だけだが、アメリカの経済危機を、国際経済の舞台裏で、ソ連がすくってやったという話さえある。船でいえば「復元性」というやつが、世界全体に強くなってきつつあるみたいだ。これから先……。 「まあ、多少の振幅はあっても、わずかずつ、ゆっくりと、文明全体が進んで行くだろうね──それがどうしたんだい？」",
@@ -8257,7 +8257,7 @@ export const books = [
     "isbn": "9784150314439",
     "asin": "4150314438",
     "readDate": "2020/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4439/9784150314439.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4439/9784150314439.jpg",
     "highlights": []
   },
   {
@@ -8268,7 +8268,7 @@ export const books = [
     "isbn": "9784775941652",
     "asin": "4775941658",
     "readDate": "2020/08/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784775941652.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1652/9784775941652.jpg",
     "highlights": [
       {
         "text": "富の集中はごく自然な避けようのないことで、暴力的、あるいは平和的再配分によってときどき緩和される。この視点からとらえると、経済史とは、富の集中と強制的再配分という収縮・弛緩を繰り返す社会的有機体のゆっくりとした心臓の鼓動であるといえよう。",
@@ -8296,7 +8296,7 @@ export const books = [
     "isbn": "9784094518474",
     "asin": "4094518479",
     "readDate": "2020/08/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8474/9784094518474.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8474/9784094518474.jpg",
     "highlights": []
   },
   {
@@ -8307,7 +8307,7 @@ export const books = [
     "isbn": "9784094518252",
     "asin": "4094518258",
     "readDate": "2020/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784094518252.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784094518252.jpg",
     "highlights": []
   },
   {
@@ -8318,7 +8318,7 @@ export const books = [
     "isbn": "9784102114032",
     "asin": "4102114033",
     "readDate": "2020/08/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4032/9784102114032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4032/9784102114032.jpg",
     "highlights": [
       {
         "text": "天災というものは、事実、ざらにあることであるが、しかし、そいつがこっちの頭上に降りかかってきたときは、容易に天災とは信じられない。この世には、戦争と同じくらいの数のペストがあった。しかも、ペストや戦争がやってきたとき、人々はいつも同じくらい無用意な状態にあっ",
@@ -8362,7 +8362,7 @@ export const books = [
     "isbn": "9784622089230",
     "asin": "4622089238",
     "readDate": "2020/08/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9230/9784622089230.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9230/9784622089230.jpg",
     "highlights": []
   },
   {
@@ -8373,7 +8373,7 @@ export const books = [
     "isbn": "9784480065292",
     "asin": "4480065296",
     "readDate": "2020/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5292/9784480065292.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5292/9784480065292.jpg",
     "highlights": []
   },
   {
@@ -8384,7 +8384,7 @@ export const books = [
     "isbn": "9784001141276",
     "asin": "4001141272",
     "readDate": "2020/08/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1276/9784001141276.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1276/9784001141276.jpg",
     "highlights": [
       {
         "text": "ローマ時代のサルスティウス（＊４） は神話について「これらのことは決して起こったことがないが、いつも存在している」という有名な言葉を残していますが、昔話もこれと同じです。つまり昔話は、決して起こったことがないけれども、常に存在しているリアリティを持った物語なのです。だからこそ昔話はいつ読んでもおもしろいのです。",
@@ -8424,7 +8424,7 @@ export const books = [
     "isbn": "9784801923508",
     "asin": "480192350X",
     "readDate": "2020/08/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3508/9784801923508.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3508/9784801923508.jpg",
     "highlights": []
   },
   {
@@ -8435,7 +8435,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2020/07/26",
-    "thumnailImage": "https://m.media-amazon.com/images/I/511Dckd-UKL.jpg",
+    "thumbnailImage": "https://m.media-amazon.com/images/I/511Dckd-UKL.jpg",
     "highlights": []
   },
   {
@@ -8446,7 +8446,7 @@ export const books = [
     "isbn": "9784049125184",
     "asin": "4049125188",
     "readDate": "2020/07/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5184/9784049125184.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5184/9784049125184.jpg",
     "highlights": [
       {
         "text": "「昔がどうだからって今が否定されるわけじゃないし……逆に今がいいから、昔がなかったことになるわけでもないんだけどさ。 繫 がりなんてあるようでないから、今こうしてるのが全部だし。今 綺麗 なら、今は好きなんだ。そう言うしかない」",
@@ -8462,7 +8462,7 @@ export const books = [
     "isbn": "9784040732688",
     "asin": "4040732685",
     "readDate": "2020/07/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2688/9784040732688.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2688/9784040732688.jpg",
     "highlights": []
   },
   {
@@ -8473,7 +8473,7 @@ export const books = [
     "isbn": "9784150314064",
     "asin": "4150314063",
     "readDate": "2020/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4064/9784150314064.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4064/9784150314064.jpg",
     "highlights": [
       {
         "text": "「『人生』という名前のゲームだ」と彼は答えた。「あるいは、『ゲーム』という名の人生だ」",
@@ -8509,7 +8509,7 @@ export const books = [
     "isbn": "9784150314057",
     "asin": "4150314055",
     "readDate": "2020/07/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4057/9784150314057.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4057/9784150314057.jpg",
     "highlights": [
       {
         "text": "なかった。サルはこの壮大な茶番を通じて、ある重要な真理を強く認識した。結局のところ、権力を握った者がすべてのルールを決めるのだ。サッカーの試合をしていたら、審判が「ゴールを決めるな」と命令してくる。審判に反抗してゴールを決めた選手は退場させられ、ゴールは無効にされる。結果的に、誰もゴールを決めようとはしなくなる。試合終了。五対〇、シハヌークの勝ち。いったいどうすればいい？ 答えは簡単だ。自分たちがルールを支配すればいい。選挙の顛末を受けて、カンボジア共産党は即座に合法部門の撤廃を決めた。権力者の定めたルールに従ってフェアプレイを行っても絶対に勝つことはできない。相手がルールを変更することで勝利を盤石にしようとするならば、自分たちもルールを逸脱してそれに応じなければならない。そのために手段を選んでいる場合ではない。残念ながら、革命が闘争であるという格言は正しい。驚くほど正しい。",
@@ -8541,7 +8541,7 @@ export const books = [
     "isbn": "9784065194287",
     "asin": "4065194288",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4287/9784065194287.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4287/9784065194287.jpg",
     "highlights": []
   },
   {
@@ -8552,7 +8552,7 @@ export const books = [
     "isbn": "9784150314415",
     "asin": "4150314411",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784150314415.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4415/9784150314415.jpg",
     "highlights": []
   },
   {
@@ -8563,7 +8563,7 @@ export const books = [
     "isbn": "9784150314408",
     "asin": "4150314403",
     "readDate": "2020/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784150314408.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784150314408.jpg",
     "highlights": []
   },
   {
@@ -8574,7 +8574,7 @@ export const books = [
     "isbn": "9784122018334",
     "asin": "4122018331",
     "readDate": "2020/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8334/9784122018334.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8334/9784122018334.jpg",
     "highlights": [
       {
         "text": "大東亜戦争における諸作戦の失敗を、組織としての日本軍の失敗ととらえ直し、これを現代の組織にとっての教訓、あるいは反面教師として活用することが、本書の最も大きなねらいである。",
@@ -8622,7 +8622,7 @@ export const books = [
     "isbn": "9784041085219",
     "asin": "4041085217",
     "readDate": "2020/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5219/9784041085219.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5219/9784041085219.jpg",
     "highlights": []
   },
   {
@@ -8633,7 +8633,7 @@ export const books = [
     "isbn": "9784003278512",
     "asin": "4003278518",
     "readDate": "2020/06/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8512/9784003278512.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8512/9784003278512.jpg",
     "highlights": []
   },
   {
@@ -8644,7 +8644,7 @@ export const books = [
     "isbn": "9784049128963",
     "asin": "4049128969",
     "readDate": "2020/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8963/9784049128963.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8963/9784049128963.jpg",
     "highlights": []
   },
   {
@@ -8655,7 +8655,7 @@ export const books = [
     "isbn": "9784108310032",
     "asin": "4108310039",
     "readDate": "2020/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/9784108310032.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/9784108310032.jpg",
     "highlights": []
   },
   {
@@ -8666,7 +8666,7 @@ export const books = [
     "isbn": "9784065197035",
     "asin": "4065197031",
     "readDate": "2020/05/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7035/9784065197035.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7035/9784065197035.jpg",
     "highlights": []
   },
   {
@@ -8677,7 +8677,7 @@ export const books = [
     "isbn": "9784094518467",
     "asin": "4094518460",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8467/9784094518467.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8467/9784094518467.jpg",
     "highlights": []
   },
   {
@@ -8688,7 +8688,7 @@ export const books = [
     "isbn": "9784094518450",
     "asin": "4094518452",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8450/9784094518450.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8450/9784094518450.jpg",
     "highlights": []
   },
   {
@@ -8699,7 +8699,7 @@ export const books = [
     "isbn": "9784094518368",
     "asin": "4094518363",
     "readDate": "2020/05/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8368/9784094518368.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8368/9784094518368.jpg",
     "highlights": []
   },
   {
@@ -8710,7 +8710,7 @@ export const books = [
     "isbn": "9784041095430",
     "asin": "4041095433",
     "readDate": "2020/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5430/9784041095430.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5430/9784041095430.jpg",
     "highlights": []
   },
   {
@@ -8721,7 +8721,7 @@ export const books = [
     "isbn": "9784094518351",
     "asin": "4094518355",
     "readDate": "2020/05/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8351/9784094518351.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8351/9784094518351.jpg",
     "highlights": []
   },
   {
@@ -8732,7 +8732,7 @@ export const books = [
     "isbn": "9784044003678",
     "asin": "404400367X",
     "readDate": "2020/03/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9784044003678.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9784044003678.jpg",
     "highlights": [
       {
         "text": "蚊にとっておあつらえ向きの増殖環境も増やしてしまった。舗装の穴、植木鉢の受け皿、詰まった雨どい、よどんだドブなど身辺で水たまりは多い。ヒトスジシマカは、大さじ一杯ほどの水でも卵を産むことができる。昔の人は墓参りのときに、花入れに一〇円玉を入れて帰った。こうすると水の中に銅のイオンが溶け出して、ボウフラが生きられないからだ。こうした先人の知恵も継承されなくなった。",
@@ -8756,7 +8756,7 @@ export const books = [
     "isbn": "9784480683540",
     "asin": "4480683542",
     "readDate": "2020/02/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3540/9784480683540.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3540/9784480683540.jpg",
     "highlights": []
   },
   {
@@ -8767,7 +8767,7 @@ export const books = [
     "isbn": "9784087816846",
     "asin": "4087816842",
     "readDate": "2020/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784087816846.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6846/9784087816846.jpg",
     "highlights": []
   },
   {
@@ -8778,7 +8778,7 @@ export const books = [
     "isbn": "9784150314156",
     "asin": "4150314152",
     "readDate": "2020/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4156/9784150314156.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4156/9784150314156.jpg",
     "highlights": []
   },
   {
@@ -8789,7 +8789,7 @@ export const books = [
     "isbn": "9784049128505",
     "asin": "4049128500",
     "readDate": "2020/02/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784049128505.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8505/9784049128505.jpg",
     "highlights": []
   },
   {
@@ -8800,7 +8800,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2020/02/08",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51w2s0SQ%2BgL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51w2s0SQ%2BgL.jpg",
     "highlights": []
   },
   {
@@ -8811,7 +8811,7 @@ export const books = [
     "isbn": "9784062919357",
     "asin": "4062919354",
     "readDate": "2020/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9357/9784062919357.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9357/9784062919357.jpg",
     "highlights": []
   },
   {
@@ -8822,7 +8822,7 @@ export const books = [
     "isbn": "9784939103407",
     "asin": "4939103404",
     "readDate": "2020/01/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9391/93910340.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9391/93910340.jpg",
     "highlights": [
       {
         "text": "まず最初に言っておきたいのは、一つのトレード・アイデアに対しては常に資金の五パーセント以下の金しか使わないということだね。そうすれば二〇回君が間違ったとしても大丈夫だし、全部やられるまでには随分時間が稼げる。強調したいのは一つのアイデアに五パーセントということだよ。だからもし君が二つの穀物の商品でそれぞれロングしていても、その二つの商品に相関関係があるのであれば一つのアイデアと考えるべきだ。",
@@ -8854,7 +8854,7 @@ export const books = [
     "isbn": "9784041032190",
     "asin": "4041032199",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2190/9784041032190.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2190/9784041032190.gif",
     "highlights": []
   },
   {
@@ -8865,7 +8865,7 @@ export const books = [
     "isbn": "9784040822587",
     "asin": "4040822587",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2587/9784040822587.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2587/9784040822587.jpg",
     "highlights": []
   },
   {
@@ -8876,7 +8876,7 @@ export const books = [
     "isbn": "9784094516876",
     "asin": "4094516875",
     "readDate": "2020/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6876/9784094516876.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6876/9784094516876.jpg",
     "highlights": []
   },
   {
@@ -8887,7 +8887,7 @@ export const books = [
     "isbn": "9784065124987",
     "asin": "4065124980",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4987/9784065124987.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4987/9784065124987.jpg",
     "highlights": []
   },
   {
@@ -8898,7 +8898,7 @@ export const books = [
     "isbn": "9784040731025",
     "asin": "4040731026",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1025/9784040731025.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1025/9784040731025.jpg",
     "highlights": [
       {
         "text": "誰に臆することなく自分の意見を述べられる＝自己中、空気読めない 他人の意見を柔軟に受け入れられる＝どうでもいい、人に興味がない",
@@ -8918,7 +8918,7 @@ export const books = [
     "isbn": "9784061497658",
     "asin": "4061497650",
     "readDate": "2020/01/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0614/06149765.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0614/06149765.jpg",
     "highlights": []
   },
   {
@@ -8929,7 +8929,7 @@ export const books = [
     "isbn": "9784094517149",
     "asin": "4094517146",
     "readDate": "2020/01/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7149/9784094517149.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7149/9784094517149.jpg",
     "highlights": []
   },
   {
@@ -8940,7 +8940,7 @@ export const books = [
     "isbn": "9784775949061",
     "asin": "4775949063",
     "readDate": "2020/01/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9061/9784775949061.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9061/9784775949061.jpg",
     "highlights": [
       {
         "text": "１．ポーカーのさまざまな現実を理解し受け入れる ２．長期的視野でプレイする ３．金を儲けることよりも正しい決断を下すことを優先させる ４．金への執着を捨てる ５．自尊心を持ち込まない ６．あらゆる感情を決断から排除する ７．分析と改善のサイクルを継続的に繰り返す 上記",
@@ -8956,7 +8956,7 @@ export const books = [
     "isbn": "9784798615202",
     "asin": "479861520X",
     "readDate": "2020/01/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784798615202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784798615202.jpg",
     "highlights": []
   },
   {
@@ -8967,7 +8967,7 @@ export const books = [
     "isbn": "9784065151624",
     "asin": "4065151627",
     "readDate": "2020/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1624/9784065151624.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1624/9784065151624.jpg",
     "highlights": []
   },
   {
@@ -8978,7 +8978,7 @@ export const books = [
     "isbn": "9784866470863",
     "asin": "4866470860",
     "readDate": "2019/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0863/9784866470863.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0863/9784866470863.jpg",
     "highlights": []
   },
   {
@@ -8989,7 +8989,7 @@ export const books = [
     "isbn": "9784309464084",
     "asin": "4309464084",
     "readDate": "2019/12/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4084/9784309464084.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4084/9784309464084.jpg",
     "highlights": [
       {
         "text": "本書のタイトルからすれば皇子ハムレット、点、線、平面、ｎ次元の多平面と多容積、あらゆる総称語、そしておそらくわれわれ個々の人間や神を入れることが正当化されるだろう。要するに──一切の事柄の総計、宇宙である。しかしながらわれわれは、《想像の存在》という言葉が即座に喚起するものにのみ限ることとした。時と空間を通して人間の想像力によって考えられた奇妙な創造物の小冊子を編んだのである。",
@@ -9025,7 +9025,7 @@ export const books = [
     "isbn": "9784873118864",
     "asin": "4873118867",
     "readDate": "2019/12/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8864/9784873118864.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8864/9784873118864.jpg",
     "highlights": []
   },
   {
@@ -9036,7 +9036,7 @@ export const books = [
     "isbn": "9784102159743",
     "asin": "4102159746",
     "readDate": "2019/12/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9743/9784102159743.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9743/9784102159743.jpg",
     "highlights": []
   },
   {
@@ -9047,7 +9047,7 @@ export const books = [
     "isbn": "9784044090012",
     "asin": "4044090017",
     "readDate": "2019/12/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0012/9784044090012.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0012/9784044090012.jpg",
     "highlights": [
       {
         "text": "道徳なき商業における拝金主義と、空理空論の道徳論者の商業 蔑視 と、この両者に引き裂かれている実情に対して、渋沢は〈現実社会において生きることのできる道徳に基づいた商業〉をめざしたのである。それを可能とする接着剤、商業と道徳との接着剤として、渋沢が選んだのが儒教であった。",
@@ -9075,7 +9075,7 @@ export const books = [
     "isbn": "9784062880701",
     "asin": "4062880709",
     "readDate": "2019/12/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0701/9784062880701.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0701/9784062880701.jpg",
     "highlights": []
   },
   {
@@ -9086,7 +9086,7 @@ export const books = [
     "isbn": "9784894563810",
     "asin": "4894563819",
     "readDate": "2019/12/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3810/9784894563810.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3810/9784894563810.jpg",
     "highlights": [
       {
         "text": "かつての目標 ──長い長い間人類の目標だったものが、突然達成されはじめ出したら……じゃいったい、その時期にうまれてきた世代は、今度は 何を 目標にしたらいいんだ？ こいつは大問題だと思わないかい？──ねえ、ミナ、ぼくたちは、時間というエスカレーターにのっけられて、自動的にこの時代の中に押し上げられて行く。ところが、この華やかで上に行くほどすばらしい栄光で光り輝いているエスカレーターの、 金色 燦然 たる頂上のむこうには──何もないんだ。 光と喜びにみちた虚無があるだけなんだ！」 「すると、あとはまっさかさまってわけ？」ミナは、かすかに苦笑するように小首をかしげて、その深い、 菫色の眼を、ぼくにむけた。 「ちがうよ、ミナ。君は虚無ってものの性質をとりちがえているよ。虚無というやつは── おちて行くべき奈落 さえないんだ。すべてがあり、そしてささえるものはなにもない……」 「私は、別にいまが〝黄金時代のはじまり〟だなんて、思っちゃいないのよ」ミナは、ベンチの傍でたちどまった。「すわりましょうよ、タツヤ」 ぼくたちは、ペンキがほとんどはげおちたベンチに腰をおろした。 木肌 が 陽ざしをすってあたたかかった。 あたたかく、 満ち足りた金色の虚無……。",
@@ -9110,7 +9110,7 @@ export const books = [
     "isbn": "9784041417034",
     "asin": "4041417031",
     "readDate": "2019/12/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7034/9784041417034.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7034/9784041417034.jpg",
     "highlights": []
   },
   {
@@ -9121,7 +9121,7 @@ export const books = [
     "isbn": "9784046043931",
     "asin": "4046043938",
     "readDate": "2019/12/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3931/9784046043931.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3931/9784046043931.jpg",
     "highlights": [
       {
         "text": "まずは新渡戸稲造の談話からです。新渡戸が展開した野球批判はおおよそ次のようなものでした。 ・野球は 賤技 なり剛勇の気なし。 ・相手を常にペテンにかけよう、計略に陥れよう、 塁 を盗もうなど、眼を四方八面に配り神経を鋭くしてやる遊びである。 ・ゆえに米人には適するが英人やドイツ人には決して出来ない。 ・英国の国技たる 蹴球※７ のように鼻が曲がっても顎骨が歪んでもボールに嚙り付いているような勇剛な遊びは米人には出来ない。 ※７ ここではラグビーを指す。 ・日本の野球選手は礼儀を知らない。過日の軽井沢で行われた外国人との試合において不調法な野次を飛ばして試合が中止になったという。 ・海外では「スポーツマンライク」と言って非常に礼儀正しいことであるが、これを日本語に訳して「運動家らしい」と言うとなんというか礼儀も知らぬ 破落漢 の様に聞こえるのも日本の運動家の品性下劣から来ている。",
@@ -9145,7 +9145,7 @@ export const books = [
     "isbn": "9784800293671",
     "asin": "4800293677",
     "readDate": "2019/12/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3671/9784800293671.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3671/9784800293671.jpg",
     "highlights": []
   },
   {
@@ -9156,7 +9156,7 @@ export const books = [
     "isbn": "9784152098993",
     "asin": "4152098996",
     "readDate": "2019/12/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784152098993.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8993/9784152098993.jpg",
     "highlights": []
   },
   {
@@ -9167,7 +9167,7 @@ export const books = [
     "isbn": "9784150505424",
     "asin": "415050542X",
     "readDate": "2019/12/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5424/9784150505424.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5424/9784150505424.jpg",
     "highlights": [
       {
         "text": "定期的に運動を始めると、それがたとえ週に１回といった少ない回数でも、他の運動とは関係のない部分も、知らないうちに変わってくる。代表的なのが、運動を始めると食生活が向上し、さらに職場での生産性も上がるという現象だ。喫煙量が減り、同僚や家族に対しても寛大になる。クレジットカードを使う回数が減り、ストレスも軽減する。",
@@ -9187,7 +9187,7 @@ export const books = [
     "isbn": "9784791713882",
     "asin": "4791713885",
     "readDate": "2019/11/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3882/9784791713882.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3882/9784791713882.jpg",
     "highlights": []
   },
   {
@@ -9198,7 +9198,7 @@ export const books = [
     "isbn": "9784152093974",
     "asin": "4152093978",
     "readDate": "2019/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3974/9784152093974.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3974/9784152093974.jpg",
     "highlights": [
       {
         "text": "株価が正規分布になるのではなく、 収益率 が正規分布になっているのだ（＊",
@@ -9238,7 +9238,7 @@ export const books = [
     "isbn": "9784791703791",
     "asin": "4791703790",
     "readDate": "2019/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784791703791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784791703791.jpg",
     "highlights": []
   },
   {
@@ -9249,7 +9249,7 @@ export const books = [
     "isbn": "9784873115658",
     "asin": "4873115655",
     "readDate": "2019/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5658/9784873115658.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5658/9784873115658.jpg",
     "highlights": []
   },
   {
@@ -9260,7 +9260,7 @@ export const books = [
     "isbn": "9784150116699",
     "asin": "4150116695",
     "readDate": "2019/11/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6699/9784150116699.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6699/9784150116699.jpg",
     "highlights": [
       {
         "text": "今日まで記憶される彼の唯一の作品は『シリンダーの救世主』 The Messiah of the Cylinder（一九一七）で、Ｈ・Ｇ・ウエルズの『睡眠者が目ざめる時』 When the Sleeper Wakes に応えて書いたアンチユートピア小説である（本文の中で、ウエルズの名が何度も言及される）。これには『一九八四年』の非常に印象的な予測がいくつも含まれているから、ジョージ・オーウェルがルッソー（・エマニュエル）の小説を読んだことは、まずまちがいないと思われる（このテーマは、きっと彼にアピールしたのだろう（ １））。",
@@ -9300,7 +9300,7 @@ export const books = [
     "isbn": "9784040724577",
     "asin": "4040724577",
     "readDate": "2019/11/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4577/9784040724577.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4577/9784040724577.jpg",
     "highlights": []
   },
   {
@@ -9311,7 +9311,7 @@ export const books = [
     "isbn": "9784041305263",
     "asin": "4041305268",
     "readDate": "2019/11/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130526.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130526.jpg",
     "highlights": []
   },
   {
@@ -9322,7 +9322,7 @@ export const books = [
     "isbn": "9784783725121",
     "asin": "4783725128",
     "readDate": "2019/11/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7837/78372512.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7837/78372512.jpg",
     "highlights": []
   },
   {
@@ -9333,7 +9333,7 @@ export const books = [
     "isbn": "9784040734026",
     "asin": "4040734025",
     "readDate": "2019/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4026/9784040734026.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4026/9784040734026.jpg",
     "highlights": []
   },
   {
@@ -9344,7 +9344,7 @@ export const books = [
     "isbn": "9784094517811",
     "asin": "4094517812",
     "readDate": "2019/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7811/9784094517811.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7811/9784094517811.jpg",
     "highlights": []
   },
   {
@@ -9355,7 +9355,7 @@ export const books = [
     "isbn": "9784166602513",
     "asin": "4166602519",
     "readDate": "2019/11/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2513/9784166602513.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2513/9784166602513.jpg",
     "highlights": [
       {
         "text": "よい入門書は、まず最初に「私たちは何を知らないのか」を問います。「私たちはなぜそのことを知らないままで今日まで済ませてこられたのか」を問います。 これは実にラディカルな問いかけです。 なぜ、私たちはあることを「知らない」のでしょう？ なぜ今日までそれを「知らずに」きたのでしょう。単に面倒くさかっただけなのでしょうか？ それは違います。私たちがあることを知らない理由はたいていの場合一つしかありません。 「知りたくない」からです。 より厳密に言えば「自分があることを『知りたくない』と思っていることを知りたくない」からです。 無知というのはたんなる知識の欠如ではありません。「知らずにいたい」というひたむきな努力の成果です。無知は怠惰の結果ではなく、勤勉の結果なのです。 噓だと思ったら、親が説教くさいことを言い始めた瞬間にふいと遠い目をする子どもの様子を思い出して下さい。",
@@ -9379,7 +9379,7 @@ export const books = [
     "isbn": "9784061490178",
     "asin": "4061490176",
     "readDate": "2019/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0178/9784061490178.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0178/9784061490178.jpg",
     "highlights": []
   },
   {
@@ -9390,7 +9390,7 @@ export const books = [
     "isbn": "9784822242978",
     "asin": "4822242978",
     "readDate": "2019/11/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224297.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224297.jpg",
     "highlights": [
       {
         "text": "幼年期の成長の効率を最大化するために最適な方法は、トレーディング日誌をつけることである。すべての取引内容を記録するだけでなく、そのトレーディングに関する見解、アイデア、その取引の結果を記録しなければならない。学んだ教訓を日誌に記録することによって、その教訓を決して無駄にしないようにしなければならない。この日誌は自分を映す鏡、また、自分がどこへ向かおうとしているかを示す地図となるのである。すべての経験、感情、思考を記録する習慣を身につけることによって、最終的には、壮年期に至る恒常的な成長を確保できる。第2の人生において、第1の人生での努力と苦労が日々のトレーディングに反映されるようになるのである。",
@@ -9406,7 +9406,7 @@ export const books = [
     "isbn": "9784040722009",
     "asin": "4040722000",
     "readDate": "2019/11/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2009/9784040722009.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2009/9784040722009.jpg",
     "highlights": []
   },
   {
@@ -9417,7 +9417,7 @@ export const books = [
     "isbn": "9784334034696",
     "asin": "4334034691",
     "readDate": "2019/11/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4696/9784334034696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4696/9784334034696.jpg",
     "highlights": []
   },
   {
@@ -9428,7 +9428,7 @@ export const books = [
     "isbn": "9784101016412",
     "asin": "4101016410",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6412/9784101016412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6412/9784101016412.jpg",
     "highlights": []
   },
   {
@@ -9439,7 +9439,7 @@ export const books = [
     "isbn": "9784046043436",
     "asin": "4046043431",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3436/9784046043436.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3436/9784046043436.jpg",
     "highlights": []
   },
   {
@@ -9450,7 +9450,7 @@ export const books = [
     "isbn": "9784041069691",
     "asin": "4041069696",
     "readDate": "2019/11/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9691/9784041069691.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9691/9784041069691.jpg",
     "highlights": [
       {
         "text": "日本、アメリカ、ヨーロッパの３つのマーケットのうち、時差の関係から月曜日に最初に市場が開くのは日本。 なので週末に世界的な事件が起きると、日本で最初に影響があらわれる。 イギリスのＥＵ離脱決定、トランプの勝利など、欧米の政治的な事件があると、まず大きく売られる。そのとき日本では売られすぎる傾向がある。 僕の経験からいえば、こういうときは 90％は逆張りで買っていい。 トランプの大統領選勝利のように、「今後どうなってしまうんだ？」という状況のときこそ逆張りだ。 もちろん、これは何か大事件が起きた場合の話。通常時にダウ先物が安くなっているからといって逆張りするのは、「上がっているときには買い」の原則に反する。 逆パターンで、週末にアメリカに好材料が出て、ダウ先物が４００くらい大きくプラスしているときに日経平均も爆上げしたら、空売りする。 だいたいすぐ戻る。",
@@ -9466,7 +9466,7 @@ export const books = [
     "isbn": "9784049121650",
     "asin": "4049121654",
     "readDate": "2019/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1650/9784049121650.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1650/9784049121650.jpg",
     "highlights": [
       {
         "text": "「昔がどうだからって今が否定されるわけじゃないし……逆に今がいいから、昔がなかったことになるわけでもないんだけどさ。 繫 がりなんてあるようでないから、今こうしてるのが全部だし。今 綺麗 なら、今は好きなんだ。そう言うしかない」",
@@ -9482,7 +9482,7 @@ export const books = [
     "isbn": "9784150117009",
     "asin": "4150117004",
     "readDate": "2019/10/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7009/9784150117009.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7009/9784150117009.jpg",
     "highlights": [
       {
         "text": "これから物語るのは、数年の前後はあってもだいたい第二次大戦から第三次大不況のあいだに落ちつく、あの悪夢の時代の実話である。",
@@ -9506,7 +9506,7 @@ export const books = [
     "isbn": "9784150413378",
     "asin": "4150413371",
     "readDate": "2019/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3378/9784150413378.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3378/9784150413378.jpg",
     "highlights": []
   },
   {
@@ -9517,7 +9517,7 @@ export const books = [
     "isbn": "9784040724607",
     "asin": "4040724607",
     "readDate": "2019/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4607/9784040724607.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4607/9784040724607.jpg",
     "highlights": []
   },
   {
@@ -9528,7 +9528,7 @@ export const books = [
     "isbn": "9784040729367",
     "asin": "4040729366",
     "readDate": "2019/10/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9367/9784040729367.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9367/9784040729367.jpg",
     "highlights": []
   },
   {
@@ -9539,7 +9539,7 @@ export const books = [
     "isbn": "9784040729350",
     "asin": "4040729358",
     "readDate": "2019/10/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9350/9784040729350.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9350/9784040729350.jpg",
     "highlights": []
   },
   {
@@ -9550,7 +9550,7 @@ export const books = [
     "isbn": "9784065170168",
     "asin": "4065170168",
     "readDate": "2019/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0168/9784065170168.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0168/9784065170168.jpg",
     "highlights": [
       {
         "text": "われわれがいま生きている「この社会」とは、どんな社会なのでしょうか。 「社会」というよく分からないものの情勢をさぐるために、従来「右／左」あるいは「保守／リベラル」という概念対が用いられてきました。「右」「左」「保守」「リベラル」というそれぞれの言葉の中身は、話し手の立場や文脈によってその都度、微妙に異なったりします。しかしまずは一般的に、「保守」あるいは「右」を「伝統や歴史を守って急激な社会変化を好まない傾向性」、「リベラル」あるいは「左」を「平等な社会を目指して社会を（ときに急進的に） 改革しようとする方向性」と理解するところから話をはじめましょう。",
@@ -9570,7 +9570,7 @@ export const books = [
     "isbn": "9784040721996",
     "asin": "4040721993",
     "readDate": "2019/10/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1996/9784040721996.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1996/9784040721996.jpg",
     "highlights": [
       {
         "text": "あとがきを書きながらも、自分の青春時代はいつだったかなと考えています。高校と大学は同じくらい楽しかったのですが、青春というワードを入れると高校の 頃 かな？ くだらない思い出でいっぱいです。教室でチョーク粉パーティーをして身体中カラフルで早退したり、 顧問 の自転車の空気キャップを 抜いてマンホールの中に 証拠 隠滅 したり、授業中にマリオ○ートで８人対戦してレインボーロードでめっちゃ身体が 傾いたり。 当時の自分からしたら 些細 なことなのでしょうが、こうやって思い出すとゴミみたいな 奴 だなと改めて実感します。でもゴミみたいなこと、今読んでる中高生の皆さんは進行形でやっているだろうし、大学生や社会人の方もやってきたはずです。否定させません、絶対やってます。赤の他人からしたらゴミみたいなのですが、当の本人たちにとっては、すげー楽しいですよね。芸人にとって鼻水はダイアモンドと同じです。だからこそ、今が青春の人たちって、すげー 羨ましいです。部活帰りにコンビニでたむろしている学生さんを見ると、ノスタルジックな気持ちになります。ベンチで初々しくも制服カップルが会話しているのを見たら、後ろからベンチを引っくり返したくなります。いや、これは僕が中高生時代から思ってることだから関係なさそうです。 青春時代は 戻ってきません。だからこそ僕は、自分ができなかった体験を補うべく書いているのかもしれません。カッコイイこと言ったなと思いましたが、最初に書こうと思ったジャンルはバトルものでした。 というわけで、今が青春だという方々は、思う存分に青春してください。凪木同様に青春なんか終わっちまったという方々は、たまに集まった友達と昔話に花を 咲かしたり、ガールズバーでチャンネーと会話したり、青春ラブコメを読んで過去補正… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -9586,7 +9586,7 @@ export const books = [
     "isbn": "9784334754099",
     "asin": "4334754090",
     "readDate": "2019/10/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4099/9784334754099.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4099/9784334754099.jpg",
     "highlights": []
   },
   {
@@ -9597,7 +9597,7 @@ export const books = [
     "isbn": "9784480084392",
     "asin": "4480084398",
     "readDate": "2019/10/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48008439.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48008439.jpg",
     "highlights": [
       {
         "text": "第一、功利的にいっても、いまあるヒトの脳というものを、手間暇かけて人工的に作ったところで、なんの得もない。ヒトの脳を作る必要などまったくない。そんなものなら、いまだって、それこそ腐るほどある。これは当り前のことだが、しばしば誤解を生じる点である。人工知能が人間を置き換えるというのは、単なる誤解に過ぎない。第一、機械というのは、ヒトの脳ほどいい加減なものではない。 それなら、ヒトの脳を置換するものはないか。それはもちろんある。あると思う。それはなにか。ヒトの脳を包含する脳である。",
@@ -9617,7 +9617,7 @@ export const books = [
     "isbn": "9784532197698",
     "asin": "4532197694",
     "readDate": "2019/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7698/9784532197698.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7698/9784532197698.jpg",
     "highlights": []
   },
   {
@@ -9628,7 +9628,7 @@ export const books = [
     "isbn": "9784041073261",
     "asin": "404107326X",
     "readDate": "2019/10/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3261/9784041073261.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3261/9784041073261.jpg",
     "highlights": [
       {
         "text": "「われわれの時代は、あまりにも理性を過大評価しているのかも知れんな……」テッドはにやにや笑った。「吸いこんだだけで、恍惚となる香りがあることを思うと、これから先は、〝古代の知恵〟である、フェロモンや向精神薬のことを、もっと考えなきゃいかんだろう。──人類の〝幸福〟のために……」",
@@ -9656,7 +9656,7 @@ export const books = [
     "isbn": "9784152098863",
     "asin": "4152098864",
     "readDate": "2019/09/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8863/9784152098863.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8863/9784152098863.jpg",
     "highlights": [
       {
         "text": "しかし、そうやって半ば暴力的に規範となる文化を取り入れることによって、それまで見えていなかったものが見えてくるのだ。なんとなくカッコ良さそうだからという理由で、理解できないフランス映画を観る。賢く見られたいからという理由で、ニーチェやマルクスやピケティを読む。人気だからという理由で、日本画やモダンアートの展覧会へ行く。そうやって、人々は本来興味のなかったものに興味を持つ。",
@@ -9676,7 +9676,7 @@ export const books = [
     "isbn": "9784103145332",
     "asin": "4103145331",
     "readDate": "2019/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5332/9784103145332.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5332/9784103145332.jpg",
     "highlights": []
   },
   {
@@ -9687,7 +9687,7 @@ export const books = [
     "isbn": "9784532197681",
     "asin": "4532197686",
     "readDate": "2019/09/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7681/9784532197681.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7681/9784532197681.jpg",
     "highlights": []
   },
   {
@@ -9698,7 +9698,7 @@ export const books = [
     "isbn": "9784150505448",
     "asin": "4150505446",
     "readDate": "2019/09/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5448/9784150505448.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5448/9784150505448.jpg",
     "highlights": []
   },
   {
@@ -9709,7 +9709,7 @@ export const books = [
     "isbn": "9784003234310",
     "asin": "4003234316",
     "readDate": "2019/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4310/9784003234310.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4310/9784003234310.jpg",
     "highlights": []
   },
   {
@@ -9720,7 +9720,7 @@ export const books = [
     "isbn": "9784048932851",
     "asin": "4048932853",
     "readDate": "2019/09/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2851/9784048932851.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2851/9784048932851.jpg",
     "highlights": []
   },
   {
@@ -9731,7 +9731,7 @@ export const books = [
     "isbn": "9784150503536",
     "asin": "4150503532",
     "readDate": "2019/09/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3536/9784150503536.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3536/9784150503536.jpg",
     "highlights": [
       {
         "text": "いったい病気の「本質」とか「新しい病気」とはなにをいうのか？ 医者は自然科学者とはちがう。自然科学者は、多くの生命体を広くとりあげ、それらがある方法によってある環境に適合してゆくさまを研究するが、このとき、方法も環境も平均で考えている。これに反して医者が問題にするのは、一個の生命体、すなわち、逆境のなかで自己のアイデンティティを守りぬこうとする個人としての人間である。",
@@ -9775,7 +9775,7 @@ export const books = [
     "isbn": "9784101171081",
     "asin": "4101171084",
     "readDate": "2019/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -9786,7 +9786,7 @@ export const books = [
     "isbn": "9784150505431",
     "asin": "4150505438",
     "readDate": "2019/09/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5431/9784150505431.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5431/9784150505431.jpg",
     "highlights": [
       {
         "text": "その昔、まだ人工知能という言葉すら存在していなかった頃、アラン・チューリング（ 74） はすでに機械の自己学習に言及していた。一九四八年と一九五〇年に執筆した、機械の知能に関する論文の中で、彼はこう述べている。機械が 考える ためには、より正確には、考えることができる生物のように行動するためには、われわれを取り巻く世界や社会の実情に関する膨大な量の知識を持たなくてはならない、と。しかし、これらの知識を機械に移行するのは気の遠くなるような作業であるばかりか、終わりがない。人間の知識には明確な限度というものがないからだ。チューリングによれば、知識をいちいちプログラム言語に変換するよりも、機械に学習能力を持たせる方がはるかに効率的だという。つまり、機械が周囲の状況や自らのいる場所、自らの行動を観察し、それによって知識や技術を獲得する能力を持つということだ。",
@@ -9810,7 +9810,7 @@ export const books = [
     "isbn": "9784003394816",
     "asin": "400339481X",
     "readDate": "2019/09/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4816/9784003394816.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4816/9784003394816.jpg",
     "highlights": []
   },
   {
@@ -9821,7 +9821,7 @@ export const books = [
     "isbn": "9784062586702",
     "asin": "4062586703",
     "readDate": "2019/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6702/9784062586702.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6702/9784062586702.jpg",
     "highlights": []
   },
   {
@@ -9832,7 +9832,7 @@ export const books = [
     "isbn": "9784775971147",
     "asin": "477597114X",
     "readDate": "2019/08/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1147/9784775971147.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1147/9784775971147.jpg",
     "highlights": [
       {
         "text": "一．長期間にわたって平均以上の利益を上げることができる企業を探す 二．その企業の株価が本質的価値より安くなるまで待ってから買う 三．企業価値が低下するか、株価が割高になるか、さらに優れた投資先が見つかるまで、その銘柄を保有する。保有期間は、月単位というよりも年単位で考える 四．この手順を必要に応じて繰り返す",
@@ -9860,7 +9860,7 @@ export const books = [
     "isbn": "9784167913403",
     "asin": "4167913402",
     "readDate": "2019/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3403/9784167913403.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3403/9784167913403.jpg",
     "highlights": []
   },
   {
@@ -9871,7 +9871,7 @@ export const books = [
     "isbn": "9784864727778",
     "asin": "4864727775",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7778/9784864727778.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7778/9784864727778.jpg",
     "highlights": []
   },
   {
@@ -9882,7 +9882,7 @@ export const books = [
     "isbn": "9784150502225",
     "asin": "4150502226",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2225/9784150502225.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2225/9784150502225.jpg",
     "highlights": [
       {
         "text": "いわゆる あまりに 人間的なものは、ほとんどつねに、 前 人間的なものであり、したがってわれわれにも高等動物にも共通に存在するものだ、ということを理解してもらいたい。心配は無用、私は人間の性質をそのまま動物に投影しているわけではない。むしろ私はその逆に、どれほど多くの動物的な遺産が人間の中に残っているかをしめしているにすぎないのだ。私",
@@ -9914,7 +9914,7 @@ export const books = [
     "isbn": "9784344032156",
     "asin": "4344032152",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2156/9784344032156.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2156/9784344032156.jpg",
     "highlights": [
       {
         "text": "長く運営されることで徐々に特定の層に利益が滞留し始めると、当然それ以外の人の間で新しいシステムの誕生を望む声が高まっていきます。 また人間には「飽き」があるので、長く同じ環境にいると不満がなかったとしても、新しい環境を望んでしまう傾向があります。",
@@ -9942,7 +9942,7 @@ export const books = [
     "isbn": "9784150313838",
     "asin": "4150313830",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3838/9784150313838.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3838/9784150313838.jpg",
     "highlights": []
   },
   {
@@ -9953,7 +9953,7 @@ export const books = [
     "isbn": "9784094511420",
     "asin": "4094511423",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1420/9784094511420.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1420/9784094511420.jpg",
     "highlights": []
   },
   {
@@ -9964,7 +9964,7 @@ export const books = [
     "isbn": "9784004315414",
     "asin": "4004315417",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5414/9784004315414.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5414/9784004315414.jpg",
     "highlights": [
       {
         "text": "多数決という意思集約の方式は、日本を含む多くの国の選挙で当たり前に使われている。だがそれは慣習のようなもので、他の方式と比べて優れているから採用されたわけではない。そもそも多数決以外の方式を考えたりはしないのが通常だろう。だが民主制のもとで選挙が果たす重要性を考えれば、多数決を安易に採用するのは、思考停止というより、もはや文化的奇習の一種である。",
@@ -10000,7 +10000,7 @@ export const books = [
     "isbn": "9784334754082",
     "asin": "4334754082",
     "readDate": "2019/08/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4082/9784334754082.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4082/9784334754082.jpg",
     "highlights": []
   },
   {
@@ -10011,7 +10011,7 @@ export const books = [
     "isbn": "9784101171197",
     "asin": "410117119X",
     "readDate": "2019/08/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1197/9784101171197.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1197/9784101171197.jpg",
     "highlights": []
   },
   {
@@ -10022,7 +10022,7 @@ export const books = [
     "isbn": "9784152098801",
     "asin": "4152098805",
     "readDate": "2019/08/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8801/9784152098801.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8801/9784152098801.jpg",
     "highlights": [
       {
         "text": "「あんた、何者だ」無理に発した声も掠れ気味だったが、彼女はあっさりと応じた。 「北条美亜羽」 ミァハ。どこかで聞き覚えのある名前に出くわし、検索を掛けようとして、実継はヒエロが外れてしまっていることを思い出す。それを見透かしたように彼女が告げた。 「小説から取った、僕自身でつけた名前だ。二十一世紀初頭のディストピア文学から」",
@@ -10066,7 +10066,7 @@ export const books = [
     "isbn": "9784101171340",
     "asin": "4101171343",
     "readDate": "2019/08/10",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51FcOSxanPL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51FcOSxanPL.jpg",
     "highlights": [
       {
         "text": "そこにおいてこそ作者は、胸を張って言おうではないか。読者に誤読の自由があるのなら、作者にだって「誤作」の自由があると。 読者はこの虚構に参加していただきたい。いや。展開にかかわった以上、その読者はこの虚構の作者であると同時に登場人物になることさえあり得る。作者が作中に登場することは、今となってはさほど珍しいことではない。",
@@ -10086,7 +10086,7 @@ export const books = [
     "isbn": "9784044092221",
     "asin": "4044092222",
     "readDate": "2019/08/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2221/9784044092221.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2221/9784044092221.jpg",
     "highlights": [
       {
         "text": "小プリニウスに限らず、多くのローマ人にとって（といっても、上層のローマ人にとって、という意味だが）の理想の老後は、 otium honestum という言葉に要約できます。直訳すると「名誉ある閑暇」ですが、わかりやすくいうと、老後の時間を高尚な趣味に費やし楽しむこと、同輩や後輩の範となるように最期を生きること、でした。 しかし、この名誉ある閑暇を実現させるためには、名声、財力、教養の三つに加えて、心身の健康が必要条件でした。小プリニウスは、これらの諸条件がすべてそろって初めて理想の老後を送ることができる、と信じていたので、三二歳で痛風を患って以来、その痛みに苦しめられ続け、老境にいたってもはやその痛みに耐えられなくなったクィントゥス＝コレッリウス＝ルフスが自ら食を断って六七歳で自害したことを、ひどく悲しみましたが、と同時に、その死に方に理解も示しています（同一・一二）。大事なのは、どれだけ生きるかではなく、いかに生きるかである、",
@@ -10102,7 +10102,7 @@ export const books = [
     "isbn": "9784150103149",
     "asin": "4150103143",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/51Q5q1sn1xL._SX334_BO1,204,203,200_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/51Q5q1sn1xL._SX334_BO1,204,203,200_.jpg",
     "highlights": [
       {
         "text": "司書の話だと、英語じゃないんですって。でも、それに近いラテン語はあるそうです。ウビーク（ｕｂｉｑｕｅ）といって、その意味は──」 「あらゆる場所、だ」ジョーはいった。 フランセスカ・スパニッシュはうなずいた。「ええ、そういう意味。でも、ＵＢＩＫという単語はありません。夢の中ではそんな綴りだったけど」 「おなじ単語だよ」ジョーはいった。「ただ、綴りがちがうだけさ」",
@@ -10122,7 +10122,7 @@ export const books = [
     "isbn": "9784140057063",
     "asin": "4140057068",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7063/9784140057063.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7063/9784140057063.jpg",
     "highlights": []
   },
   {
@@ -10133,7 +10133,7 @@ export const books = [
     "isbn": "9784061590922",
     "asin": "4061590928",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0922/9784061590922.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0922/9784061590922.jpg",
     "highlights": [
       {
         "text": "群衆は、ただ過激な感情にのみ動かされるのであるから、その心を捉えようとする弁士は、強い断定的な言葉を大いに用いねばならない。誇張し断言し 反覆 すること、そして推論によって何かを証明しようと決して試みないこと、これが、民衆の会合で弁士がよく用いる論法である。",
@@ -10173,7 +10173,7 @@ export const books = [
     "isbn": "9784022618443",
     "asin": "4022618442",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8443/9784022618443.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8443/9784022618443.jpg",
     "highlights": [
       {
         "text": "都会ではそうした環境は稀少です。親が「外遊び」というのを相当意識して、そういう場所に連れて行くなどして、かなり意図的にさせないと、自分からはしません。 つまり、親にそういう知識、意識、意欲があるかないかで、子どもの脳の発達に大きな格差が生まれてしまう。 最近、都心の公園をたまたま通りがかった友人から聞いた話です。 子どもが木登りをしていました。イチジクの木に登って実を食べていたのです。 しかも相当に高いところまで登っていたのは、なんと女の子でした。 聞くと、名門と呼ばれる私立小学校の子でした。下に数人の子がいて見ていたそうです。 私立小へ行くことと頭の良し悪しは直接には関係しませんが、少なくとも彼女の親は教育に熱心だったはずです。だとすると、幼いころから、外遊びも十分にさせていた可能性があります。 一方で、そういうことをさせられなかった子どもは、木登りもできなければ、勉強もできない。その子が大人になって、子どもを生んでも、そういう教育をしない。そうすれば、その子どもも同じようになってしまう。 私が危惧しているのは、そういう格差です。 小学校の先生からも、こんな話を聞きました。最近の子どもは、かけっこが速い子どもは勉強もできる。身体に特に異状はないのに、かけっこがちゃんとできない子は勉強もできないそうです。 せめて「バリアオンリー」の家を、と言ったのも、こういう事態が進みかねないからです。",
@@ -10237,7 +10237,7 @@ export const books = [
     "isbn": "9784041085202",
     "asin": "4041085209",
     "readDate": "2019/08/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784041085202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5202/9784041085202.jpg",
     "highlights": []
   },
   {
@@ -10248,7 +10248,7 @@ export const books = [
     "isbn": "9784041075548",
     "asin": "4041075548",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5548/9784041075548.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5548/9784041075548.jpg",
     "highlights": []
   },
   {
@@ -10259,7 +10259,7 @@ export const books = [
     "isbn": "9784041061114",
     "asin": "4041061113",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1114/9784041061114.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1114/9784041061114.jpg",
     "highlights": []
   },
   {
@@ -10270,7 +10270,7 @@ export const books = [
     "isbn": "9784041061091",
     "asin": "4041061091",
     "readDate": "2019/08/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1091/9784041061091.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1091/9784041061091.jpg",
     "highlights": []
   },
   {
@@ -10281,7 +10281,7 @@ export const books = [
     "isbn": "9784845914333",
     "asin": "4845914336",
     "readDate": "2019/08/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4333/9784845914333.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4333/9784845914333.jpg",
     "highlights": [
       {
         "text": "その日のうちにやりたいこと、やらねばならないことを決め、それを毎日必ず決まった時間にやる。そうすれば欲望に煩わされることはない」",
@@ -10305,7 +10305,7 @@ export const books = [
     "isbn": "9784844398844",
     "asin": "4844398849",
     "readDate": "2019/07/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8844/9784844398844.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8844/9784844398844.jpg",
     "highlights": []
   },
   {
@@ -10316,7 +10316,7 @@ export const books = [
     "isbn": "9784905073246",
     "asin": "4905073243",
     "readDate": "2019/07/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3246/9784905073246.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3246/9784905073246.jpg",
     "highlights": []
   },
   {
@@ -10327,7 +10327,7 @@ export const books = [
     "isbn": "9784898154151",
     "asin": "4898154158",
     "readDate": "2019/07/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4151/9784898154151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4151/9784898154151.jpg",
     "highlights": [
       {
         "text": "「え？ 青春？」 「青春映画とか青春小説とか、あとロックのバンドが歌ってるでしょ、若者の悩みやら葛藤みたいなのを。でもね、あんなの青春だと思ったらダメよ。あれは全部、大人が作ってるんだからね」 「うん？」 「ああいうのは大人のみみっちい後悔を子供に演じさせてるだけなの。あんたは本物の子供なんだから、そんなのに付き合わなくて",
@@ -10359,7 +10359,7 @@ export const books = [
     "isbn": "9784334962272",
     "asin": "4334962270",
     "readDate": "2019/07/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2272/9784334962272.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2272/9784334962272.jpg",
     "highlights": [
       {
         "text": "もし 暗黒 郷 がわれわれの未来のなかにあるとすれば――人種差別的なファシズムへと社会が回帰することを予想した作家フィリップ・ロスやシンクレア・ルイスが描く悪夢のなかにではなく――能力にもとづく生産性至上主義という教えのなかにあるはずだ。",
@@ -10375,7 +10375,7 @@ export const books = [
     "isbn": "9784905425182",
     "asin": "4905425182",
     "readDate": "2019/07/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5182/9784905425182.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5182/9784905425182.jpg",
     "highlights": [
       {
         "text": "スマナサーラ 「自分に合っている仕事を探す」ということに対しては、私はずっと養老先生と同じく、反対意見を言っています。あれは「自分を変えたくはない」「発展させたくはない」「プログレスさせたくはない」という反進化論です。進化させたくないんです。 釈 今の人たちは、「確固たる自分」というものが「ある」ということを前提としている。だからこそ、「何かもっと自分に向いた仕事があるんじゃないか」とか、「もっと自分にぴったりの場所があるんじゃないか」という方向へと向かってしまうのでしょうね。そういえば、一時期、「自分探し」なんていう言葉も 流行りました。しかし、その「本当の自分がどこかにある」という前提と、だから「それを損ないたくない」「それを必死で守ろうとする」といった生き方は、構造的な苦悩を生み出し続けるのではないでしょうか。",
@@ -10391,7 +10391,7 @@ export const books = [
     "isbn": "9784336063557",
     "asin": "4336063559",
     "readDate": "2019/07/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3557/9784336063557.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3557/9784336063557.jpg",
     "highlights": []
   },
   {
@@ -10402,7 +10402,7 @@ export const books = [
     "isbn": "9784150117245",
     "asin": "4150117241",
     "readDate": "2019/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7245/9784150117245.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7245/9784150117245.jpg",
     "highlights": []
   },
   {
@@ -10413,7 +10413,7 @@ export const books = [
     "isbn": "9784152098498",
     "asin": "415209849X",
     "readDate": "2019/07/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8498/9784152098498.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8498/9784152098498.jpg",
     "highlights": [
       {
         "text": "無限の図書館が示すこのメタファーはこれまでに、ほかにも無数のかたちで表現されてきた。音符のありとあらゆる組み合わせ、さまざまなものを収めた無限に続くキャビネット、ありうるかぎりのたんぱく質配列の連なり、推理小説のありとあらゆるプロット、神を意味する秘密の呼称の一覧、万人に開かれた図書館としての世界や自然やグーグル、普遍的著作としての聖書、コーラン、ファースト・フォリオ、そして『フィネガンズ・ウェイク』、タイプライターを打つサル、あらゆる次元の暗号文、自動筆記、連続的物語叙述（訳注 絵画などで異なる時間をひとつの構図のなかに描き込む方法。異時同図とも呼ばれる）、名もなき都市、数学的および量子力学的不確定性の形式的叙述、未知の海（mare incognitum） や無主の地（terra nullius）、ありとあらゆるツイート。ピクセルで構成されるを使用すれば、あらゆる文字列だけでなく、あらゆる画像を作り出せる。固体は理論上、限りなく薄い平面にスライスできる。",
@@ -10437,7 +10437,7 @@ export const books = [
     "isbn": "9784152098702",
     "asin": "4152098708",
     "readDate": "2019/07/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8702/9784152098702.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8702/9784152098702.jpg",
     "highlights": [
       {
         "text": "全身全霊で研究に打ち込むんだ。成果を得ることなど考えず、ひたすら励め。研究に専念していれば、知らず知らずのうちに一生が終わる。〝腰を据える〟というのは、つまりそういうことだ。 あるいはその反対に、金儲けを唯一の目標として、どうやって稼ぐかだけを一心不乱に考えるのでもいい。その場合も、稼いだ金をどう使うかなんか考えちゃだめだ。そして死ぬ間際、枕元に山積みになった金貨を見ながら、グランデ（一八三三年に刊行されたバルザックの長篇小説『ウジェニー・グランデ』の登場人物） みたいにこう言うのさ。『ああ、これで体が温まる』ってね……。だから、すばらしい人生を送る鍵は、なにかひとつのものに夢中になることにある。たとえば父さんの場合は……」",
@@ -10457,7 +10457,7 @@ export const books = [
     "isbn": "9784065160145",
     "asin": "4065160146",
     "readDate": "2019/07/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0145/9784065160145.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0145/9784065160145.jpg",
     "highlights": [
       {
         "text": "やはり HKE の別名義にあたる THE DARKEST FUTURE の『FLORAL SHOPPE 2』は、アメリカの音楽家 Vektroid によるヴェイパーウェイヴの金字塔といえる作品『FLORAL SHOPPE』の悪意に満ちたパロディであると同時に、ある意味でヴェイパーウェイヴのひとつの極北といえる作品だ。資本主義に対する批判的アイロニーの極点、それは端的に世界の終末──アーティスト名が表しているように「もっともダークな未来」──を提示することであり、そのためにはヴェイパーウェイヴそれ自体を破壊することすら厭わない。",
@@ -10481,7 +10481,7 @@ export const books = [
     "isbn": "9784150505387",
     "asin": "4150505381",
     "readDate": "2019/07/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5387/9784150505387.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5387/9784150505387.jpg",
     "highlights": [
       {
         "text": "情報を集めるという行為そのものが結果に悪影響を与えてしまう場合に、どうしたら適切な情報にもとづく判断ができるのだろう。これはきわめて困難な状況で、パラドックスに限りなく近いと言える。 この種の問題にぶつかったとき、たいていの人は直感的に、「見る」ことと「跳ぶ」ことを 秤 にかける必要があるというようなことを口にするだろう。つまり、判断基準を定めるのに十分な数のアパートを見たうえで、その基準を満たすものならよしとするということだ。実際、このように秤にかけるという考え方は正論そのものだ。もっとも、どこで線を引くべきかと問われたら、ほとんどの人は自信をもって答えることが できない。しかし、安心してよい。答えはあるのだ。 三七パーセント。 最良の物件に入居できる可能性を最大にしたければ、部屋探しに 充てる時間の三七パーセント（一カ月かけるつもりなら最初の一一日間）までは結論を出さずにただ物件を見て回る。小切手帳は家に置いておき、判断基準を定めることに専念する。しかし三七パーセント以降は、それまでに見たどの物件よりもよい部屋に出会ったらすぐさま保証金を払って契約するのだ。これは「見る」と「跳ぶ」を直感的に満足のいく形で折りあわせた答えであるばかりでなく、 最適であることが証明可能な 解となる。",
@@ -10541,7 +10541,7 @@ export const books = [
     "isbn": "9784150313791",
     "asin": "4150313792",
     "readDate": "2019/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784150313791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3791/9784150313791.jpg",
     "highlights": [
       {
         "text": "「人は誰でも他人を苦しめ、不幸にする、たとえその気がなくともね。誰かの役に立たねばならない、周囲を幸福にせねばならないなんてさ、考えないことだ。もしそんなことが実現できていると感じたなら、それは思い上がりってもん",
@@ -10557,7 +10557,7 @@ export const books = [
     "isbn": "9784309025216",
     "asin": "4309025218",
     "readDate": "2019/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5216/9784309025216.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5216/9784309025216.jpg",
     "highlights": [
       {
         "text": "ＡＲは街を美しくする──そういう触れ込みだった。 ひしめく看板。がなり立てる音声広告。いきなり目の前に突き出されるフライヤー。それらは物理的実体を伴っていて、聞きたくない音、見たくない色彩を排除できず、チラシを配る人間や地置きの広告サインは歩行のさまたげとなった。それにくらべて、ＡＲならばいくらでもフィルタできる。空間という資源をほとんど侵害しない。好きなデザインで世界を飾ることもできる。そう 喧伝 されていたのだ。 実は逆だった。 ユーザが自分でフィルタを設定するからこそ ＡＲで飾られた街は魅力を失うのだ。 街は自室ではない。ねむるための巣穴ではなく、獲物を獲りにゆく山野なのだ。 街の光景も多数の主体の自律的活動が織りなす点では、山野と変わらぬ一種の〈自然〉だ。自分の思い通りにならない他者の 横溢。そこにこそ街の価値はある。ＡＲを重ね書きすることは、狩り場じゅうに自分の体臭を塗りこめるような愚行だ。",
@@ -10597,7 +10597,7 @@ export const books = [
     "isbn": "9784121506016",
     "asin": "4121506014",
     "readDate": "2019/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784121506016.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6016/9784121506016.jpg",
     "highlights": [
       {
         "text": "愛は消える。変容する。形を変える。何を定義しているかすら、もはやわからない。愛に実態は乏しい。恋人との交歓の中で互いに「愛している」とささやきあったところで、その意味するものが必ずしも同じことだという保証はない。 なぜなら愛は、あいまいなものであるからだ。",
@@ -10645,7 +10645,7 @@ export const books = [
     "isbn": "9784309464855",
     "asin": "4309464858",
     "readDate": "2019/06/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4855/9784309464855.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4855/9784309464855.jpg",
     "highlights": [
       {
         "text": "仕事の多さから夢は生じ、言葉の多さから暴言は生じるものである。",
@@ -10665,7 +10665,7 @@ export const books = [
     "isbn": "9784864726924",
     "asin": "4864726922",
     "readDate": "2019/06/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6924/9784864726924.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6924/9784864726924.jpg",
     "highlights": []
   },
   {
@@ -10676,7 +10676,7 @@ export const books = [
     "isbn": "9784040730301",
     "asin": "4040730305",
     "readDate": "2019/06/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0301/9784040730301.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0301/9784040730301.jpg",
     "highlights": []
   },
   {
@@ -10687,7 +10687,7 @@ export const books = [
     "isbn": "9784864727488",
     "asin": "4864727481",
     "readDate": "2019/06/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7488/9784864727488.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7488/9784864727488.jpg",
     "highlights": []
   },
   {
@@ -10698,7 +10698,7 @@ export const books = [
     "isbn": "9784434208232",
     "asin": "4434208233",
     "readDate": "2019/06/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8232/9784434208232.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8232/9784434208232.jpg",
     "highlights": []
   },
   {
@@ -10709,7 +10709,7 @@ export const books = [
     "isbn": "9784003279250",
     "asin": "4003279255",
     "readDate": "2019/06/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9250/9784003279250.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9250/9784003279250.jpg",
     "highlights": [
       {
         "text": "はっきりした物言いより、暗示の方が遥かにその効果が大きいのです。人間の心理にはどうやら、断定に対してはそれを否定しようとする傾きがある。",
@@ -10749,7 +10749,7 @@ export const books = [
     "isbn": "9784150504489",
     "asin": "4150504482",
     "readDate": "2019/06/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4489/9784150504489.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4489/9784150504489.jpg",
     "highlights": [
       {
         "text": "ヨーロッパでは、貴金属不足の状況を打破するために二つの方策を考えた。一つは、労働と製品、つまり奴隷と木材を輸出することで、バグダッドで銀を、コルドバやカイロではアフリカの金を入手する方法だ。もう一方は、イスラム社会に戦争を挑んで貴金属を略奪するやり方だ。繰り返しおこなわれた十字軍の遠征やそれに引き続く征服のための戦いは、異教徒をキリスト教徒に改宗させるという目的のほか、ヨーロッパの貴金属不足を克服しようという意図があった。",
@@ -10781,7 +10781,7 @@ export const books = [
     "isbn": "9784864726672",
     "asin": "4864726671",
     "readDate": "2019/06/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6672/9784864726672.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6672/9784864726672.jpg",
     "highlights": []
   },
   {
@@ -10792,7 +10792,7 @@ export const books = [
     "isbn": "9784150122232",
     "asin": "4150122237",
     "readDate": "2019/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2232/9784150122232.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2232/9784150122232.jpg",
     "highlights": [
       {
         "text": "自分が何者かを知る唯一の方法は、新しいなにかを創造することだろう。",
@@ -10812,7 +10812,7 @@ export const books = [
     "isbn": "9784152094452",
     "asin": "4152094451",
     "readDate": "2019/05/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4452/9784152094452.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4452/9784152094452.jpg",
     "highlights": [
       {
         "text": "「私さ」梃子はいった。「したくないことしなくていいようにしたくて」 周りが梃子を見た。「したくないこと？」 「昔あったんだけど幼稚園で」咳払い梃子は言葉を継いだ。「おもちゃだったと思うんだけどさ、先生がいうのよはいじゃあお片付け競争しますみたいな。誰が一番速いかなあそれじゃあ用意どんとかっていうとさあ、みんな何か片付け始めるんだよね。あほみたいなんだけどさ本当。あれ本当頭おかしいよね。私は片付けたくねえんだっつうの、何でびりだと馬鹿みたいになんだよって思って。馬鹿みたいにいわれたんだけどさその時に私。何かさあやりたくないこととか？ 強制的に何かやらす時ってすぐに競争にするよね人は」いって梃子は恥ずかしそうに笑った。「ああいうのよくないよね。競争させればいうこと聞くだろみたいな発想？ 不健全だよね。子供は馬鹿だからさあ、聞いちゃうわけじゃんそういう風にされると。そうじゃなく正しくない圧力には屈しちゃ駄目ってこと教えないと」",
@@ -10840,7 +10840,7 @@ export const books = [
     "isbn": "9784532357696",
     "asin": "4532357691",
     "readDate": "2019/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7696/9784532357696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7696/9784532357696.jpg",
     "highlights": []
   },
   {
@@ -10851,7 +10851,7 @@ export const books = [
     "isbn": "9784167910600",
     "asin": "4167910608",
     "readDate": "2019/05/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0600/9784167910600.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0600/9784167910600.jpg",
     "highlights": [
       {
         "text": "会計は、収入と支出を集計するだけでなく、投資家に還元すべき利益剰余金の累計を計算するために活用されたのである。",
@@ -10867,7 +10867,7 @@ export const books = [
     "isbn": "9784150118457",
     "asin": "4150118450",
     "readDate": "2019/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8457/9784150118457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8457/9784150118457.jpg",
     "highlights": []
   },
   {
@@ -10878,7 +10878,7 @@ export const books = [
     "isbn": "9784822244576",
     "asin": "4822244571",
     "readDate": "2019/05/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224457.jpg",
     "highlights": []
   },
   {
@@ -10889,7 +10889,7 @@ export const books = [
     "isbn": "9784093801041",
     "asin": "4093801045",
     "readDate": "2019/05/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1041/9784093801041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1041/9784093801041.jpg",
     "highlights": [
       {
         "text": "かつては漁業そのものが原始的略奪産業と呼ばれていた時代がある。農業のように育てることをせず、資本を使わず、自然界が生産した漁獲物を収奪してくるからだ。",
@@ -10917,7 +10917,7 @@ export const books = [
     "isbn": "9784309464695",
     "asin": "4309464696",
     "readDate": "2019/05/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4695/9784309464695.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4695/9784309464695.jpg",
     "highlights": [
       {
         "text": "新しいものが何ひとつないことを 知っているゆえに何ごとをもはじめないのは 衒学的な詭弁── 原罪だ。",
@@ -10933,7 +10933,7 @@ export const books = [
     "isbn": "9784532355395",
     "asin": "4532355397",
     "readDate": "2019/05/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5395/9784532355395.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5395/9784532355395.jpg",
     "highlights": []
   },
   {
@@ -10944,7 +10944,7 @@ export const books = [
     "isbn": "9784049120172",
     "asin": "4049120178",
     "readDate": "2019/04/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784049120172.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784049120172.jpg",
     "highlights": []
   },
   {
@@ -10955,7 +10955,7 @@ export const books = [
     "isbn": "9784040731018",
     "asin": "4040731018",
     "readDate": "2019/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1018/9784040731018.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1018/9784040731018.jpg",
     "highlights": []
   },
   {
@@ -10966,7 +10966,7 @@ export const books = [
     "isbn": "9784150504427",
     "asin": "4150504423",
     "readDate": "2019/04/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4427/9784150504427.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4427/9784150504427.jpg",
     "highlights": []
   },
   {
@@ -10977,7 +10977,7 @@ export const books = [
     "isbn": "9784150505363",
     "asin": "4150505365",
     "readDate": "2019/04/23",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784150505363.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5363/9784150505363.jpg",
     "highlights": []
   },
   {
@@ -10988,7 +10988,7 @@ export const books = [
     "isbn": "9784048936163",
     "asin": "4048936166",
     "readDate": "2019/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6163/9784048936163.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6163/9784048936163.jpg",
     "highlights": []
   },
   {
@@ -10999,7 +10999,7 @@ export const books = [
     "isbn": "9784150118440",
     "asin": "4150118442",
     "readDate": "2019/04/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8440/9784150118440.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8440/9784150118440.jpg",
     "highlights": []
   },
   {
@@ -11010,7 +11010,7 @@ export const books = [
     "isbn": "9784152098375",
     "asin": "4152098376",
     "readDate": "2019/03/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8375/9784152098375.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8375/9784152098375.jpg",
     "highlights": []
   },
   {
@@ -11021,7 +11021,7 @@ export const books = [
     "isbn": "9784152098412",
     "asin": "4152098414",
     "readDate": "2019/03/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784152098412.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8412/9784152098412.jpg",
     "highlights": []
   },
   {
@@ -11032,7 +11032,7 @@ export const books = [
     "isbn": "9784492444474",
     "asin": "4492444475",
     "readDate": "2019/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4474/9784492444474.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4474/9784492444474.jpg",
     "highlights": []
   },
   {
@@ -11043,7 +11043,7 @@ export const books = [
     "isbn": "9784492654651",
     "asin": "4492654658",
     "readDate": "2019/03/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784492654651.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4651/9784492654651.jpg",
     "highlights": []
   },
   {
@@ -11054,7 +11054,7 @@ export const books = [
     "isbn": "9784781651132",
     "asin": "4781651135",
     "readDate": "2019/03/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784781651132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784781651132.jpg",
     "highlights": []
   },
   {
@@ -11065,7 +11065,7 @@ export const books = [
     "isbn": "9784152097767",
     "asin": "4152097760",
     "readDate": "2019/03/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7767/9784152097767.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7767/9784152097767.jpg",
     "highlights": []
   },
   {
@@ -11076,7 +11076,7 @@ export const books = [
     "isbn": "9784152097750",
     "asin": "4152097752",
     "readDate": "2019/02/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7750/9784152097750.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7750/9784152097750.jpg",
     "highlights": []
   },
   {
@@ -11087,7 +11087,7 @@ export const books = [
     "isbn": "9784781617268",
     "asin": "4781617263",
     "readDate": "2019/02/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7268/9784781617268.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7268/9784781617268.jpg",
     "highlights": []
   },
   {
@@ -11098,7 +11098,7 @@ export const books = [
     "isbn": "9784781617411",
     "asin": "4781617417",
     "readDate": "2019/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7411/9784781617411.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7411/9784781617411.jpg",
     "highlights": []
   },
   {
@@ -11109,7 +11109,7 @@ export const books = [
     "isbn": "9784864106627",
     "asin": "4864106622",
     "readDate": "2019/02/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6627/9784864106627.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6627/9784864106627.jpg",
     "highlights": []
   },
   {
@@ -11120,7 +11120,7 @@ export const books = [
     "isbn": "9784532197353",
     "asin": "453219735X",
     "readDate": "2019/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7353/9784532197353.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7353/9784532197353.jpg",
     "highlights": []
   },
   {
@@ -11131,7 +11131,7 @@ export const books = [
     "isbn": "9784532197346",
     "asin": "4532197341",
     "readDate": "2019/02/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7346/9784532197346.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7346/9784532197346.jpg",
     "highlights": []
   },
   {
@@ -11142,7 +11142,7 @@ export const books = [
     "isbn": "9784532197339",
     "asin": "4532197333",
     "readDate": "2019/02/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7339/9784532197339.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7339/9784532197339.jpg",
     "highlights": []
   },
   {
@@ -11153,7 +11153,7 @@ export const books = [
     "isbn": "9784152095596",
     "asin": "4152095598",
     "readDate": "2019/02/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5596/9784152095596.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5596/9784152095596.jpg",
     "highlights": [
       {
         "text": "幸福は「自分の注意を何にどう割り振るか」で決まる。",
@@ -11221,7 +11221,7 @@ export const books = [
     "isbn": "9784492503027",
     "asin": "4492503021",
     "readDate": "2019/02/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3027/9784492503027.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3027/9784492503027.jpg",
     "highlights": []
   },
   {
@@ -11232,7 +11232,7 @@ export const books = [
     "isbn": "9784797382228",
     "asin": "4797382228",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2228/9784797382228.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2228/9784797382228.jpg",
     "highlights": []
   },
   {
@@ -11243,7 +11243,7 @@ export const books = [
     "isbn": "9784150312343",
     "asin": "4150312346",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2343/9784150312343.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2343/9784150312343.jpg",
     "highlights": [
       {
         "text": "そして、何の意味もない人生だった。 妻もいない。子供もいない。自分が何のためにこの世界を生きてきたのか意味を見出せない。俺が唯一愛した人は、俺のせいでこの世界から消えてしまった。 だが、それももう終わりだ。 泡は沈む。 さぁ、世界を消し去ってしまおう。 こんな、愛する人のいない世界なんて。",
@@ -11263,7 +11263,7 @@ export const books = [
     "isbn": "9784150312336",
     "asin": "4150312338",
     "readDate": "2019/02/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2336/9784150312336.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2336/9784150312336.jpg",
     "highlights": [
       {
         "text": "「ああいう作品のほとんどって、主人公が何度も世界をやり直して自分の望む未来に変えていくって感じじゃない？ 思ったんだけど、それって主人公が自分の望まない並行世界を勝手に否定してるってことなのよね。その世界はその世界で、自分じゃない自分が生きて作り上げてきた世界なのに」",
@@ -11279,7 +11279,7 @@ export const books = [
     "isbn": "9784887218215",
     "asin": "4887218214",
     "readDate": "2019/02/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8215/9784887218215.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8215/9784887218215.jpg",
     "highlights": []
   },
   {
@@ -11290,7 +11290,7 @@ export const books = [
     "isbn": "9784142230907",
     "asin": "4142230905",
     "readDate": "2019/01/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0907/9784142230907.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0907/9784142230907.jpg",
     "highlights": []
   },
   {
@@ -11301,7 +11301,7 @@ export const books = [
     "isbn": "9784908925344",
     "asin": "4908925348",
     "readDate": "2019/01/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5344/9784908925344.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5344/9784908925344.jpg",
     "highlights": []
   },
   {
@@ -11312,7 +11312,7 @@ export const books = [
     "isbn": "9784152097200",
     "asin": "4152097205",
     "readDate": "2019/01/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7200/9784152097200.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7200/9784152097200.jpg",
     "highlights": [
       {
         "text": "一般的な一〇代の若者は、グループのなかで信頼される存在になりたいと願い、少なくとも温かく受け容れられたいと考えるものだ。そして、服や音楽について友人たちと共通の好みをもつことが、グループに受け容れられるひとつの手段になる。このとき、特定のアーティストやバンドの存在が、好きな音楽ジャンルを選ぶ決め手となる。あなたや友人たちは、たんにリコーダーが使われているからといって、一部の曲をそのジャンルから除外しようとするのではなく、アルバムやアーティスト全体を支持するようになる。もうひとつ大切なのは、まわりのほぼ全員を「ダサい」とみなすことによって、あなたと友人は自分たちを「かっこいい」と考えるということだ。あるかっこいいバンドを見つけたら、自分たちだけが彼らのファンなのだと信じようとする。だから、大好きなバンドがメインストリームで人気を集めるようになると、ひどくがっかりするものだ。一",
@@ -11356,7 +11356,7 @@ export const books = [
     "isbn": "9784309464831",
     "asin": "4309464831",
     "readDate": "2019/01/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4831/9784309464831.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4831/9784309464831.jpg",
     "highlights": [
       {
         "text": "ある。ミラノの自宅の書物の迷路（まさに記憶の集積）に私たちを誘いつつ、ウンベルト・エーコはこう言う。「私たちの存在は私たち自身の記憶にほかならない。記憶こそ私たちの魂、記憶を失えば私たちは魂を失う」と。 記憶を失ってはならない、繰り返しこう言い続けたエーコの言葉を、私たちも心にとどめておきたい。",
@@ -11372,7 +11372,7 @@ export const books = [
     "isbn": "9784101050089",
     "asin": "4101050082",
     "readDate": "2019/01/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0089/9784101050089.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0089/9784101050089.jpg",
     "highlights": []
   },
   {
@@ -11383,7 +11383,7 @@ export const books = [
     "isbn": "9784480082961",
     "asin": "4480082964",
     "readDate": "2019/01/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2961/9784480082961.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2961/9784480082961.jpg",
     "highlights": []
   },
   {
@@ -11394,7 +11394,7 @@ export const books = [
     "isbn": "9784150504144",
     "asin": "4150504148",
     "readDate": "2019/01/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4144/9784150504144.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4144/9784150504144.jpg",
     "highlights": [
       {
         "text": "ショーペンハウアーはこう書いている。「とてもわかりやすく、それでいて何とも不可解な、言いようのない音楽の深みは、音楽が私たちの最も内側にある感情をすべて再現しているのに、リアリティがまったくなく、痛みからはかけ離れている……という事実に起因する。音楽は人生とそこで起こる出来事の真髄のみを表現し、決してそれ自体を表現するのではない」 音楽を聴くと聴覚を使い、感情がわくだけでなく、運動することにもなる。「われわれは筋肉を使って音楽を聴く」とニーチェも書いている。",
@@ -11434,7 +11434,7 @@ export const books = [
     "isbn": "9784150503901",
     "asin": "4150503907",
     "readDate": "2019/01/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3901/9784150503901.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3901/9784150503901.jpg",
     "highlights": []
   },
   {
@@ -11445,7 +11445,7 @@ export const books = [
     "isbn": "9784153350151",
     "asin": "415335015X",
     "readDate": "2019/01/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0151/9784153350151.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0151/9784153350151.jpg",
     "highlights": []
   },
   {
@@ -11456,7 +11456,7 @@ export const books = [
     "isbn": "9784336042972",
     "asin": "4336042977",
     "readDate": "2019/01/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3360/33604297.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3360/33604297.jpg",
     "highlights": []
   },
   {
@@ -11467,7 +11467,7 @@ export const books = [
     "isbn": "9784766425192",
     "asin": "4766425197",
     "readDate": "2019/01/06",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5192/9784766425192.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5192/9784766425192.jpg",
     "highlights": []
   },
   {
@@ -11478,7 +11478,7 @@ export const books = [
     "isbn": "9784864727174",
     "asin": "4864727171",
     "readDate": "2019/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7174/9784864727174.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7174/9784864727174.jpg",
     "highlights": []
   },
   {
@@ -11489,7 +11489,7 @@ export const books = [
     "isbn": "9784334753504",
     "asin": "4334753507",
     "readDate": "2019/01/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3504/9784334753504.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3504/9784334753504.jpg",
     "highlights": [
       {
         "text": "は、あなたたちが、まるで永遠に生きられるかのように生きているからだ。あなたたちが、自分のもろさにいつまでも気づかないからだ。あなたたちが、どれだけたくさんの時間が過ぎてしまったかを、気にもとめないからだ。あなたたちが、まるで豊かにあふれる泉から湧いてくるかのように、時間を無駄使いしているからだ。たぶん、そんなことをしているうちに、あなたたちの最後の日となる、まさにその日がやってくるのだろう――まあその日だって、［自分のためでなく］ 別のだれかや、別の用事のために使われているわけだがね。 あなたたちは、どんなことでも、死すべき人間のように恐れる。そのくせ、どんなことでも、不死なる神のように欲するのだ。",
@@ -11573,7 +11573,7 @@ export const books = [
     "isbn": "9784863542457",
     "asin": "4863542453",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2457/9784863542457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2457/9784863542457.jpg",
     "highlights": []
   },
   {
@@ -11584,7 +11584,7 @@ export const books = [
     "isbn": "9784864726658",
     "asin": "4864726655",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6658/9784864726658.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6658/9784864726658.jpg",
     "highlights": []
   },
   {
@@ -11595,7 +11595,7 @@ export const books = [
     "isbn": "9784094516104",
     "asin": "4094516107",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6104/9784094516104.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6104/9784094516104.jpg",
     "highlights": []
   },
   {
@@ -11606,7 +11606,7 @@ export const books = [
     "isbn": "9784152097866",
     "asin": "4152097868",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7866/9784152097866.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7866/9784152097866.jpg",
     "highlights": []
   },
   {
@@ -11617,7 +11617,7 @@ export const books = [
     "isbn": "9784041308011",
     "asin": "4041308011",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/81NctqtympL._SL200_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/81NctqtympL._SL200_.jpg",
     "highlights": [
       {
         "text": "失業罪などという罪ができたのも、憲法改正のおかげだ。改正に反対しきれなかったのは、革新勢力が 反対 にばかり熱をいれ、しかも反対運動の足なみがそろわなかったからだ。─",
@@ -11665,7 +11665,7 @@ export const books = [
     "isbn": "9784560080399",
     "asin": "4560080399",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0399/9784560080399.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0399/9784560080399.jpg",
     "highlights": []
   },
   {
@@ -11676,7 +11676,7 @@ export const books = [
     "isbn": "9784152098061",
     "asin": "4152098066",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8061/9784152098061.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8061/9784152098061.jpg",
     "highlights": []
   },
   {
@@ -11687,7 +11687,7 @@ export const books = [
     "isbn": "9784003279298",
     "asin": "4003279298",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9298/9784003279298.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9298/9784003279298.jpg",
     "highlights": []
   },
   {
@@ -11698,7 +11698,7 @@ export const books = [
     "isbn": "9784891767815",
     "asin": "4891767812",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7815/9784891767815.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7815/9784891767815.jpg",
     "highlights": []
   },
   {
@@ -11709,7 +11709,7 @@ export const books = [
     "isbn": "9784150311308",
     "asin": "4150311307",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1308/9784150311308.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1308/9784150311308.jpg",
     "highlights": [
       {
         "text": "彼女は機嫌良さそうに、式の引き出物の相談をしてきたよ。どうも、僕と暮らしていたのは、得体のしれない化け物だったらしい。僕は恐怖した。もし彼女の不貞を知っていることを悟られたら、この化け物に殺されると思って、表面を取り繕って誤魔化し、夜は二人で買った寝台に入って、知らない男の体液が付いているのを知りながら、それでも逃げられずに、朝までずっと吐き気に耐えた。地獄さ。それからは、助かりたい一心で離別を進めた。その女は、彼とは別れるつもりだったんです、本当に好きなのは貴方なんです、なんていう代筆作家が考えたような台詞を並べ立てて、ああ、これは本当に人間ではないのかもしれない、機械的な反射で言葉を並べるだけ、一見して自我のように見えるだけで、その実は神経節の反応で動くだけの、昆虫のようなものなんだと理解した。そうして僕は、その本質的な理解と引き換えに、ほとんど全てを失ったのさ」 私は言葉を無くし、酒を呷ったが、飲み干しても次の言葉が出ず、注ぎ足そうとして、しかし、瓶は空で、沈黙だけが続いた。遠",
@@ -11729,7 +11729,7 @@ export const books = [
     "isbn": "9784334039790",
     "asin": "4334039790",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9790/9784334039790.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9790/9784334039790.jpg",
     "highlights": [
       {
         "text": "故郷に残った４人と比べ、移住した４人は、社会経済的にあきらかに高いにあり、そのまま最期を迎えることになる。私の祖父が若いころに気づいていたように、ヒルビリーにとって社会的に上昇する最善の方法は、州外に移住することだったのだ。",
@@ -11769,7 +11769,7 @@ export const books = [
     "isbn": "9784040728247",
     "asin": "4040728246",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8247/9784040728247.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8247/9784040728247.jpg",
     "highlights": []
   },
   {
@@ -11780,7 +11780,7 @@ export const books = [
     "isbn": "9784040728186",
     "asin": "4040728181",
     "readDate": "2018/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8186/9784040728186.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8186/9784040728186.jpg",
     "highlights": [
       {
         "text": "誰に臆することなく自分の意見を述べられる＝自己中、空気読めない 他人の意見を柔軟に受け入れられる＝どうでもいい、人に興味がない",
@@ -11800,7 +11800,7 @@ export const books = [
     "isbn": "9784140817513",
     "asin": "4140817518",
     "readDate": "2018/12/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7513/9784140817513.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7513/9784140817513.jpg",
     "highlights": []
   },
   {
@@ -11811,7 +11811,7 @@ export const books = [
     "isbn": "9784150504533",
     "asin": "4150504539",
     "readDate": "2018/12/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4533/9784150504533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4533/9784150504533.jpg",
     "highlights": []
   },
   {
@@ -11822,7 +11822,7 @@ export const books = [
     "isbn": "9784041308196",
     "asin": "4041308194",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "「読まざるこそ自然なれ」といっても、──その知恵さえ、 読まなければ、あたえられないという、おかしなパラドックスによって呪われている。『ホモ』は『サピエンス』によって呪われているのだ。その 種 がこの地球上に出現した時から……。",
@@ -11890,7 +11890,7 @@ export const books = [
     "isbn": "9784309625034",
     "asin": "4309625037",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5034/9784309625034.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5034/9784309625034.jpg",
     "highlights": []
   },
   {
@@ -11901,7 +11901,7 @@ export const books = [
     "isbn": "9784065132555",
     "asin": "406513255X",
     "readDate": "2018/12/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2555/9784065132555.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2555/9784065132555.jpg",
     "highlights": []
   },
   {
@@ -11912,7 +11912,7 @@ export const books = [
     "isbn": "9784094517620",
     "asin": "4094517626",
     "readDate": "2018/11/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7620/9784094517620.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7620/9784094517620.jpg",
     "highlights": [
       {
         "text": "たった一言で伝えられる想いもあれば、どんなに言葉を尽くしたって届かない気持ちもあり、だからこそ、ありとあらゆる手段でもって、それを形にしようとするのです。 例えば、小説なんてその最たるものなのではないでしょうか。 語らないからこそ伝わるものがあり、語り倒すことで何一つ伝えないこともある。 その解釈のほとんどすべては読者の方に委ねるほかないのですが、願わくば、少しでも多く、この想いが届けばいいなと祈りながら私は日々書いております。 あるいは、彼と彼女も。さらに言えば、彼も彼女も。 そんな風に言葉を 紡ぎ、心をつなぎ、日々の続きを送っていくのだと思います。",
@@ -11948,7 +11948,7 @@ export const books = [
     "isbn": "9784791771035",
     "asin": "4791771036",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1035/9784791771035.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1035/9784791771035.jpg",
     "highlights": []
   },
   {
@@ -11959,7 +11959,7 @@ export const books = [
     "isbn": "9784781607986",
     "asin": "4781607985",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7986/9784781607986.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7986/9784781607986.jpg",
     "highlights": []
   },
   {
@@ -11970,7 +11970,7 @@ export const books = [
     "isbn": "9784775972328",
     "asin": "4775972324",
     "readDate": "2018/11/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2328/9784775972328.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2328/9784775972328.jpg",
     "highlights": [
       {
         "text": "株式投資で成功する戦略とは、アメリカの上場企業の株式すべてを、極めて低いコストで保有すること、である。そうすることで、これらの企業が配当や利益成長というかたちでもたらすリターンのほぼすべてを獲得することができるのだ。 この戦略を実行する最良の方法も極めてシンプルだ。 市場全体のポートフォリオを有するファンドを取得し、永遠に持ち続けることである。",
@@ -12026,7 +12026,7 @@ export const books = [
     "isbn": "9784040697437",
     "asin": "404069743X",
     "readDate": "2018/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7437/9784040697437.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7437/9784040697437.jpg",
     "highlights": [
       {
         "text": "「その顔は……さすがに理解したようね。会話のコツと同じ、本物の『ほめ』というのは、その人が人生において、何をこだわっているのかを探る事なのよ。ほめられたいのは外見である場合もあるし、学業や部活、仕事である場合もある。何かの趣味である可能性もある。それを掘り当てるのが 貴方 の仕事なの」",
@@ -12054,7 +12054,7 @@ export const books = [
     "isbn": "9784040695518",
     "asin": "4040695518",
     "readDate": "2018/11/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5518/9784040695518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5518/9784040695518.jpg",
     "highlights": [
       {
         "text": "「つまりあたしが言いたいのはね、自分のキャラと世界観を客観的に把握すること、そしてそれに『似合う』服を選ぶことよ。",
@@ -12122,7 +12122,7 @@ export const books = [
     "isbn": "9784103311621",
     "asin": "4103311622",
     "readDate": "2018/11/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1621/9784103311621.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1621/9784103311621.jpg",
     "highlights": []
   },
   {
@@ -12133,7 +12133,7 @@ export const books = [
     "isbn": "9784101001203",
     "asin": "4101001200",
     "readDate": "2018/11/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10100120.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10100120.jpg",
     "highlights": []
   },
   {
@@ -12144,7 +12144,7 @@ export const books = [
     "isbn": "9784150504526",
     "asin": "4150504520",
     "readDate": "2018/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4526/9784150504526.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4526/9784150504526.jpg",
     "highlights": []
   },
   {
@@ -12155,7 +12155,7 @@ export const books = [
     "isbn": "9784150310004",
     "asin": "4150310009",
     "readDate": "2018/11/25",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0004/9784150310004.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0004/9784150310004.jpg",
     "highlights": [
       {
         "text": "寄せてはかえし 寄せてはかえし かえしては寄せる波の音は、何億年ものほとんど永劫にちかいむかしからこの世界をどよもしていた。",
@@ -12215,7 +12215,7 @@ export const books = [
     "isbn": "9784048922814",
     "asin": "4048922815",
     "readDate": "2018/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2814/9784048922814.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2814/9784048922814.jpg",
     "highlights": []
   },
   {
@@ -12226,7 +12226,7 @@ export const books = [
     "isbn": "9784048658911",
     "asin": "4048658913",
     "readDate": "2018/11/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8911/9784048658911.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8911/9784048658911.jpg",
     "highlights": []
   },
   {
@@ -12237,7 +12237,7 @@ export const books = [
     "isbn": "9784048653947",
     "asin": "4048653946",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3947/9784048653947.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3947/9784048653947.jpg",
     "highlights": []
   },
   {
@@ -12248,7 +12248,7 @@ export const books = [
     "isbn": "9784048651356",
     "asin": "4048651358",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1356/9784048651356.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1356/9784048651356.jpg",
     "highlights": []
   },
   {
@@ -12259,7 +12259,7 @@ export const books = [
     "isbn": "9784048691734",
     "asin": "4048691732",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1734/9784048691734.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1734/9784048691734.jpg",
     "highlights": []
   },
   {
@@ -12270,7 +12270,7 @@ export const books = [
     "isbn": "9784048668088",
     "asin": "4048668080",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8088/9784048668088.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8088/9784048668088.jpg",
     "highlights": []
   },
   {
@@ -12281,7 +12281,7 @@ export const books = [
     "isbn": "9784822244668",
     "asin": "4822244660",
     "readDate": "2018/11/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224466.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224466.jpg",
     "highlights": [
       {
         "text": "ない。「トレーディングはすべからく投資家には有害なのだ」と言ったバンガード・グループの創始者、ジョン・ボーグルに私は賛成だ。彼に言わせると、「トレーディングに手を染めると、自らの首を絞めることになる。その誘惑に負けそうになったらミス・マフェットにならって、蜘蛛（スパイダーズ）やその同類を見かけたら、さっさと逃げることだ」",
@@ -12297,7 +12297,7 @@ export const books = [
     "isbn": "9784048664875",
     "asin": "4048664875",
     "readDate": "2018/11/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4875/9784048664875.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4875/9784048664875.jpg",
     "highlights": []
   },
   {
@@ -12308,7 +12308,7 @@ export const books = [
     "isbn": "9784270007082",
     "asin": "4270007087",
     "readDate": "2018/11/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7082/9784270007082.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7082/9784270007082.jpg",
     "highlights": []
   },
   {
@@ -12319,7 +12319,7 @@ export const books = [
     "isbn": "9784822246808",
     "asin": "4822246809",
     "readDate": "2018/11/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6808/9784822246808.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6808/9784822246808.jpg",
     "highlights": []
   },
   {
@@ -12330,7 +12330,7 @@ export const books = [
     "isbn": "9784023315303",
     "asin": "4023315303",
     "readDate": "2018/11/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5303/9784023315303.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5303/9784023315303.jpg",
     "highlights": []
   },
   {
@@ -12341,7 +12341,7 @@ export const books = [
     "isbn": "9784791765553",
     "asin": "4791765559",
     "readDate": "2018/11/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5553/9784791765553.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5553/9784791765553.jpg",
     "highlights": []
   },
   {
@@ -12352,7 +12352,7 @@ export const books = [
     "isbn": "9784152098023",
     "asin": "4152098023",
     "readDate": "2018/10/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8023/9784152098023.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8023/9784152098023.jpg",
     "highlights": []
   },
   {
@@ -12363,7 +12363,7 @@ export const books = [
     "isbn": "9784309464800",
     "asin": "4309464807",
     "readDate": "2018/10/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784309464800.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/9784309464800.jpg",
     "highlights": []
   },
   {
@@ -12374,7 +12374,7 @@ export const books = [
     "isbn": "9784152095657",
     "asin": "4152095652",
     "readDate": "2018/10/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5657/9784152095657.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5657/9784152095657.jpg",
     "highlights": [
       {
         "text": "私たち人間は、健康になるように進化したのではない。困難の多い多様な条件のもとでできるだけ多くの子を持てるようにと自然選択の作用を受けたのである。結果として、私たちは何不自由のない快適な条件のもとで何を食べ、どれだけ運動するかについて、合理的な選択ができるようには進化していない。",
@@ -12402,7 +12402,7 @@ export const books = [
     "isbn": "9784532356286",
     "asin": "4532356288",
     "readDate": "2018/10/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6286/9784532356286.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6286/9784532356286.jpg",
     "highlights": []
   },
   {
@@ -12413,7 +12413,7 @@ export const books = [
     "isbn": "9784760149858",
     "asin": "4760149856",
     "readDate": "2018/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9858/9784760149858.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9858/9784760149858.jpg",
     "highlights": []
   },
   {
@@ -12424,7 +12424,7 @@ export const books = [
     "isbn": "9780735213678",
     "asin": "0735213674",
     "readDate": "2018/10/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9780735213678.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3678/9780735213678.jpg",
     "highlights": []
   },
   {
@@ -12435,7 +12435,7 @@ export const books = [
     "isbn": "9784150503895",
     "asin": "4150503893",
     "readDate": "2018/10/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3895/9784150503895.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3895/9784150503895.jpg",
     "highlights": []
   },
   {
@@ -12446,7 +12446,7 @@ export const books = [
     "isbn": "9784152097989",
     "asin": "4152097981",
     "readDate": "2018/10/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7989/9784152097989.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7989/9784152097989.jpg",
     "highlights": []
   },
   {
@@ -12457,7 +12457,7 @@ export const books = [
     "isbn": "9784041030400",
     "asin": "4041030404",
     "readDate": "2018/10/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0400/9784041030400.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0400/9784041030400.jpg",
     "highlights": [
       {
         "text": "大切なのは、「心とは、そもそもそういうものだ」と理解しておくことです。心とは求めつづけるもの。それゆえに渇きつづけるもの──。",
@@ -12505,7 +12505,7 @@ export const books = [
     "isbn": "9784150505073",
     "asin": "4150505071",
     "readDate": "2018/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5073/9784150505073.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5073/9784150505073.jpg",
     "highlights": [
       {
         "text": "たとえば、〈モナド〉（１という数）は、あらゆる数の生成源であり、物質世界に存在する水、空気、火などと同じくらい現実的な実体であると同時に、あらゆる創造物の根源にある〝形而上学的な調和〟を意味するひとつの観念でもあった（ ８）。",
@@ -12529,7 +12529,7 @@ export const books = [
     "isbn": "9780062464347",
     "asin": "0062464345",
     "readDate": "2018/10/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4347/9780062464347.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4347/9780062464347.jpg",
     "highlights": []
   },
   {
@@ -12540,7 +12540,7 @@ export const books = [
     "isbn": "9784041017890",
     "asin": "4041017890",
     "readDate": "2018/09/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7890/9784041017890.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7890/9784041017890.jpg",
     "highlights": [
       {
         "text": "経験は我々に多くのことを教えてくれるが、その教え方は人生の貴重な時間を無駄に食い尽くしてしまう。ゆえに、その特別な知恵を学ぶために必要な時間の長さを考えると、経験による教えはそれほど価値があるとはいえない。死を目前にしてわかっても、それは無駄になるだけだ。さらに、経験による知識とは流行に似ている。今日、成功した行動も、 明日 にはもはやうまく働かず、役にたたないだろう。 原理原則だけが長続きする。そして今、私はこの原理原則を手にしている。なぜならば、私を偉大なものへと導いてくれる法則が、これらの巻物の言葉の中にあるからだ。",
@@ -12568,7 +12568,7 @@ export const books = [
     "isbn": "9784488590017",
     "asin": "4488590012",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4885/48859001.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4885/48859001.jpg",
     "highlights": [
       {
         "text": "人間とは究極的には、無数の多種多様な独立した人格の集合体と考えられるかもしれないということだ。",
@@ -12584,7 +12584,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2018/09/26",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -12595,7 +12595,7 @@ export const books = [
     "isbn": "9784150310585",
     "asin": "4150310580",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0585/9784150310585.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0585/9784150310585.jpg",
     "highlights": []
   },
   {
@@ -12606,7 +12606,7 @@ export const books = [
     "isbn": "9784344031821",
     "asin": "4344031822",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1821/9784344031821.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1821/9784344031821.jpg",
     "highlights": []
   },
   {
@@ -12617,7 +12617,7 @@ export const books = [
     "isbn": "9784334036676",
     "asin": "4334036678",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6676/9784334036676.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6676/9784334036676.jpg",
     "highlights": [
       {
         "text": "この解釈では、観測者に認識できなくなってしまった世界が無数に存在していることになります。それは膨大な数の平行世界となって存在し続けます。あなたはすべてのありうる世界に無数に分裂していくことになります。エヴェレット解釈の支持者であるブライス・ドウィットは、この解釈を「多世界解釈」と呼びました。",
@@ -12649,7 +12649,7 @@ export const books = [
     "isbn": "9784150103361",
     "asin": "4150103364",
     "readDate": "2018/09/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "こうした不平は、人間性に本来そなわった一つの習性なのだ。石炭時代の人々は、蒸気機関の発明に不平を鳴らしている。シェイクスピアの芝居の一つに出てくる配役は、火薬の発明を嘆いている。おそらく、千年後の時代の人々は、電子頭脳の発明を非難していることだろう。",
@@ -12689,7 +12689,7 @@ export const books = [
     "isbn": "9784150313142",
     "asin": "4150313148",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3142/9784150313142.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3142/9784150313142.jpg",
     "highlights": [
       {
         "text": "意識とは、文明により個人にダウンロードされるソフトウェアである、と。",
@@ -12705,7 +12705,7 @@ export const books = [
     "isbn": "9784488018252",
     "asin": "4488018254",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784488018252.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8252/9784488018252.jpg",
     "highlights": []
   },
   {
@@ -12716,7 +12716,7 @@ export const books = [
     "isbn": "9784783725077",
     "asin": "4783725071",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -12727,7 +12727,7 @@ export const books = [
     "isbn": "9784265951376",
     "asin": "4265951376",
     "readDate": "2018/09/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1376/9784265951376.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1376/9784265951376.jpg",
     "highlights": []
   },
   {
@@ -12738,7 +12738,7 @@ export const books = [
     "isbn": "9784802510288",
     "asin": "4802510284",
     "readDate": "2018/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0288/9784802510288.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0288/9784802510288.jpg",
     "highlights": []
   },
   {
@@ -12749,7 +12749,7 @@ export const books = [
     "isbn": "9784295003359",
     "asin": "4295003352",
     "readDate": "2018/09/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3359/9784295003359.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3359/9784295003359.jpg",
     "highlights": []
   },
   {
@@ -12760,7 +12760,7 @@ export const books = [
     "isbn": "9784150120856",
     "asin": "4150120854",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0856/9784150120856.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0856/9784150120856.jpg",
     "highlights": [
       {
         "text": "「悔い改めよ、ハーレクィン！」とチクタクマンはいった。 「くそくらえ」 彼らは〈矯正院〉へ彼を送った。彼らは〈矯正院〉で彼をたたきなおした。それは『一九八四年』でウィンストン・スミスが受けた方法とそっくりだったが、誰もそんな本のことを覚えていなかったし、どうせ技術は大昔からあるものだった。",
@@ -12776,7 +12776,7 @@ export const books = [
     "isbn": "9784101800998",
     "asin": "4101800995",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0998/9784101800998.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0998/9784101800998.jpg",
     "highlights": []
   },
   {
@@ -12787,7 +12787,7 @@ export const books = [
     "isbn": "9784797490039",
     "asin": "4797490039",
     "readDate": "2018/09/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7974/79749003.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7974/79749003.jpg",
     "highlights": []
   },
   {
@@ -12798,7 +12798,7 @@ export const books = [
     "isbn": "9784003233511",
     "asin": "4003233514",
     "readDate": "2018/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784003233511.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3511/9784003233511.jpg",
     "highlights": []
   },
   {
@@ -12809,7 +12809,7 @@ export const books = [
     "isbn": "9784152093967",
     "asin": "415209396X",
     "readDate": "2018/09/19",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3967/9784152093967.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3967/9784152093967.jpg",
     "highlights": []
   },
   {
@@ -12820,7 +12820,7 @@ export const books = [
     "isbn": "9784167907822",
     "asin": "4167907828",
     "readDate": "2018/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7822/9784167907822.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7822/9784167907822.jpg",
     "highlights": []
   },
   {
@@ -12831,7 +12831,7 @@ export const books = [
     "isbn": "9784834081374",
     "asin": "4834081370",
     "readDate": "2018/09/17",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1374/9784834081374.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1374/9784834081374.jpg",
     "highlights": []
   },
   {
@@ -12842,7 +12842,7 @@ export const books = [
     "isbn": "9784560007501",
     "asin": "4560007500",
     "readDate": "2018/09/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7501/9784560007501.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7501/9784560007501.jpg",
     "highlights": []
   },
   {
@@ -12853,7 +12853,7 @@ export const books = [
     "isbn": "9784047344518",
     "asin": "4047344516",
     "readDate": "2018/09/14",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4518/9784047344518.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4518/9784047344518.jpg",
     "highlights": []
   },
   {
@@ -12864,7 +12864,7 @@ export const books = [
     "isbn": "9784003279212",
     "asin": "4003279212",
     "readDate": "2018/09/13",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9212/9784003279212.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9212/9784003279212.jpg",
     "highlights": []
   },
   {
@@ -12875,7 +12875,7 @@ export const books = [
     "isbn": "9784062202947",
     "asin": "4062202948",
     "readDate": "2018/09/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2947/9784062202947.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2947/9784062202947.jpg",
     "highlights": []
   },
   {
@@ -12886,7 +12886,7 @@ export const books = [
     "isbn": "9784087606249",
     "asin": "4087606244",
     "readDate": "2018/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6249/9784087606249.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6249/9784087606249.jpg",
     "highlights": []
   },
   {
@@ -12897,7 +12897,7 @@ export const books = [
     "isbn": "9784152093950",
     "asin": "4152093951",
     "readDate": "2018/09/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3950/9784152093950.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3950/9784152093950.jpg",
     "highlights": []
   },
   {
@@ -12908,7 +12908,7 @@ export const books = [
     "isbn": "9784102200025",
     "asin": "4102200029",
     "readDate": "2018/09/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0025/9784102200025.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0025/9784102200025.jpg",
     "highlights": []
   },
   {
@@ -12919,7 +12919,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2018/09/08",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "ひとつ言えることは、この「鈍感力」こそが、見たこともない景色を見せてくれたということ。",
@@ -12939,7 +12939,7 @@ export const books = [
     "isbn": "9784065125557",
     "asin": "4065125553",
     "readDate": "2018/09/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5557/9784065125557.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5557/9784065125557.jpg",
     "highlights": [
       {
         "text": "作者は。ほとんどなんの良心の 呵責 もなく物語の登場人物を殺す。どころか利用する。娯楽に。感動に。 憂さ晴らしに。 ある意味では死の展示場。良質な物語を生むための死の生産工場。ほとんどすべての物語は不幸を必要とする。まず不幸がある。それを解体。解決してハッピーエンド。または失敗してバッドエンド。多くの物語に共通する基本構造。なるほど身勝手かもな。",
@@ -12955,7 +12955,7 @@ export const books = [
     "isbn": "9784150505189",
     "asin": "4150505187",
     "readDate": "2018/09/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5189/9784150505189.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5189/9784150505189.jpg",
     "highlights": [
       {
         "text": "が、海賊版のｍｐ３の大半は、少数の組織されたグループから発信されていた。",
@@ -12975,7 +12975,7 @@ export const books = [
     "isbn": "9784152095459",
     "asin": "4152095458",
     "readDate": "2018/08/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5459/9784152095459.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5459/9784152095459.jpg",
     "highlights": []
   },
   {
@@ -12986,7 +12986,7 @@ export const books = [
     "isbn": "9784151310805",
     "asin": "4151310800",
     "readDate": "2018/08/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0805/9784151310805.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0805/9784151310805.jpg",
     "highlights": [
       {
         "text": "頭文字はどっちも同じで、Ｕ・Ｎ・Ｏｗｅｎだ。ところで、ちょいと連想を働かせて、この名前をＵＮｋｎｏｗｎと変えてみたら、どうだろう。アンノウン、すなわち、〝名なし〟だよ！」",
@@ -13002,7 +13002,7 @@ export const books = [
     "isbn": "9784163908502",
     "asin": "4163908501",
     "readDate": "2018/08/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8502/9784163908502.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8502/9784163908502.jpg",
     "highlights": [
       {
         "text": "製薬会社には思いがけない味方がいた。１９６０年に『引き裂かれた自己（６）』を著した精神分析医のＲ・Ｄ・レインだ。この本はカウンターカルチャーのバイブルになった。ヒッピー、吟遊詩人、アメリカやヨーロッパの大学で反戦活動を行っていた活動家がこの本を抱え、狂気は「狂った世界への完全に合理的な反応だ」というレインの教義を唱えていた。 レインの名声はまたたく間に広まった。レインは「反精神医学」運動の顔になり、精神病の烙印を押すことを終わりにしようと訴えた。レインは狂気を前向きな概念として捉えていた。ベトナム戦争を賞賛し、大学構内での銃乱射を許すような社会では、人の精神が社会そのものよりも狂っているとは考えられないと唱えた。実際、反対意見に「狂気」という烙印を押すこと自体が、彼らの口を封じる手段なのだと言っていた。",
@@ -13038,7 +13038,7 @@ export const books = [
     "isbn": "9784150504199",
     "asin": "4150504199",
     "readDate": "2018/07/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4199/9784150504199.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4199/9784150504199.jpg",
     "highlights": [
       {
         "text": "金銭的インセンティブに頼るかどうかを決めるには、そのインセンティブが、守るに値する姿勢や規範を蝕むかどうかを問う必要がある。この問いに答えるには、市場の論理は道徳の論理にならざるをえない。要するに、経済学者は「道徳を売買」しなければならないのである。",
@@ -13054,7 +13054,7 @@ export const books = [
     "isbn": "9784061842236",
     "asin": "4061842234",
     "readDate": "2018/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/06184223.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0618/06184223.jpg",
     "highlights": []
   },
   {
@@ -13065,7 +13065,7 @@ export const books = [
     "isbn": "9784101001708",
     "asin": "4101001707",
     "readDate": "2018/07/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1708/9784101001708.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1708/9784101001708.jpg",
     "highlights": []
   },
   {
@@ -13076,7 +13076,7 @@ export const books = [
     "isbn": "9784065122617",
     "asin": "4065122619",
     "readDate": "2018/07/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2617/9784065122617.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2617/9784065122617.jpg",
     "highlights": []
   },
   {
@@ -13087,7 +13087,7 @@ export const books = [
     "isbn": "9784152091314",
     "asin": "4152091312",
     "readDate": "2018/07/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1314/9784152091314.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1314/9784152091314.jpg",
     "highlights": []
   },
   {
@@ -13098,7 +13098,7 @@ export const books = [
     "isbn": "9784334033583",
     "asin": "433403358X",
     "readDate": "2018/07/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403358.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403358.jpg",
     "highlights": [
       {
         "text": "動物というのは、基本的な設計をもつ祖先がいる。そして次の段階は、その祖先の設計図を借りてきて変更するしか、新たな動物を創り出す術はない。だから、新しい設計は、所詮は祖先の設計図のどこかを消しゴムで消し、何か簡単にできることを付け加えることでしか、実現できないのだ。",
@@ -13114,7 +13114,7 @@ export const books = [
     "isbn": "9784167658144",
     "asin": "4167658143",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8144/9784167658144.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8144/9784167658144.jpg",
     "highlights": [
       {
         "text": "戦って勝つためには「非人間的」でなくてはならないと、すなわち「人間らしさ」を捨てて機械や昆虫のように感情のない無機質な装甲兵器になってしまわなくてはダメなのだと、彼らが無意識に考えているということなのだろうか？ だとしたら、男の子は大変だなぁ。幼い頃から「戦って勝つ」ことを義務づけられ、そのために「人間性を捨てよ」と諭されているも同然ではないか。次から次に現れるより強大な敵と戦い続け、しかも負けることを許されず、そのためには人間であることすら捨てなくてはならないなんて、そんなメッセージを幼少時から受け取り続けた男の子たちは、実生活において否応なく「負け」を認めなくてはならなくなった時に、女の子よりも遥かに大きな挫折感を味わうのだろうな。",
@@ -13138,7 +13138,7 @@ export const books = [
     "isbn": "9784167658137",
     "asin": "4167658135",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8137/9784167658137.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8137/9784167658137.jpg",
     "highlights": [
       {
         "text": "女王様は、太宰治が大嫌いである。 単なる人でなしのくせに、文学的あるいは哲学的な苦悩と絶望を声高に喧伝することによって、己の弱さや愚劣さやだらしなさを正当化している、キザで驕慢なナルシスト……これが女王様の「太宰」観だ。",
@@ -13154,7 +13154,7 @@ export const books = [
     "isbn": "9784488146078",
     "asin": "4488146074",
     "readDate": "2018/07/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6078/9784488146078.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6078/9784488146078.jpg",
     "highlights": []
   },
   {
@@ -13165,7 +13165,7 @@ export const books = [
     "isbn": "9784167658120",
     "asin": "4167658127",
     "readDate": "2018/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8120/9784167658120.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8120/9784167658120.jpg",
     "highlights": [
       {
         "text": "接客業においてもっとも必要とされる能力は、客が何を求めて来ているのか、自分はどんな役割を果たせばいいのか、瞬時に摑むセンスだと思う。指名したホストには色恋を求めても、ヘルプに求めるものは、また",
@@ -13197,7 +13197,7 @@ export const books = [
     "isbn": "9784023316324",
     "asin": "4023316326",
     "readDate": "2018/07/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6324/9784023316324.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6324/9784023316324.jpg",
     "highlights": []
   },
   {
@@ -13208,7 +13208,7 @@ export const books = [
     "isbn": "9784163900247",
     "asin": "4163900241",
     "readDate": "2018/07/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0247/9784163900247.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0247/9784163900247.jpg",
     "highlights": [
       {
         "text": "現在、「草食男子」などと呼ばれる若い男たちも、女のエロス権力への潜在的な恐怖を「抑圧」ではなく「忌避」という形で表現している人々なのかもしれない。男は生涯、女を恐れ続ける生き物なのだ。",
@@ -13284,7 +13284,7 @@ export const books = [
     "isbn": "9784167658076",
     "asin": "4167658070",
     "readDate": "2018/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765807.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765807.jpg",
     "highlights": [
       {
         "text": "世の中の人間のタイプは「自分の持っていない物を数えあげつつ生きる人」と「自分の持っている物を数えあげつつ生きる人」の、大きくふたつに分かれるのかもしれない。 傍",
@@ -13308,7 +13308,7 @@ export const books = [
     "isbn": "9784167658052",
     "asin": "4167658054",
     "readDate": "2018/06/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765805.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1676/16765805.jpg",
     "highlights": [
       {
         "text": "ちょっとしたファンタジー小説並みの「心の旅」であったのだ。ファンタジー小説とは、「往きて還りし物語」である、と言われる。主人公が何かを求めて旅立ち、そして最後に戻ってくる物語。",
@@ -13336,7 +13336,7 @@ export const books = [
     "isbn": "9784757160590",
     "asin": "4757160593",
     "readDate": "2018/06/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0590/9784757160590.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0590/9784757160590.jpg",
     "highlights": []
   },
   {
@@ -13347,7 +13347,7 @@ export const books = [
     "isbn": "9784757746466",
     "asin": "4757746466",
     "readDate": "2018/06/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6466/9784757746466.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6466/9784757746466.jpg",
     "highlights": []
   },
   {
@@ -13358,7 +13358,7 @@ export const books = [
     "isbn": "9784167658106",
     "asin": "4167658100",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8106/9784167658106.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8106/9784167658106.jpg",
     "highlights": [
       {
         "text": "ナルシシズムとは何か。それは、他者の視線を満たすことだけを欲求する空っぽの自己なのである。",
@@ -13402,7 +13402,7 @@ export const books = [
     "isbn": "9784140815458",
     "asin": "4140815450",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5458/9784140815458.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5458/9784140815458.jpg",
     "highlights": [
       {
         "text": "もしもアップルがこのまま自分たちの道を進めば、すべての製品のボタンはひとつになる。今では、Siri（シリ）という音声認識機能も開発されたので、ボタンがなくなる日を覚悟してもいいだろう。結局、「１」よりもシンプルな数字は「０」だけだからだ。",
@@ -13430,7 +13430,7 @@ export const books = [
     "isbn": "9784314010030",
     "asin": "4314010037",
     "readDate": "2018/06/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3140/31401003.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3140/31401003.jpg",
     "highlights": []
   },
   {
@@ -13441,7 +13441,7 @@ export const books = [
     "isbn": "9784757160583",
     "asin": "4757160585",
     "readDate": "2018/06/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0583/9784757160583.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0583/9784757160583.jpg",
     "highlights": []
   },
   {
@@ -13452,7 +13452,7 @@ export const books = [
     "isbn": "9784334751791",
     "asin": "4334751792",
     "readDate": "2018/06/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1791/9784334751791.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1791/9784334751791.jpg",
     "highlights": []
   },
   {
@@ -13463,7 +13463,7 @@ export const books = [
     "isbn": "9784150503680",
     "asin": "4150503680",
     "readDate": "2018/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784150503680.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3680/9784150503680.jpg",
     "highlights": [
       {
         "text": "「これはゲーテが『ファウスト』のなかで使ってる言葉で、ルーカスはそれに現代語という服を着せている。科学技術はわれわれを救いはしない、というメッセージだ。現代のコンピュータ、機械器具、そんなものでは十分ではない。われわれは自分の直観に、自分の真の存在に頼らなければならない」",
@@ -13523,7 +13523,7 @@ export const books = [
     "isbn": "9784309253725",
     "asin": "4309253725",
     "readDate": "2018/06/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3725/9784309253725.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3725/9784309253725.jpg",
     "highlights": []
   },
   {
@@ -13534,7 +13534,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2018/06/12",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "① システム基本計画 … システム導入を検討する（本書では対象外） ②提案対応 … システムを導入する業者を決定する（本書では対象外） ③要件定義 … システムの要件を取りまとめる（2章） ④基本設計 … システムの基本的な動きをまとめる（3章） ⑤詳細設計 … パラメーターやフォローなどシステムの詳細を決める（4章） ⑥テスト … システム構築した結果をテストする（5章） ⑦移行 … システムを開始するための作業を行う（6章）",
@@ -13582,7 +13582,7 @@ export const books = [
     "isbn": "9784575154399",
     "asin": "4575154393",
     "readDate": "2018/06/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4399/9784575154399.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4399/9784575154399.jpg",
     "highlights": [
       {
         "text": "もっと重要な教訓がある。こういう学生たちは、結婚したあと、いずれ定年離婚になるのではないかということである。なぜなら、出産に対する態度が「知ってらア」なのだから、育児だって同じだろうと思われるからである。おそらく自分では育児に関わらないし、関わる気もないかもしれない。結婚する気すらないかもしれない。",
@@ -13734,7 +13734,7 @@ export const books = [
     "isbn": "9784152097323",
     "asin": "4152097329",
     "readDate": "2018/06/04",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784152097323.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7323/9784152097323.jpg",
     "highlights": []
   },
   {
@@ -13745,7 +13745,7 @@ export const books = [
     "isbn": "9784798039435",
     "asin": "4798039438",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9435/9784798039435.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9435/9784798039435.jpg",
     "highlights": []
   },
   {
@@ -13756,7 +13756,7 @@ export const books = [
     "isbn": "9784101171050",
     "asin": "410117105X",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1050/9784101171050.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1050/9784101171050.jpg",
     "highlights": [
       {
         "text": "マスコミが報道すれば、なんだってビッグ・ニュースになるのです」彼はうなずいた。「報道価値なんて、報道したあとからいくらでも出てくるんです。",
@@ -13772,7 +13772,7 @@ export const books = [
     "isbn": "9784822267896",
     "asin": "482226789X",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7896/9784822267896.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7896/9784822267896.jpg",
     "highlights": []
   },
   {
@@ -13783,7 +13783,7 @@ export const books = [
     "isbn": "9784152097316",
     "asin": "4152097310",
     "readDate": "2018/05/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7316/9784152097316.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7316/9784152097316.jpg",
     "highlights": []
   },
   {
@@ -13794,7 +13794,7 @@ export const books = [
     "isbn": "9784062050760",
     "asin": "4062050765",
     "readDate": "2018/05/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784062050760.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784062050760.jpg",
     "highlights": []
   },
   {
@@ -13805,7 +13805,7 @@ export const books = [
     "isbn": "9784152097576",
     "asin": "4152097574",
     "readDate": "2018/05/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784152097576.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784152097576.jpg",
     "highlights": [
       {
         "text": "なぜ人間は、ほれぼれするような知性と、がっかりするような無知をあわせ持っているのか。たいていの人間は限られた理解しか持ち合わせていないのに、これほど多くを成し遂げてこられたのはなぜなのか。本書ではこうした疑問に答えていく。",
@@ -13873,7 +13873,7 @@ export const books = [
     "isbn": "9784766421620",
     "asin": "4766421620",
     "readDate": "2018/05/21",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1620/9784766421620.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1620/9784766421620.jpg",
     "highlights": []
   },
   {
@@ -13884,7 +13884,7 @@ export const books = [
     "isbn": "9784334751647",
     "asin": "4334751644",
     "readDate": "2018/05/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1647/9784334751647.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1647/9784334751647.jpg",
     "highlights": [
       {
         "text": "天の星々よ、光を消せ。おれのこの胸の奥底にわだかまる黒い野望に、光を当てるな。手のやることを目には見せるな。やらねばならぬ。やってしまって、たとえ目が見るのを怖れるようなことであっても、やるしかない。（",
@@ -13912,7 +13912,7 @@ export const books = [
     "isbn": "9784062884426",
     "asin": "4062884429",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4426/9784062884426.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4426/9784062884426.jpg",
     "highlights": [
       {
         "text": "中世盛期以降、ドイツの貴族は城・領地・修道院の三つをもって勢力の基盤とした",
@@ -13956,7 +13956,7 @@ export const books = [
     "isbn": "9784880591452",
     "asin": "4880591459",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/51iqmXywSnL._AC_SL1500_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/51iqmXywSnL._AC_SL1500_.jpg",
     "highlights": []
   },
   {
@@ -13967,7 +13967,7 @@ export const books = [
     "isbn": "9784042118046",
     "asin": "4042118046",
     "readDate": "2018/05/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8046/9784042118046.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8046/9784042118046.jpg",
     "highlights": [
       {
         "text": "た。「自分がどんなに大きなお姉さんなのか考えなさい。今日はどんなにがんばったか考えなさい。今、何時だか考えなさい。なんでもいいから考えなさい。とにかく泣いちゃだめ！」",
@@ -13991,7 +13991,7 @@ export const books = [
     "isbn": "9784781680088",
     "asin": "4781680089",
     "readDate": "2018/05/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0088/9784781680088.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0088/9784781680088.jpg",
     "highlights": [
       {
         "text": "完成した標語よりも、標語について人々に考えさせることのほうが、社会的な影響力があると考えられていたのである。高額の賞金を用意し、射幸心を利用して人々を教化しようというのも、「楽しいプロパガンダ」の一種であったことがわかるだろう。",
@@ -14007,7 +14007,7 @@ export const books = [
     "isbn": "9784334037383",
     "asin": "4334037380",
     "readDate": "2018/05/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7383/9784334037383.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7383/9784334037383.jpg",
     "highlights": [
       {
         "text": "ます。「左右」の意味を「東西南北」で説明し、「東西南北」を「左右」で説明するのは、循環論法です。 『新明解国語辞典』は、この点、工夫しています。 みぎ【右】 アナログ時計の文字盤に向かった時に、一時から五時までの表示のある側。〔「明」という漢字の「月」が書かれている側と一致〕 （『新明解国語辞典』第７版）",
@@ -14039,7 +14039,7 @@ export const books = [
     "isbn": "9784062072281",
     "asin": "4062072289",
     "readDate": "2018/05/11",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2281/9784062072281.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2281/9784062072281.jpg",
     "highlights": []
   },
   {
@@ -14050,7 +14050,7 @@ export const books = [
     "isbn": "9784061592995",
     "asin": "4061592998",
     "readDate": "2018/05/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2995/9784061592995.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2995/9784061592995.jpg",
     "highlights": []
   },
   {
@@ -14061,7 +14061,7 @@ export const books = [
     "isbn": "9784863541948",
     "asin": "4863541945",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1948/9784863541948.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1948/9784863541948.jpg",
     "highlights": []
   },
   {
@@ -14072,7 +14072,7 @@ export const books = [
     "isbn": "9784822256784",
     "asin": "4822256782",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6784/9784822256784.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6784/9784822256784.jpg",
     "highlights": []
   },
   {
@@ -14083,7 +14083,7 @@ export const books = [
     "isbn": "9784167483210",
     "asin": "4167483211",
     "readDate": "2018/05/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3210/9784167483210.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3210/9784167483210.jpg",
     "highlights": [
       {
         "text": "その焼け跡を見て、何を思ったか──。俺はもう、この世で「絶対」という言葉は使わないぞ、と。「絶対に俺のうちは焼けない」とか、「絶対に俺は人を殺さない」とか、「絶対に神風は吹く」とか、「絶対に日本は勝つ」とか、そういうことはあり得ない、そんなものはウソだ、と自分の家の焼け跡に立ち、荒涼たる焼け野原を見ながら思ったんです。それ以来、わたくしは「絶対」という言葉は使っていない。",
@@ -14147,7 +14147,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2018/04/30",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -14158,7 +14158,7 @@ export const books = [
     "isbn": "9784167483159",
     "asin": "4167483157",
     "readDate": "2018/04/30",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3159/9784167483159.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3159/9784167483159.jpg",
     "highlights": [
       {
         "text": "今日の日本および日本人にとって、いちばん大切なものは〝平衡感覚〟によって復元力を身につけることではないかと思う。内外情勢の変化によって、右に左に、大きくゆれるということは、やむをえない。ただ、適当な時期に平衡をとり戻すことができるか、できないかによって、民族の、あるいは個人の運命がきまるのではあるまいか。",
@@ -14186,7 +14186,7 @@ export const books = [
     "isbn": "9784003226216",
     "asin": "4003226216",
     "readDate": "2018/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6216/9784003226216.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6216/9784003226216.jpg",
     "highlights": []
   },
   {
@@ -14197,7 +14197,7 @@ export const books = [
     "isbn": "9784839946531",
     "asin": "4839946531",
     "readDate": "2018/04/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6531/9784839946531.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6531/9784839946531.jpg",
     "highlights": [
       {
         "text": "すべてのメディアは、われわれのすみからすみまで変えてしまう。それらのメディアは個人的、政治的、経済的、美的、心理的、道徳的、倫理的、社会的な出来事のすべてに深く浸透しているから、メディアはわれわれのどんな部分にも触れ、影響を及ぼし、変えてしまう。メディアはマッサージである。こうした環境としてのメディアの作用に関する知識なしには、社会と文化の変動を理解することはできない。 （マクルーハン『メディアはマッサージである』より）",
@@ -14265,7 +14265,7 @@ export const books = [
     "isbn": "9784334033224",
     "asin": "4334033229",
     "readDate": "2018/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403322.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3340/33403322.jpg",
     "highlights": [
       {
         "text": "わかった状態になったとき、各部分からは、「文脈と矛盾なく関連がつき、文脈を介して他の部分とも矛盾なく関連がつく意味」が引き出されているのです。",
@@ -14285,7 +14285,7 @@ export const books = [
     "isbn": "9784065020418",
     "asin": "4065020417",
     "readDate": "2018/04/22",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0418/9784065020418.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0418/9784065020418.jpg",
     "highlights": []
   },
   {
@@ -14296,7 +14296,7 @@ export const books = [
     "isbn": "9784062884457",
     "asin": "4062884453",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4457/9784062884457.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4457/9784062884457.jpg",
     "highlights": [
       {
         "text": "モカとは、もともとアラビア半島南端のイエメンにある港町の名前です。",
@@ -14344,7 +14344,7 @@ export const books = [
     "isbn": "9784000259316",
     "asin": "4000259318",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9316/9784000259316.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9316/9784000259316.jpg",
     "highlights": []
   },
   {
@@ -14355,7 +14355,7 @@ export const books = [
     "isbn": "9784622078760",
     "asin": "4622078767",
     "readDate": "2018/04/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8760/9784622078760.gif",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8760/9784622078760.gif",
     "highlights": []
   },
   {
@@ -14366,7 +14366,7 @@ export const books = [
     "isbn": "9784000259309",
     "asin": "400025930X",
     "readDate": "2018/04/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9309/9784000259309.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9309/9784000259309.jpg",
     "highlights": []
   },
   {
@@ -14377,7 +14377,7 @@ export const books = [
     "isbn": "9784152095602",
     "asin": "4152095601",
     "readDate": "2018/04/09",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5602/9784152095602.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5602/9784152095602.jpg",
     "highlights": []
   },
   {
@@ -14388,7 +14388,7 @@ export const books = [
     "isbn": "9784480431691",
     "asin": "4480431691",
     "readDate": "2018/04/03",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1691/9784480431691.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1691/9784480431691.jpg",
     "highlights": []
   },
   {
@@ -14399,7 +14399,7 @@ export const books = [
     "isbn": "9784805727041",
     "asin": "4805727047",
     "readDate": "2018/04/02",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784805727041.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7041/9784805727041.jpg",
     "highlights": []
   },
   {
@@ -14410,7 +14410,7 @@ export const books = [
     "isbn": "9784480097576",
     "asin": "4480097570",
     "readDate": "2018/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784480097576.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7576/9784480097576.jpg",
     "highlights": []
   },
   {
@@ -14421,7 +14421,7 @@ export const books = [
     "isbn": "9784101098548",
     "asin": "4101098549",
     "readDate": "2018/03/31",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8548/9784101098548.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8548/9784101098548.jpg",
     "highlights": [
       {
         "text": "人類の理想はなんであろう。となると、これは大問題で一冊や二冊の本で論じきれるものではない。また、論じてみたところで、なんの結論も出てこないにきまっている。しかし、人間個人の理想となると、すべて共通で「ぬれ手でアワといった調子で大金をつかみたい」の一語につきる。この欲望が心の奥にあれば、あなたは人間であり、しかも正気であるとの証明ともなるわけであろう。",
@@ -14437,7 +14437,7 @@ export const books = [
     "isbn": "9784102033012",
     "asin": "4102033017",
     "readDate": "2018/03/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3012/9784102033012.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3012/9784102033012.jpg",
     "highlights": [
       {
         "text": "人間は精神的な教養を積むよりも富を積むほうに千万倍の努力を 献 げている。だからすでに得た富を 殖やそうとして、席の暖まる暇もないほどに忙しく、 蟻 のようにこつこつと、朝から晩まで骨を折っている人が実に多い。富を殖やすための手段の世界を自己の視界とし、この狭い視界からそとに出れば、何一つ知らない。精神はからっぽで、そのため、ほかのものはいっさい受けつける力がない。最高級の享楽、すなわち精神的享楽は、 高嶺 の花である。暇はかからないで金のかかる 刹那 的・感能的な享楽を合間合間にむさぼって、最高級の享楽の 填め合せをしようとするけれども、一向填め合せにはならない。",
@@ -14549,7 +14549,7 @@ export const books = [
     "isbn": "9784103145325",
     "asin": "4103145323",
     "readDate": "2018/03/28",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5325/9784103145325.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5325/9784103145325.jpg",
     "highlights": []
   },
   {
@@ -14560,7 +14560,7 @@ export const books = [
     "isbn": "9784334752064",
     "asin": "4334752063",
     "readDate": "2018/03/26",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2064/9784334752064.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2064/9784334752064.jpg",
     "highlights": [
       {
         "text": "資本とはなにか。 「蓄積され貯蔵された一定量の労働である。」（",
@@ -14600,7 +14600,7 @@ export const books = [
     "isbn": "9784488772017",
     "asin": "4488772013",
     "readDate": "2018/03/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2017/9784488772017.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2017/9784488772017.jpg",
     "highlights": []
   },
   {
@@ -14611,7 +14611,7 @@ export const books = [
     "isbn": "9784334753696",
     "asin": "4334753698",
     "readDate": "2018/03/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3696/9784334753696.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3696/9784334753696.jpg",
     "highlights": [
       {
         "text": "人間は精神的な教養を積むよりも富を積むほうに千万倍の努力を 献 げている。だからすでに得た富を 殖やそうとして、席の暖まる暇もないほどに忙しく、 蟻 のようにこつこつと、朝から晩まで骨を折っている人が実に多い。富を殖やすための手段の世界を自己の視界とし、この狭い視界からそとに出れば、何一つ知らない。精神はからっぽで、そのため、ほかのものはいっさい受けつける力がない。最高級の享楽、すなわち精神的享楽は、 高嶺 の花である。暇はかからないで金のかかる 刹那 的・感能的な享楽を合間合間にむさぼって、最高級の享楽の 填め合せをしようとするけれども、一向填め合せにはならない。",
@@ -14723,7 +14723,7 @@ export const books = [
     "isbn": "9784484101132",
     "asin": "4484101130",
     "readDate": "2018/03/07",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784484101132.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1132/9784484101132.jpg",
     "highlights": []
   },
   {
@@ -14734,7 +14734,7 @@ export const books = [
     "isbn": "9784391146912",
     "asin": "4391146916",
     "readDate": "2018/02/15",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6912/9784391146912.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6912/9784391146912.jpg",
     "highlights": []
   },
   {
@@ -14745,7 +14745,7 @@ export const books = [
     "isbn": "9784532356873",
     "asin": "4532356873",
     "readDate": "2018/02/12",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784532356873.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6873/9784532356873.jpg",
     "highlights": []
   },
   {
@@ -14756,7 +14756,7 @@ export const books = [
     "isbn": "9784000296441",
     "asin": "4000296442",
     "readDate": "2018/01/20",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6441/9784000296441.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6441/9784000296441.jpg",
     "highlights": []
   },
   {
@@ -14767,7 +14767,7 @@ export const books = [
     "isbn": "9784000296595",
     "asin": "4000296590",
     "readDate": "2018/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6595/9784000296595.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6595/9784000296595.jpg",
     "highlights": []
   },
   {
@@ -14778,7 +14778,7 @@ export const books = [
     "isbn": "9784802510172",
     "asin": "4802510179",
     "readDate": "2018/01/16",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784802510172.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0172/9784802510172.jpg",
     "highlights": []
   },
   {
@@ -14789,7 +14789,7 @@ export const books = [
     "isbn": "9784003369524",
     "asin": "4003369521",
     "readDate": "2018/01/05",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9524/9784003369524.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9524/9784003369524.jpg",
     "highlights": []
   },
   {
@@ -14800,7 +14800,7 @@ export const books = [
     "isbn": "9784327401689",
     "asin": "4327401684",
     "readDate": "2017/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1689/9784327401689.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1689/9784327401689.jpg",
     "highlights": []
   },
   {
@@ -14811,7 +14811,7 @@ export const books = [
     "isbn": "9784150503673",
     "asin": "4150503672",
     "readDate": "2017/12/29",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3673/9784150503673.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3673/9784150503673.jpg",
     "highlights": []
   },
   {
@@ -14822,7 +14822,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2017/12/28",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/31g6QOM7JaL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/31g6QOM7JaL.jpg",
     "highlights": [
       {
         "text": "自分が何気なく読んでいるこの「本」というものは、実はものすごいツールなのではないか。ここには著者の生きてきた時間が凝縮されている。ひとりの人間が何十年とかけて積み上げてきたものを、短時間で吸収できるのだ。思想、哲学、発見、知見、そしてメッセージ。活版印刷がどうして人類史上最大クラスの発明なのか、わかった気がした。どんな高度な思想や学術的発見があっても、多くの人に伝えられなければ意味がない。知識というのは伝達されるから意味があるのだ。",
@@ -14858,7 +14858,7 @@ export const books = [
     "isbn": "9784908059704",
     "asin": "4908059705",
     "readDate": "2017/12/24",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784908059704.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9704/9784908059704.jpg",
     "highlights": []
   },
   {
@@ -14869,7 +14869,7 @@ export const books = [
     "isbn": "9784106103506",
     "asin": "4106103508",
     "readDate": "2017/12/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3506/9784106103506.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3506/9784106103506.jpg",
     "highlights": []
   },
   {
@@ -14880,7 +14880,7 @@ export const books = [
     "isbn": "9784150312848",
     "asin": "4150312842",
     "readDate": "2017/12/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2848/9784150312848.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2848/9784150312848.jpg",
     "highlights": []
   },
   {
@@ -14891,7 +14891,7 @@ export const books = [
     "isbn": "9784167909819",
     "asin": "4167909812",
     "readDate": "2017/12/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9819/9784167909819.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9819/9784167909819.jpg",
     "highlights": [
       {
         "text": "大統領選は、「 輝ける アメリカ」「 美しい アメリカ」と、マヘリア・ジャクソンの唄のようなスローガンで、徹底的におしまくった。──対立候補は老練な国際政治家で、アジア、中東、ヨーロッパ、アフリカのこんがらかった状況に対する彼の展望は、的確で、説得力があり、海外での人気は圧倒的だったが、アメリカ国内では、かえって理解者がすくなかった。",
@@ -14919,7 +14919,7 @@ export const books = [
     "isbn": "9784484101019",
     "asin": "4484101017",
     "readDate": "2017/12/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1019/9784484101019.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1019/9784484101019.jpg",
     "highlights": []
   },
   {
@@ -14930,7 +14930,7 @@ export const books = [
     "isbn": "9784103145318",
     "asin": "4103145315",
     "readDate": "2017/12/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5318/9784103145318.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5318/9784103145318.jpg",
     "highlights": [
       {
         "text": "さっきから同じ場所をどうどう巡りしているような気がしてならない。もしかして作者が困っておるのか。続きをどう書いていいかわからなくなり、執筆を中断しているのだろうか。あるいは何か他の理由で書けなくなったのか。 その通り。おれは書けなくなった。何故おれが書けなくなったかを書かねばなるまい。そもそも日本という国は今、福島の原発事故によって大きな胃の病に冒されている。これでもし頭の病や心臓の病を併発し外傷を受けでもすれば日本は終りであり、それは誰もが知っており、例えばその恐ろしい夢を見て夜中に覚醒し、それが夢ではなくて現実の恐怖なのだと認識した時に迫ってくるものは背筋が凍りつくほどの冷酷なものだ。だが福島の人以外は、それが目醒めている時であれば誰もがこれから眼を背けようとする。一般の社会人は日常の瑣事に逃げ込み、政府とてすぐに国際問題や政争に眼を向けようとする。われわれ作家にしても、いかに真剣に原発事故のことを考えようとしたところで、ともすれば荒唐無稽なファンタジイに逃避してしまうのが落ちであろう。しかもそのようなファンタジイには現実に対してどのような効果があるのか。ストレスという病から読者を遠ざけちょっとしたカタルシスを与えるくらいが関の山だ。当然のことだが問題の解決からは遥かに遠い。政府の言い方を真似れば喫緊の課題となっている恐怖の源を前にしてわれわれは立ちすくみ、ただ何もできずにぼんやりしているだけだ。 この事故はあと何十年も何百年も、それどころか何万年も何十万年も尾を引いて後世に及ぶ。その責任は誰が取るのかと言えばわれわれに決まっているようなものなのだが、それはとても取れるようなものではないのだから、結局は前の戦争を起して周辺諸国に迷惑をかけたのが自分たちのひと世代、ふた… エクスポートの制限に達したため、一部のハイライトが非表示になっているか、省略されています。",
@@ -14946,7 +14946,7 @@ export const books = [
     "isbn": "9784150120092",
     "asin": "4150120099",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784150120092.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0092/9784150120092.jpg",
     "highlights": []
   },
   {
@@ -14957,7 +14957,7 @@ export const books = [
     "isbn": "9784101171159",
     "asin": "4101171157",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -14968,7 +14968,7 @@ export const books = [
     "isbn": "9784087711196",
     "asin": "4087711196",
     "readDate": "2017/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1196/9784087711196.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1196/9784087711196.jpg",
     "highlights": []
   },
   {
@@ -14979,7 +14979,7 @@ export const books = [
     "isbn": "9784101171012",
     "asin": "4101171017",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117101.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117101.jpg",
     "highlights": []
   },
   {
@@ -14990,7 +14990,7 @@ export const books = [
     "isbn": "9784101171074",
     "asin": "4101171076",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117107.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1011/10117107.jpg",
     "highlights": []
   },
   {
@@ -15001,7 +15001,7 @@ export const books = [
     "isbn": "9784101171135",
     "asin": "4101171130",
     "readDate": "2017/11/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1135/9784101171135.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1135/9784101171135.jpg",
     "highlights": []
   },
   {
@@ -15012,7 +15012,7 @@ export const books = [
     "isbn": "9784101006055",
     "asin": "4101006059",
     "readDate": "2017/11/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6055/9784101006055.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6055/9784101006055.jpg",
     "highlights": []
   },
   {
@@ -15023,7 +15023,7 @@ export const books = [
     "isbn": "9784065104408",
     "asin": "4065104408",
     "readDate": "2017/11/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784065104408.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4408/9784065104408.jpg",
     "highlights": []
   },
   {
@@ -15034,7 +15034,7 @@ export const books = [
     "isbn": "9784041099155",
     "asin": "4041099153",
     "readDate": "2017/11/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9155/9784041099155.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9155/9784041099155.jpg",
     "highlights": []
   },
   {
@@ -15045,7 +15045,7 @@ export const books = [
     "isbn": "9784778315306",
     "asin": "4778315308",
     "readDate": "2017/11/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5306/9784778315306.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5306/9784778315306.jpg",
     "highlights": []
   },
   {
@@ -15056,7 +15056,7 @@ export const books = [
     "isbn": "9784040723396",
     "asin": "4040723392",
     "readDate": "2017/11/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3396/9784040723396.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3396/9784040723396.jpg",
     "highlights": []
   },
   {
@@ -15067,7 +15067,7 @@ export const books = [
     "isbn": "9784480689894",
     "asin": "4480689893",
     "readDate": "2017/11/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9894/9784480689894.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9894/9784480689894.jpg",
     "highlights": [
       {
         "text": "『人生』の世界へようこそ！ ここではあなたは種族「ホモ・サピエンス」の１人としてゲームをプレイします。あなたは美味しい食事をしたり、生殖行為を行ったり、人から 讃えられたり、自尊心を満足させることで「幸福点」を入手できます。ゲームオーバーになるまでに他のプレイヤーよりも多くの「幸福点」を稼ぎ、ハイスコアを目指しましょう！",
@@ -15095,7 +15095,7 @@ export const books = [
     "isbn": "9784822245641",
     "asin": "4822245640",
     "readDate": "2017/11/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224564.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8222/82224564.jpg",
     "highlights": [
       {
         "text": "そして日本で建造した船舶を使ったコンテナ輸送サービスを推進すべく、四億四〇〇〇万ドルの補助金財源を確保する。いま考えると信じられないほど寛容な補助金だった。船会社は新造船の五％しか自己資金を用意する必要はない。残りは政府系の日本開発銀行（現日本政策投資銀行）が出してくれる。三年間は返済猶予、四年目から一〇年間で返済するが、金利は五・五％で、政府が開銀から借り入れる利率より低かった。これで足りない分は都市銀行から調達しなければならないが、それでも借入金利のうち二％は政府が負担してくれる。言ってみればプレゼントのようなものだった。日本の船会社は七〇年末までに、合計一五八隻をすべて日本の造船メーカーに発注した（原注 13）。 日本以外では、一九六九年七月に",
@@ -15111,7 +15111,7 @@ export const books = [
     "isbn": "9784480058652",
     "asin": "4480058656",
     "readDate": "2017/11/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48005865.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4800/48005865.jpg",
     "highlights": [
       {
         "text": "文字は新石器革命の条件ではなく結果として出現したのであり、知識を強固にするためというより、支配と搾取を容易にするためのものであったという考察を繰り広げる。",
@@ -15155,7 +15155,7 @@ export const books = [
     "isbn": "9784274068768",
     "asin": "4274068765",
     "readDate": "2017/11/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8768/9784274068768.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8768/9784274068768.jpg",
     "highlights": []
   },
   {
@@ -15166,7 +15166,7 @@ export const books = [
     "isbn": "9784150114510",
     "asin": "415011451X",
     "readDate": "2017/11/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011451.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011451.jpg",
     "highlights": []
   },
   {
@@ -15177,7 +15177,7 @@ export const books = [
     "isbn": "9784152097040",
     "asin": "4152097043",
     "readDate": "2017/10/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7040/9784152097040.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7040/9784152097040.jpg",
     "highlights": [
       {
         "text": "ドナトゥスはラテン語を書くのに用いられる文字とその種々の機能を一覧表にし、文字の3つの属性、すなわち字名 (nomen)、字形 (figura)、効力 (potestas) の定義で章を締めくくっている。アルフリック",
@@ -15209,7 +15209,7 @@ export const books = [
     "isbn": "9784062880381",
     "asin": "4062880385",
     "readDate": "2017/10/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0381/9784062880381.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0381/9784062880381.jpg",
     "highlights": [
       {
         "text": "FeliCaは、鉄道の自動改札をスムーズに通過するため、〇・二秒という短時間でデータの処理ができることを目指して開発された。最初に導入されたのは香港の交通カードであるオクトパスカードであったが、その後、ＪＲ東日本の Suica にも導入された。",
@@ -15233,7 +15233,7 @@ export const books = [
     "isbn": "9784167483104",
     "asin": "4167483106",
     "readDate": "2017/10/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1674/16748310.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1674/16748310.jpg",
     "highlights": [
       {
         "text": "ヒトラーは『わが闘争』で、日本人を想像力の欠如した劣等民族、ただしドイツの手先として使うなら、小器用で小利口で役に立つ国民",
@@ -15253,7 +15253,7 @@ export const books = [
     "isbn": "9784794218797",
     "asin": "4794218796",
     "readDate": "2017/10/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8797/9784794218797.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8797/9784794218797.jpg",
     "highlights": []
   },
   {
@@ -15264,7 +15264,7 @@ export const books = [
     "isbn": "9784151200519",
     "asin": "4151200517",
     "readDate": "2017/10/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0519/9784151200519.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0519/9784151200519.jpg",
     "highlights": []
   },
   {
@@ -15275,7 +15275,7 @@ export const books = [
     "isbn": "9784873117003",
     "asin": "4873117003",
     "readDate": "2017/10/02",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7003/9784873117003.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7003/9784873117003.jpg",
     "highlights": []
   },
   {
@@ -15286,7 +15286,7 @@ export const books = [
     "isbn": "9784140086681",
     "asin": "4140086688",
     "readDate": "2017/10/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6681/9784140086681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6681/9784140086681.jpg",
     "highlights": []
   },
   {
@@ -15297,7 +15297,7 @@ export const books = [
     "isbn": "9784309462554",
     "asin": "4309462553",
     "readDate": "2017/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3094/30946255.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3094/30946255.jpg",
     "highlights": [
       {
         "text": "本書によれば「生命、宇宙、その他もろもろ」の究極の答えは四十二である。なぜ四十二なのか、これについては「エジプトの『死者の書』に出てくる神の数と同じ」とか「ルイス・キャロルの『アリス』に出てくる規則の番号と同じ」とかいろいろ言われているようだが、ダグラス・アダムス本人は一貫して、「まったく意味のない数字として選んだ」と語っている。",
@@ -15317,7 +15317,7 @@ export const books = [
     "isbn": "9784062749367",
     "asin": "406274936X",
     "readDate": "2017/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0627/06274936.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0627/06274936.jpg",
     "highlights": [
       {
         "text": "生きてても虚しいわ。どんな偉いもんになってもどんなたくさんお金儲けても、人間死んだら煙か土か食い物や。火に焼かれて煙になるか、地に埋められて土んなるか、下手したらケモノに食べられてまうんやで」。",
@@ -15333,7 +15333,7 @@ export const books = [
     "isbn": "9784150113377",
     "asin": "4150113378",
     "readDate": "2017/09/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011337.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011337.jpg",
     "highlights": [
       {
         "text": "いずれ、バッハをきいたときに感じる歓びの生理学的根拠を、順を追って説明する人が出てくるだろうが、だからといって、いきなりその歓びが、〝原始的な〟反応だとか、生物学的ないかさまだとか、陶酔薬による高揚感と同様の空虚な体験だとかいうことになったりするだろうか？ 「あの子の笑顔を見",
@@ -15373,7 +15373,7 @@ export const books = [
     "isbn": "9784094516746",
     "asin": "4094516743",
     "readDate": "2017/09/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6746/9784094516746.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6746/9784094516746.jpg",
     "highlights": []
   },
   {
@@ -15384,7 +15384,7 @@ export const books = [
     "isbn": "9784794218780",
     "asin": "4794218788",
     "readDate": "2017/09/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8780/9784794218780.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8780/9784794218780.jpg",
     "highlights": []
   },
   {
@@ -15395,7 +15395,7 @@ export const books = [
     "isbn": "9784152097033",
     "asin": "4152097035",
     "readDate": "2017/09/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7033/9784152097033.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7033/9784152097033.jpg",
     "highlights": [
       {
         "text": "コンピューターについて、ノーバート・ウィーナーはたんなる微分方程式の計算機にとどまらないと考え、ヴァニヴァー・ブッシュは情報整理の効率化に役立つに違いないと信じた。そしてリックライダーは、その「思考する機械」を、何よりもまず通信デバイスとしてとらえた。人間とコンピューターとで労働を分配すれば、時間を節約し、民主制を洗練し、意思決定を改善できると彼は主張した。",
@@ -15411,7 +15411,7 @@ export const books = [
     "isbn": "9784864724920",
     "asin": "486472492X",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4920/9784864724920.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4920/9784864724920.jpg",
     "highlights": []
   },
   {
@@ -15422,7 +15422,7 @@ export const books = [
     "isbn": "9784864725330",
     "asin": "4864725330",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5330/9784864725330.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5330/9784864725330.jpg",
     "highlights": []
   },
   {
@@ -15433,7 +15433,7 @@ export const books = [
     "isbn": "9784864723473",
     "asin": "4864723478",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3473/9784864723473.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3473/9784864723473.jpg",
     "highlights": []
   },
   {
@@ -15444,7 +15444,7 @@ export const books = [
     "isbn": "9784864725866",
     "asin": "4864725861",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5866/9784864725866.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5866/9784864725866.jpg",
     "highlights": []
   },
   {
@@ -15455,7 +15455,7 @@ export const books = [
     "isbn": "9784864725620",
     "asin": "4864725624",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5620/9784864725620.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5620/9784864725620.jpg",
     "highlights": []
   },
   {
@@ -15466,7 +15466,7 @@ export const books = [
     "isbn": "9784864725217",
     "asin": "4864725217",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5217/9784864725217.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5217/9784864725217.jpg",
     "highlights": []
   },
   {
@@ -15477,7 +15477,7 @@ export const books = [
     "isbn": "9784864725408",
     "asin": "4864725403",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5408/9784864725408.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5408/9784864725408.jpg",
     "highlights": []
   },
   {
@@ -15488,7 +15488,7 @@ export const books = [
     "isbn": "9784864726023",
     "asin": "4864726027",
     "readDate": "2017/09/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6023/9784864726023.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6023/9784864726023.jpg",
     "highlights": []
   },
   {
@@ -15499,7 +15499,7 @@ export const books = [
     "isbn": "9784334037468",
     "asin": "4334037461",
     "readDate": "2017/09/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7468/9784334037468.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7468/9784334037468.jpg",
     "highlights": []
   },
   {
@@ -15510,7 +15510,7 @@ export const books = [
     "isbn": "9784344426429",
     "asin": "4344426428",
     "readDate": "2017/09/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6429/9784344426429.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6429/9784344426429.jpg",
     "highlights": [
       {
         "text": "生きるのが苦しくなったときは、世間の価値観や周りの意見にとらわれずに「自分が何が好きか」という感覚をしっかり持つことが大事だ。「自分はこれが好きだ、これをしているときが幸せだ」というものをはっきり持てば充実感を味わえるし、同じような趣味や価値観を持つ仲間もできるし、人との繫がりができればそれが社会の中の居場所として自分を支えてくれる。",
@@ -15546,7 +15546,7 @@ export const books = [
     "isbn": "9784048704731",
     "asin": "4048704737",
     "readDate": "2017/09/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4731/9784048704731.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4731/9784048704731.jpg",
     "highlights": [
       {
         "text": "「作品の中にルールを作る。読者もそのルールを理解する。するとルールに 則っている間は先の展開が予測しやすくなるので、非常に読みやすくなります。逆にルールからわざと逸脱すれば、読者の感情を動かし、サプライズを与える事ができる。時計の振り子を想像してみて下さい。左に振れる。次は右に振れる。少し眺めていればそれだけでルールが完成します。〝左の次は右、右の次は左〟。読者は次の動きが予想できますから、とても読みやすい。あとは振り子の動きを少しずつ、少しずつ大きくしていく。そうして読みやすさを保ったままで大きな流れに引き込むんです」",
@@ -15562,7 +15562,7 @@ export const books = [
     "isbn": "9784041395035",
     "asin": "4041395038",
     "readDate": "2017/08/31",
-    "thumnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51Z0KGUTkUL.jpg",
+    "thumbnailImage": "https://images-fe.ssl-images-amazon.com/images/I/51Z0KGUTkUL.jpg",
     "highlights": []
   },
   {
@@ -15573,7 +15573,7 @@ export const books = [
     "isbn": "9784163906836",
     "asin": "4163906835",
     "readDate": "2017/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6836/9784163906836.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6836/9784163906836.jpg",
     "highlights": [
       {
         "text": "ダニエルは世界には目に見えない優しい力があるという考えを、まだ捨てることができないでいた。「わたしは両親と同じ 蚊帳 の中で寝ていた。両親は大きなベッド、わたしは小さなベッドだ。わたしは九歳だった。そして神に祈った。こんな祈りの言葉を唱えたんだ。神様、あなたがとても忙しいことや、いまが厳しい時代だということはわかっています。多くは望みません。ただもう一日、生きながらえさせてください、と」",
@@ -15593,7 +15593,7 @@ export const books = [
     "isbn": "9784150115944",
     "asin": "415011594X",
     "readDate": "2017/08/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011594.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011594.jpg",
     "highlights": [
       {
         "text": "いっしょにいても、ひとりきりでいるのと変わりがなく、ゆえにわたしたちには、別れるほかに道がなかった。 ひとりきりで永遠を生きたいとは、だれも思わないのだから。",
@@ -15609,7 +15609,7 @@ export const books = [
     "isbn": "9784041050057",
     "asin": "4041050057",
     "readDate": "2017/08/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0057/9784041050057.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0057/9784041050057.jpg",
     "highlights": []
   },
   {
@@ -15620,7 +15620,7 @@ export const books = [
     "isbn": "9784122040120",
     "asin": "4122040124",
     "readDate": "2017/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0120/9784122040120.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0120/9784122040120.jpg",
     "highlights": []
   },
   {
@@ -15631,7 +15631,7 @@ export const books = [
     "isbn": "9784480069504",
     "asin": "448006950X",
     "readDate": "2017/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9504/9784480069504.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9504/9784480069504.jpg",
     "highlights": [
       {
         "text": "勉強は基礎が大切 右の勉強は、具体的で身体的な場面を離れた概念なのに気づくだろうか。勉強は……と言いかけて、適切な文字通りのことばが見当たらない。そこで建築の領域から表現を借りてくる。これを支えるのは 似ている という感覚である。メタファーは類似性をベースとする。",
@@ -15671,7 +15671,7 @@ export const books = [
     "isbn": "9784062839020",
     "asin": "4062839024",
     "readDate": "2017/08/24",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9020/9784062839020.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9020/9784062839020.jpg",
     "highlights": []
   },
   {
@@ -15682,7 +15682,7 @@ export const books = [
     "isbn": "9784480434036",
     "asin": "4480434038",
     "readDate": "2017/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4036/9784480434036.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4036/9784480434036.jpg",
     "highlights": []
   },
   {
@@ -15693,7 +15693,7 @@ export const books = [
     "isbn": "9784480065131",
     "asin": "448006513X",
     "readDate": "2017/07/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5131/9784480065131.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5131/9784480065131.jpg",
     "highlights": [
       {
         "text": "実際問題としては、組織の主たる層は一般人ですし、そして、一般人は哲学など毛ほどの興味もありません。このことはしかと胸に刻んでおいて下さい。浄土教のナムアミダブツなど一般人は悪霊退散の呪文程度にしか思ってませんし、毎日神棚に手を合わせていても 天岩戸 も知らなかったりします。",
@@ -15737,7 +15737,7 @@ export const books = [
     "isbn": "9784121022202",
     "asin": "4121022203",
     "readDate": "2017/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2202/9784121022202.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2202/9784121022202.jpg",
     "highlights": [
       {
         "text": "言語習得における見本の重要性",
@@ -15761,7 +15761,7 @@ export const books = [
     "isbn": "9784309226729",
     "asin": "4309226728",
     "readDate": "2017/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6729/9784309226729.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6729/9784309226729.jpg",
     "highlights": []
   },
   {
@@ -15772,7 +15772,7 @@ export const books = [
     "isbn": "9784309226712",
     "asin": "430922671X",
     "readDate": "2017/07/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6712/9784309226712.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6712/9784309226712.jpg",
     "highlights": []
   },
   {
@@ -15783,7 +15783,7 @@ export const books = [
     "isbn": "9784797386158",
     "asin": "4797386150",
     "readDate": "2017/07/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6158/9784797386158.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6158/9784797386158.jpg",
     "highlights": []
   },
   {
@@ -15794,7 +15794,7 @@ export const books = [
     "isbn": "9784048651936",
     "asin": "4048651935",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1936/9784048651936.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1936/9784048651936.jpg",
     "highlights": []
   },
   {
@@ -15805,7 +15805,7 @@ export const books = [
     "isbn": "9784048912518",
     "asin": "4048912518",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784048912518.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2518/9784048912518.jpg",
     "highlights": []
   },
   {
@@ -15816,7 +15816,7 @@ export const books = [
     "isbn": "9784048867337",
     "asin": "4048867334",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7337/9784048867337.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7337/9784048867337.jpg",
     "highlights": []
   },
   {
@@ -15827,7 +15827,7 @@ export const books = [
     "isbn": "9784048685955",
     "asin": "4048685953",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868595.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868595.jpg",
     "highlights": []
   },
   {
@@ -15838,7 +15838,7 @@ export const books = [
     "isbn": "9784048682756",
     "asin": "404868275X",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868275.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868275.jpg",
     "highlights": []
   },
   {
@@ -15849,7 +15849,7 @@ export const books = [
     "isbn": "9784048680127",
     "asin": "4048680129",
     "readDate": "2017/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868012.jpg",
     "highlights": []
   },
   {
@@ -15860,7 +15860,7 @@ export const books = [
     "isbn": "9784048674614",
     "asin": "4048674617",
     "readDate": "2017/07/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867461.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867461.jpg",
     "highlights": []
   },
   {
@@ -15871,7 +15871,7 @@ export const books = [
     "isbn": "9784488523015",
     "asin": "4488523013",
     "readDate": "2017/07/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3015/9784488523015.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3015/9784488523015.jpg",
     "highlights": []
   },
   {
@@ -15882,7 +15882,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2017/06/30",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/91yx72KxkcL._SL1500_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/91yx72KxkcL._SL1500_.jpg",
     "highlights": [
       {
         "text": "──もぐりの人夫なんてこんなものだ。 彼等の大部分は俺同様失権者、つまり政府株をもたない連中だった。政府が株式会社組織の営利事業になって以来、政府株、すなわち行政株式会社の株を十株以上もたないものは一切の公民権──実は一切の人権を 剝奪 されるのだ。政府は物価操作一つで、この安い労働力をうんと作り出す事もできた──こんな常識的な事を知らなかった俺は、馬鹿と言われてもしかたがない。もっともはじめから知らなかったのか、知ってて忘れたのか、その点はっきりしなかったが。",
@@ -15898,7 +15898,7 @@ export const books = [
     "isbn": "9784488663032",
     "asin": "4488663036",
     "readDate": "2017/06/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3032/9784488663032.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3032/9784488663032.jpg",
     "highlights": [
       {
         "text": "くれればいいのだが、と彼は内心祈る気持だった。 「共に宇宙を旅する隣人として、惑星地球の全住民に代わって一言ご挨拶申し上げます。われわれは、生きとし生ける者すべてに対する平和と友好の意思をもってここにやって参りました。この邂逅が、両民族の恒久的共存の端緒とならんことを、そしてさらには深い相互理解を通じて節度ある共栄関係発展の契機とならんことを切に願うものであります。今より後、ガニメアンと地球人はそれによって共にその母星を後にし全宇宙の公海とも言うべきこの出会いの場所に旅し来たった最先端の知識の一層の進展に相携えて努力いたそうではありませんか」 ガニメアンたちは敬意を示して、ストレルの",
@@ -15914,7 +15914,7 @@ export const books = [
     "isbn": "9784048679046",
     "asin": "404867904X",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867904.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867904.jpg",
     "highlights": []
   },
   {
@@ -15925,7 +15925,7 @@ export const books = [
     "isbn": "9784334761745",
     "asin": "4334761747",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476174.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476174.jpg",
     "highlights": [
       {
         "text": "＊２「ぼくには日本の格闘技、バリツの心得があったから――これまでにも何度か役に立ったことがあるんだが――相手の腕をさっとすり抜けた」 バリツという格闘技は存在しないが、一八九九年にＥ・Ｗ・バートン＝ライトが〝バーティツ〟として英国に紹介した日本の護身術（つまり柔術）が、〝バリツ〟と誤記されたというのが定説。",
@@ -15941,7 +15941,7 @@ export const books = [
     "isbn": "9784061832466",
     "asin": "4061832468",
     "readDate": "2017/06/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "志賀直哉の短編に『宿かりの死』というのがある。短編というよりは掌編ともいうべき小品で、ほんの一、二分で読み終えてしまうくらいの作品なのであるが、私はこの宿かりこそ、浪漫的読書人の姿ではないかと思う。",
@@ -15961,7 +15961,7 @@ export const books = [
     "isbn": "9784101006079",
     "asin": "4101006075",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784101006079.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6079/9784101006079.jpg",
     "highlights": []
   },
   {
@@ -15972,7 +15972,7 @@ export const books = [
     "isbn": "9784041305089",
     "asin": "404130508X",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -15983,7 +15983,7 @@ export const books = [
     "isbn": "9784757217645",
     "asin": "4757217641",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7645/9784757217645.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7645/9784757217645.jpg",
     "highlights": []
   },
   {
@@ -15994,7 +15994,7 @@ export const books = [
     "isbn": "9784041049938",
     "asin": "4041049938",
     "readDate": "2017/06/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9938/9784041049938.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9938/9784041049938.jpg",
     "highlights": []
   },
   {
@@ -16005,7 +16005,7 @@ export const books = [
     "isbn": "9784040723389",
     "asin": "4040723384",
     "readDate": "2017/06/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3389/9784040723389.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3389/9784040723389.jpg",
     "highlights": []
   },
   {
@@ -16016,7 +16016,7 @@ export const books = [
     "isbn": "9784757217638",
     "asin": "4757217633",
     "readDate": "2017/06/23",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7638/9784757217638.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7638/9784757217638.jpg",
     "highlights": []
   },
   {
@@ -16027,7 +16027,7 @@ export const books = [
     "isbn": "9784153350205",
     "asin": "4153350206",
     "readDate": "2017/06/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0205/9784153350205.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0205/9784153350205.jpg",
     "highlights": []
   },
   {
@@ -16038,7 +16038,7 @@ export const books = [
     "isbn": "9784488605025",
     "asin": "4488605028",
     "readDate": "2017/06/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5025/9784488605025.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5025/9784488605025.jpg",
     "highlights": []
   },
   {
@@ -16049,7 +16049,7 @@ export const books = [
     "isbn": "9784152096845",
     "asin": "4152096845",
     "readDate": "2017/06/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6845/9784152096845.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6845/9784152096845.jpg",
     "highlights": []
   },
   {
@@ -16060,7 +16060,7 @@ export const books = [
     "isbn": "9784004306092",
     "asin": "4004306094",
     "readDate": "2017/06/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6092/9784004306092.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6092/9784004306092.gif",
     "highlights": []
   },
   {
@@ -16071,7 +16071,7 @@ export const books = [
     "isbn": "9784150504960",
     "asin": "4150504962",
     "readDate": "2017/06/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4960/9784150504960.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4960/9784150504960.jpg",
     "highlights": []
   },
   {
@@ -16082,7 +16082,7 @@ export const books = [
     "isbn": "9784480097699",
     "asin": "4480097694",
     "readDate": "2017/05/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7699/9784480097699.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7699/9784480097699.jpg",
     "highlights": []
   },
   {
@@ -16093,7 +16093,7 @@ export const books = [
     "isbn": "9784150312725",
     "asin": "4150312729",
     "readDate": "2017/05/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2725/9784150312725.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2725/9784150312725.jpg",
     "highlights": []
   },
   {
@@ -16104,7 +16104,7 @@ export const books = [
     "isbn": "9784150115418",
     "asin": "4150115419",
     "readDate": "2017/05/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011541.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011541.jpg",
     "highlights": []
   },
   {
@@ -16115,7 +16115,7 @@ export const books = [
     "isbn": "9784150504656",
     "asin": "4150504652",
     "readDate": "2017/05/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4656/9784150504656.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4656/9784150504656.jpg",
     "highlights": []
   },
   {
@@ -16126,7 +16126,7 @@ export const books = [
     "isbn": "9784480425997",
     "asin": "4480425993",
     "readDate": "2017/05/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5997/9784480425997.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5997/9784480425997.jpg",
     "highlights": []
   },
   {
@@ -16137,7 +16137,7 @@ export const books = [
     "isbn": "9784150504649",
     "asin": "4150504644",
     "readDate": "2017/05/01",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4649/9784150504649.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4649/9784150504649.jpg",
     "highlights": []
   },
   {
@@ -16148,7 +16148,7 @@ export const books = [
     "isbn": "9784167181147",
     "asin": "4167181142",
     "readDate": "2017/04/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16718114.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1671/16718114.jpg",
     "highlights": []
   },
   {
@@ -16159,7 +16159,7 @@ export const books = [
     "isbn": "9784150300036",
     "asin": "4150300038",
     "readDate": "2017/04/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "かぎりなく宇宙にひろがってゆく。そのことにもとより何の意味もない。つねに充足は内にある。新しい精神は新しい冒険の所産か。人々は都市を造り、個室にひそみすでに夢の終ったことを知る。かぎりないその絶望のくりかえし。ここにあるものは終った夢の 堆積 だ。",
@@ -16191,7 +16191,7 @@ export const books = [
     "isbn": "9784062188043",
     "asin": "406218804X",
     "readDate": "2017/04/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8043/9784062188043.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8043/9784062188043.jpg",
     "highlights": [
       {
         "text": "凄味のある小説を書く作家として筆者がまず思い浮かべるのは色川武大である。この人は本人そのものに凄味があったのだが、これは直接つきあった者でないとわかるまい。色川武大は別に阿佐田哲也のペンネームで「麻雀放浪記」などのギャンブル小説を書いているが、特にギャンブル小説ではなくてもその作品すべてには凄味があり、純文学系統の作品であってもギャンブル小説に似た凄味を持っている。",
@@ -16283,7 +16283,7 @@ export const books = [
     "isbn": "9784000009775",
     "asin": "400000977X",
     "readDate": "2017/04/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9775/9784000009775.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9775/9784000009775.jpg",
     "highlights": []
   },
   {
@@ -16294,7 +16294,7 @@ export const books = [
     "isbn": "9784150117429",
     "asin": "415011742X",
     "readDate": "2017/04/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7429/9784150117429.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7429/9784150117429.jpg",
     "highlights": []
   },
   {
@@ -16305,7 +16305,7 @@ export const books = [
     "isbn": "9784150504809",
     "asin": "4150504806",
     "readDate": "2017/03/27",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4809/9784150504809.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4809/9784150504809.jpg",
     "highlights": []
   },
   {
@@ -16316,7 +16316,7 @@ export const books = [
     "isbn": "9784150504212",
     "asin": "4150504210",
     "readDate": "2017/03/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4212/9784150504212.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4212/9784150504212.jpg",
     "highlights": []
   },
   {
@@ -16327,7 +16327,7 @@ export const books = [
     "isbn": "9784040720777",
     "asin": "4040720776",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0777/9784040720777.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0777/9784040720777.jpg",
     "highlights": []
   },
   {
@@ -16338,7 +16338,7 @@ export const books = [
     "isbn": "9784061399648",
     "asin": "4061399640",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9648/9784061399648.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9648/9784061399648.jpg",
     "highlights": []
   },
   {
@@ -16349,7 +16349,7 @@ export const books = [
     "isbn": "9784061399655",
     "asin": "4061399659",
     "readDate": "2017/03/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9655/9784061399655.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9655/9784061399655.jpg",
     "highlights": []
   },
   {
@@ -16360,7 +16360,7 @@ export const books = [
     "isbn": "9784150311216",
     "asin": "4150311218",
     "readDate": "2017/03/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1216/9784150311216.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1216/9784150311216.jpg",
     "highlights": [
       {
         "text": "「人は知るべきだ」 先生の言葉を反芻する。あの時僕は、どれくらい知るべきですか、と聞いた。 「知れるだけだよ」 道 終・常 イチ先生はそう答えた。",
@@ -16384,7 +16384,7 @@ export const books = [
     "isbn": "9784150310370",
     "asin": "4150310378",
     "readDate": "2017/03/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0370/9784150310370.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0370/9784150310370.jpg",
     "highlights": []
   },
   {
@@ -16395,7 +16395,7 @@ export const books = [
     "isbn": "9784061582712",
     "asin": "4061582712",
     "readDate": "2017/03/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0615/06158271.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0615/06158271.jpg",
     "highlights": [
       {
         "text": "この時私は始めて文学とはどんなものであるか、その 概念 を根本的に自力で作り上げるよりほかに、私を救う途はないのだと 悟ったのです。今までは全く他人本位で、根のない 萍 のように、そこいらをでたらめに 漂 よっていたから、 駄目 であったという事にようやく気がついたのです。私のここに他人本位というのは、自分の酒を人に飲んでもらって、後からその品評を聴いて、それを理が非でもそうだとしてしまういわゆる 人真似 を指すのです。",
@@ -16427,7 +16427,7 @@ export const books = [
     "isbn": "9784152096661",
     "asin": "4152096667",
     "readDate": "2017/03/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6661/9784152096661.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6661/9784152096661.jpg",
     "highlights": []
   },
   {
@@ -16438,7 +16438,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2017/03/04",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": []
   },
   {
@@ -16449,7 +16449,7 @@ export const books = [
     "isbn": "",
     "asin": null,
     "readDate": "2017/03/04",
-    "thumnailImage": "https://images-na.ssl-images-amazon.com/images/I/81KahmBP41L._AC_SX75_CR,0,0,75,75_.jpg",
+    "thumbnailImage": "https://images-na.ssl-images-amazon.com/images/I/81KahmBP41L._AC_SX75_CR,0,0,75,75_.jpg",
     "highlights": []
   },
   {
@@ -16460,7 +16460,7 @@ export const books = [
     "isbn": "9784041315224",
     "asin": "4041315220",
     "readDate": "2017/02/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5224/9784041315224.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5224/9784041315224.jpg",
     "highlights": []
   },
   {
@@ -16471,7 +16471,7 @@ export const books = [
     "isbn": "9784151200168",
     "asin": "4151200169",
     "readDate": "2017/02/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -16482,7 +16482,7 @@ export const books = [
     "isbn": "9784151200120",
     "asin": "4151200126",
     "readDate": "2017/02/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120012.jpg",
     "highlights": [
       {
         "text": "私は確信しているんだよ、リュカ、すべての人間は一冊の本を書くために生まれたのであって、ほかにはどんな目的もないんだ。天才的な本であろうと、 凡庸 な本であろうと、そんなことは大した問題じゃない。けれども、何も書かなければ、人は無為に生きたことになる。地上を通りすぎただけで 痕跡 を残さずに終わるのだから。",
@@ -16502,7 +16502,7 @@ export const books = [
     "isbn": "9784041305249",
     "asin": "4041305241",
     "readDate": "2017/02/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130524.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130524.jpg",
     "highlights": [
       {
         "text": "女性にとっては今や空前の結婚難時代となった。私が編集している男性雑誌「イリュージョン」でも、「いかにして女から逃げるか」だとか、「女と結婚しなくてすむ方法」とか「最も安あがりな離婚のしかた」「女はこうして男をだます」「あなたは女性に狙われている」などという特集をやると、たちまち四日足らずで売り切れてしまうぐらいだ。現にこの私も、三十三歳にして未だに運よく独身である。",
@@ -16534,7 +16534,7 @@ export const books = [
     "isbn": "9784334038540",
     "asin": "4334038549",
     "readDate": "2017/02/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8540/9784334038540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8540/9784334038540.jpg",
     "highlights": [
       {
         "text": "目の力によって対象と自分を分断し、境界線をはっきりさせること、それが近代における「大人になる」ということです。低次の感覚から高次の感覚へ――。教育とは、まさに子どもを触る世界から見る世界へ移行させることなのです。",
@@ -16562,7 +16562,7 @@ export const books = [
     "isbn": "9784101098302",
     "asin": "4101098301",
     "readDate": "2017/02/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8302/9784101098302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8302/9784101098302.jpg",
     "highlights": []
   },
   {
@@ -16573,7 +16573,7 @@ export const books = [
     "isbn": "9784006020019",
     "asin": "4006020015",
     "readDate": "2017/02/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0019/9784006020019.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0019/9784006020019.jpg",
     "highlights": [
       {
         "text": "この蛆虫のような学生どもはいったい何を考えてるのかね。ひとりひとりは みたいな脳しか持ってないみたいだし、きっと集団思考やっとるのだろうね。だいたい文学部へこんなにたくさん、何を教わりにくるんだい。文学なんてものは存在しないんだよね。あのう、これが文学だと認められたものの集合体、という意味でも、ある内在的特性があるからというので認知されたものという意味でも、文学なんて存在しないんだよね。だから当然この虫けらどもは、何を教わっていいかよくわからずにここへ来てるわけで、言ってみりゃこいつら、文学なんてどうでもいいんだよな」",
@@ -16649,7 +16649,7 @@ export const books = [
     "isbn": "9784150504755",
     "asin": "415050475X",
     "readDate": "2017/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4755/9784150504755.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4755/9784150504755.jpg",
     "highlights": []
   },
   {
@@ -16660,7 +16660,7 @@ export const books = [
     "isbn": "9784152094681",
     "asin": "4152094680",
     "readDate": "2017/02/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4681/9784152094681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4681/9784152094681.jpg",
     "highlights": []
   },
   {
@@ -16671,7 +16671,7 @@ export const books = [
     "isbn": "9784151200021",
     "asin": "4151200029",
     "readDate": "2017/02/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120002.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1512/15120002.jpg",
     "highlights": [
       {
         "text": "「良」か「不可」かを判定する基準として、ぼくらには、きわめて単純なルールがある。作文の内容は真実でなければならない、というルールだ。ぼくらが記述するのは、あるがままの事物、ぼくらが見たこと、ぼくらが聞いたこと、ぼくらが実行したこと、でなければならない。 たとえば、「おばあちゃんは魔女に似ている」と書くことは禁じられている。しかし、「人びとはおばあちゃんを〈魔女〉と呼ぶ」と書くことは許されている。 「〈小さな町〉は美しい」と書くことは禁じられている。なぜなら、〈小さな町〉は、ぼくらの目に美しく映り、それでいてほかの誰かの目には醜く映るのかもしれないから。 同じように、もしぼくらが「従卒は親切だ」と書けば、それは一個の真実ではない。というのは、もしかすると従卒に、ぼくらの知らない意地悪な面があるのかもしれないからだ。だから、ぼくらは単に、「従卒はぼくらに毛布をくれる」と書く。",
@@ -16687,7 +16687,7 @@ export const books = [
     "isbn": "9784779114304",
     "asin": "4779114306",
     "readDate": "2017/02/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784779114304.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784779114304.jpg",
     "highlights": []
   },
   {
@@ -16698,7 +16698,7 @@ export const books = [
     "isbn": "9784409130124",
     "asin": "4409130129",
     "readDate": "2017/01/28",
-    "thumnailImage": "",
+    "thumbnailImage": "",
     "highlights": [
       {
         "text": "エーデルマンが言うように、記憶とは事象の単なる記録や再生ではなく、個人の価値観や視点による再編、再建の作業なのである。",
@@ -16714,7 +16714,7 @@ export const books = [
     "isbn": "9784873117584",
     "asin": "4873117585",
     "readDate": "2017/01/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7584/9784873117584.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7584/9784873117584.jpg",
     "highlights": []
   },
   {
@@ -16725,7 +16725,7 @@ export const books = [
     "isbn": "9784150120979",
     "asin": "4150120978",
     "readDate": "2017/01/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0979/9784150120979.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0979/9784150120979.jpg",
     "highlights": []
   },
   {
@@ -16736,7 +16736,7 @@ export const books = [
     "isbn": "9784488663025",
     "asin": "4488663028",
     "readDate": "2017/01/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3025/9784488663025.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3025/9784488663025.jpg",
     "highlights": [
       {
         "text": "くれればいいのだが、と彼は内心祈る気持だった。 「共に宇宙を旅する隣人として、惑星地球の全住民に代わって一言ご挨拶申し上げます。われわれは、生きとし生ける者すべてに対する平和と友好の意思をもってここにやって参りました。この邂逅が、両民族の恒久的共存の端緒とならんことを、そしてさらには深い相互理解を通じて節度ある共栄関係発展の契機とならんことを切に願うものであります。今より後、ガニメアンと地球人はそれによって共にその母星を後にし全宇宙の公海とも言うべきこの出会いの場所に旅し来たった最先端の知識の一層の進展に相携えて努力いたそうではありませんか」 ガニメアンたちは敬意を示して、ストレルの",
@@ -16752,7 +16752,7 @@ export const books = [
     "isbn": "9784150121044",
     "asin": "4150121044",
     "readDate": "2016/12/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1044/9784150121044.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1044/9784150121044.jpg",
     "highlights": []
   },
   {
@@ -16763,7 +16763,7 @@ export const books = [
     "isbn": "9784040720760",
     "asin": "4040720768",
     "readDate": "2016/12/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784040720760.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0760/9784040720760.jpg",
     "highlights": [
       {
         "text": "「名古屋 駅で売ってる 生麩 のまんじゅうさ。昨日、久しぶりに中学時代の友達に会いに行って、さっき 戻ってきたんだ」 「へぇ、これ名古屋名物なのか……」 「名古屋名物というにはマイナーかもしれないけどね。でも、今まで食べた人全員に好評という、ヒット率の高い 逸品 だよ」 伊織 の言う通り、美味さだけでなくその軽さや 滑らかさが後を引いて、あっという間に三つ目を口にしてしまうくらいには大当たりだった。 「まぁでも、 純粋 に名古屋名物といえば、まずはひよこ型プリンの『ぴよりん』がお薦めかな。これはかつて存在したシャチホコ型シュークリーム『シャチボン』の流れをくむ、正統的な名古屋ネタスイーツだね。続いて名古屋〝らしさ〟を追求するなら断然、 坂角 の『ゆかり 黄金 缶』。名古屋駅限定のキンキラキンのパッケージに、中身はエビの 香りたっぷりのえびせんべい。 悪趣味 さとエビという、まさに名古屋のソウルをふんだんに盛り込んだ 傑作 だ。そういえば、名古屋名物に赤福やうなぎパイを 推す人がいるけど、あれはそれぞれ 伊勢 と 浜名湖 の名物であって厳密には名古屋じゃないからね。名古屋駅もそれを 憂慮 したのか、一度うなぎパイの方の取り扱いをやめたんだけど、それがかえって地元民の 怒りを買ってクレームが 殺到……」 「お前実は名古屋大好きだろそうなんだろ」 と、弁舌の止まらない伊織に 呆れつつ、俺は四つ目のまんじゅうを口に 放り込んだ。",
@@ -16799,7 +16799,7 @@ export const books = [
     "isbn": "9784150120009",
     "asin": "4150120005",
     "readDate": "2016/12/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0009/9784150120009.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0009/9784150120009.jpg",
     "highlights": [
       {
         "text": "人間は他の世界、他の文明と出会うために出かけて行ったくせに、自分自身のことも完全には知らないのだ。",
@@ -16815,7 +16815,7 @@ export const books = [
     "isbn": "9784094080667",
     "asin": "409408066X",
     "readDate": "2016/12/07",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408066.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408066.jpg",
     "highlights": []
   },
   {
@@ -16826,7 +16826,7 @@ export const books = [
     "isbn": "9784094080650",
     "asin": "4094080651",
     "readDate": "2016/12/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408065.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0940/09408065.jpg",
     "highlights": []
   },
   {
@@ -16837,7 +16837,7 @@ export const books = [
     "isbn": "9784041049921",
     "asin": "404104992X",
     "readDate": "2016/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9921/9784041049921.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9921/9784041049921.jpg",
     "highlights": []
   },
   {
@@ -16848,7 +16848,7 @@ export const books = [
     "isbn": "9784150115319",
     "asin": "4150115311",
     "readDate": "2016/11/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011531.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011531.jpg",
     "highlights": []
   },
   {
@@ -16859,7 +16859,7 @@ export const books = [
     "isbn": "9784488663018",
     "asin": "448866301X",
     "readDate": "2016/11/22",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3018/9784488663018.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3018/9784488663018.jpg",
     "highlights": []
   },
   {
@@ -16870,7 +16870,7 @@ export const books = [
     "isbn": "9784150112899",
     "asin": "4150112894",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011289.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011289.jpg",
     "highlights": []
   },
   {
@@ -16881,7 +16881,7 @@ export const books = [
     "isbn": "9784150112905",
     "asin": "4150112908",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011290.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011290.jpg",
     "highlights": []
   },
   {
@@ -16892,7 +16892,7 @@ export const books = [
     "isbn": "9784344424012",
     "asin": "4344424018",
     "readDate": "2016/11/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4012/9784344424012.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4012/9784344424012.jpg",
     "highlights": []
   },
   {
@@ -16903,7 +16903,7 @@ export const books = [
     "isbn": "9784061963771",
     "asin": "4061963775",
     "readDate": "2016/10/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3771/9784061963771.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3771/9784061963771.jpg",
     "highlights": []
   },
   {
@@ -16914,7 +16914,7 @@ export const books = [
     "isbn": "9784334761677",
     "asin": "4334761674",
     "readDate": "2016/10/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476167.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476167.jpg",
     "highlights": []
   },
   {
@@ -16925,7 +16925,7 @@ export const books = [
     "isbn": "9784334761639",
     "asin": "4334761631",
     "readDate": "2016/10/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476163.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33476163.jpg",
     "highlights": [
       {
         "text": "た。「きみは見ているだけで、観察していないんだ。見ることと観察することとは、まるっきり違う。たとえば、玄関からこの部屋へ上がる階段を、きみは何度も見ているね」",
@@ -16949,7 +16949,7 @@ export const books = [
     "isbn": "9784102134061",
     "asin": "4102134069",
     "readDate": "2016/10/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4061/9784102134061.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4061/9784102134061.jpg",
     "highlights": []
   },
   {
@@ -16960,7 +16960,7 @@ export const books = [
     "isbn": "9784163695808",
     "asin": "416369580X",
     "readDate": "2016/10/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1636/16369580.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1636/16369580.jpg",
     "highlights": [
       {
         "text": "もちろん僕にだって負けず嫌いなところはなくはない。しかしなぜか、他人を相手に勝ったり負けたりすることには、昔から一貫してあまりこだわらなかった。そういう性向は大人になってもおおむね変わらない。何ごとによらず、他人に勝とうが負けようが、そんなに気にならない。それよりは、自分自身の設定した基準をクリアできるかできないか──そちらの方により関心が向く。そういう意味で長距離走は、僕のメンタリティーにぴたりとはまるスポーツだった。",
@@ -16992,7 +16992,7 @@ export const books = [
     "isbn": "9784102134054",
     "asin": "4102134050",
     "readDate": "2016/09/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1021/10213405.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1021/10213405.jpg",
     "highlights": []
   },
   {
@@ -17003,7 +17003,7 @@ export const books = [
     "isbn": "9784150504540",
     "asin": "4150504547",
     "readDate": "2016/09/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4540/9784150504540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4540/9784150504540.jpg",
     "highlights": [
       {
         "text": "しっかり定着したルーチンからはずれなくてはならないのに、そうするのをなぜか忘れていたという経験がないだろうか。たとえば、帰宅途中でドラッグストアに立ち寄らなくてはならないとしよう。一日じゅう、その用事のことが頭にある。リハーサルをする――そこへ行くのに、いつものルートから一歩だけそれて、臨時に方向転換するところを思い描いてみさえする。それなのになぜか、ふと気づくと、どこにも立ち寄らずに自宅の玄関先まで帰ってきている。あそこで方向転換するのを忘れ、そこを通り過ぎたことさえ覚えていない。それが、 考えもせず にやっている習慣であり、どんなに頭の一部が何かほかのことをしなければならないと知っていても、それに反して出しゃばってくる、ルーチンというものだ。",
@@ -17047,7 +17047,7 @@ export const books = [
     "isbn": "9784488013516",
     "asin": "4488013511",
     "readDate": "2016/09/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3516/9784488013516.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3516/9784488013516.jpg",
     "highlights": []
   },
   {
@@ -17058,7 +17058,7 @@ export const books = [
     "isbn": "9784488013523",
     "asin": "448801352X",
     "readDate": "2016/09/19",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -17069,7 +17069,7 @@ export const books = [
     "isbn": "9784003243848",
     "asin": "4003243846",
     "readDate": "2016/09/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/00324384.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0032/00324384.jpg",
     "highlights": [
       {
         "text": "掟の問題",
@@ -17101,7 +17101,7 @@ export const books = [
     "isbn": "9784041026229",
     "asin": "4041026229",
     "readDate": "2016/09/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6229/9784041026229.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6229/9784041026229.jpg",
     "highlights": []
   },
   {
@@ -17112,7 +17112,7 @@ export const books = [
     "isbn": "9784062760812",
     "asin": "4062760819",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0812/9784062760812.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0812/9784062760812.jpg",
     "highlights": [
       {
         "text": "愛は祈りだ。 僕は祈る。 僕の好きな人たちに皆そろって幸せになってほしい。 それぞれの願いを 叶えてほしい。 温かい場所で、あるいは涼しい場所で、とにかく心地よい場所で、それぞれの好きな人たちに囲まれて楽しく暮らしてほしい。 最大の幸福が空から皆に降り注ぐといい。 僕は世界中の全ての人たちが好きだ。 名前を知ってる人、知らない人、これから知ることになる人、これからも知らずに終わる人、そういう人たちを皆愛している。 なぜならうまくすれば僕とそういう人たちはとても仲良くなれるし、そういう可能性があるということで、僕にとっては皆を愛するに十分なのだ。 世界の全ての人々、皆の持つ僕との違いなんてもちろん僕はかまわない。 人は皆違って当然だ。 皆の欠点や失策や間違いについてすら僕は別にどうでもいい。 何かの偶然で知り合いになれる、ひょっとしたら友達になれる、もしかすると、お互いにとても大事な存在になれる、そういう可能性があるということで、僕は僕以外の人全員のことが好きなのだ。 一人一人、知り合えばさらに、個別に愛することができる。 僕達はたまたまお互いのことを知らないけれど、知り合ったら、うまくすれば、もしかすると、さらに深く強く愛し合えるのだ。 僕はだから、皆のために祈る。 祈りはそのまま、愛なのだ。 祈りも",
@@ -17136,7 +17136,7 @@ export const books = [
     "isbn": "9784042118039",
     "asin": "4042118038",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8039/9784042118039.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8039/9784042118039.jpg",
     "highlights": [
       {
         "text": "変わり方があまりに急だったので、とてもこわくなったアリスは、それでもまだ自分が 存在 していることに、ほっとしました。",
@@ -17156,7 +17156,7 @@ export const books = [
     "isbn": "9784101152080",
     "asin": "410115208X",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2080/9784101152080.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2080/9784101152080.jpg",
     "highlights": []
   },
   {
@@ -17167,7 +17167,7 @@ export const books = [
     "isbn": "9784101152097",
     "asin": "4101152098",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2097/9784101152097.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2097/9784101152097.jpg",
     "highlights": []
   },
   {
@@ -17178,7 +17178,7 @@ export const books = [
     "isbn": "9784396316921",
     "asin": "4396316925",
     "readDate": "2016/08/29",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6921/9784396316921.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6921/9784396316921.jpg",
     "highlights": []
   },
   {
@@ -17189,7 +17189,7 @@ export const books = [
     "isbn": "9784622023487",
     "asin": "4622023482",
     "readDate": "2016/08/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -17200,7 +17200,7 @@ export const books = [
     "isbn": "9784150504595",
     "asin": "4150504598",
     "readDate": "2016/08/25",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4595/9784150504595.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4595/9784150504595.jpg",
     "highlights": []
   },
   {
@@ -17211,7 +17211,7 @@ export const books = [
     "isbn": "9784150504502",
     "asin": "4150504504",
     "readDate": "2016/08/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4502/9784150504502.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4502/9784150504502.jpg",
     "highlights": []
   },
   {
@@ -17222,7 +17222,7 @@ export const books = [
     "isbn": "9784150504496",
     "asin": "4150504490",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4496/9784150504496.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4496/9784150504496.jpg",
     "highlights": []
   },
   {
@@ -17233,7 +17233,7 @@ export const books = [
     "isbn": "9784041305256",
     "asin": "404130525X",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130525.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0413/04130525.jpg",
     "highlights": []
   },
   {
@@ -17244,7 +17244,7 @@ export const books = [
     "isbn": "9784048704694",
     "asin": "4048704699",
     "readDate": "2016/08/20",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4694/9784048704694.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4694/9784048704694.jpg",
     "highlights": [
       {
         "text": "ピーター・ディキンスン『 生ける 屍』。サンリオＳＦ文庫。",
@@ -17260,7 +17260,7 @@ export const books = [
     "isbn": "9784062838986",
     "asin": "4062838982",
     "readDate": "2016/08/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8986/9784062838986.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8986/9784062838986.jpg",
     "highlights": []
   },
   {
@@ -17271,7 +17271,7 @@ export const books = [
     "isbn": "9784896375626",
     "asin": "4896375629",
     "readDate": "2016/08/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5626/9784896375626.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5626/9784896375626.jpg",
     "highlights": []
   },
   {
@@ -17282,7 +17282,7 @@ export const books = [
     "isbn": "9784896375084",
     "asin": "4896375084",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5084/9784896375084.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5084/9784896375084.jpg",
     "highlights": []
   },
   {
@@ -17293,7 +17293,7 @@ export const books = [
     "isbn": "9784062813860",
     "asin": "4062813866",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3860/9784062813860.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3860/9784062813860.jpg",
     "highlights": []
   },
   {
@@ -17304,7 +17304,7 @@ export const books = [
     "isbn": "9784896375411",
     "asin": "4896375416",
     "readDate": "2016/08/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5411/9784896375411.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5411/9784896375411.jpg",
     "highlights": []
   },
   {
@@ -17315,7 +17315,7 @@ export const books = [
     "isbn": "9784799208038",
     "asin": "4799208039",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8038/9784799208038.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8038/9784799208038.jpg",
     "highlights": []
   },
   {
@@ -17326,7 +17326,7 @@ export const books = [
     "isbn": "9784896374650",
     "asin": "4896374657",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4650/9784896374650.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4650/9784896374650.jpg",
     "highlights": []
   },
   {
@@ -17337,7 +17337,7 @@ export const books = [
     "isbn": "9784896374858",
     "asin": "4896374851",
     "readDate": "2016/08/15",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4858/9784896374858.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4858/9784896374858.jpg",
     "highlights": []
   },
   {
@@ -17348,7 +17348,7 @@ export const books = [
     "isbn": "9784799206805",
     "asin": "479920680X",
     "readDate": "2016/08/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6805/9784799206805.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6805/9784799206805.jpg",
     "highlights": []
   },
   {
@@ -17359,7 +17359,7 @@ export const books = [
     "isbn": "9784799207512",
     "asin": "4799207512",
     "readDate": "2016/08/14",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7512/9784799207512.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7512/9784799207512.jpg",
     "highlights": []
   },
   {
@@ -17370,7 +17370,7 @@ export const books = [
     "isbn": "9784101215266",
     "asin": "410121526X",
     "readDate": "2016/08/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5266/9784101215266.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5266/9784101215266.jpg",
     "highlights": [
       {
         "text": "医者さんに、魂とは何ですか、と言われて、僕はよくこれを言いますよ。分けられないものを明確に分けた途端に消えるものを魂というと。善と悪とかでもそうです。だから、魂の観点からものを見るというのは、そういう区別を全部、一遍、ご破算にして見ることなんです。障害のある人とない人、男と女、そういう区別を全部消して見る。",
@@ -17410,7 +17410,7 @@ export const books = [
     "isbn": "9784758031813",
     "asin": "4758031819",
     "readDate": "2016/08/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1813/9784758031813.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1813/9784758031813.jpg",
     "highlights": []
   },
   {
@@ -17421,7 +17421,7 @@ export const books = [
     "isbn": "9784150504113",
     "asin": "4150504113",
     "readDate": "2016/08/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4113/9784150504113.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4113/9784150504113.jpg",
     "highlights": []
   },
   {
@@ -17432,7 +17432,7 @@ export const books = [
     "isbn": "9784775949016",
     "asin": "4775949012",
     "readDate": "2016/08/12",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9016/9784775949016.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9016/9784775949016.jpg",
     "highlights": []
   },
   {
@@ -17443,7 +17443,7 @@ export const books = [
     "isbn": "9784864724470",
     "asin": "4864724474",
     "readDate": "2016/08/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4470/9784864724470.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4470/9784864724470.jpg",
     "highlights": []
   },
   {
@@ -17454,7 +17454,7 @@ export const books = [
     "isbn": "9784864724739",
     "asin": "4864724733",
     "readDate": "2016/08/06",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4739/9784864724739.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4739/9784864724739.jpg",
     "highlights": []
   },
   {
@@ -17465,7 +17465,7 @@ export const books = [
     "isbn": "9784864724241",
     "asin": "4864724245",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4241/9784864724241.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4241/9784864724241.jpg",
     "highlights": []
   },
   {
@@ -17476,7 +17476,7 @@ export const books = [
     "isbn": "9784102184219",
     "asin": "410218421X",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4219/9784102184219.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4219/9784102184219.jpg",
     "highlights": []
   },
   {
@@ -17487,7 +17487,7 @@ export const books = [
     "isbn": "9784777111053",
     "asin": "4777111059",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/9784777111053.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/9784777111053.jpg",
     "highlights": [
       {
         "text": "「君がバラのために使った時間が長ければ長いほど、バラは君にとって大切な存在になるんだ」 ――ボクがバラのために使った時間が長ければ長いほど……。 王子さまは、また、その言葉を覚えるために、くり返しました。 「人間たちは、みんな、このことを忘れてしまっている。 だけど、君は忘れちゃあだめだよ。 君は、いったん誰かを飼いならしたら、いつまでもその人との関係を大切にしなくちゃ」 ――いつまでもその人との関係を大切に……。 王子さまは、覚えるために、その言葉をくり返しました。",
@@ -17511,7 +17511,7 @@ export const books = [
     "isbn": "9784904209394",
     "asin": "4904209397",
     "readDate": "2016/08/05",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9394/9784904209394.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9394/9784904209394.jpg",
     "highlights": [
       {
         "text": "私はもともと人工知能に興味があったのですが、実際に自分が研究に携わることになるそもそものきっかけは、東京駅の裏手にあった書店で『The Cognitive Computer』（邦題『考えるコンピュータ』ダイヤモンド社）という英語の原書を手に取ったことでした。",
@@ -17535,7 +17535,7 @@ export const books = [
     "isbn": "9784864724302",
     "asin": "486472430X",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4302/9784864724302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4302/9784864724302.jpg",
     "highlights": []
   },
   {
@@ -17546,7 +17546,7 @@ export const books = [
     "isbn": "9784864724449",
     "asin": "486472444X",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4449/9784864724449.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4449/9784864724449.jpg",
     "highlights": []
   },
   {
@@ -17557,7 +17557,7 @@ export const books = [
     "isbn": "9784864724661",
     "asin": "4864724660",
     "readDate": "2016/08/04",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4661/9784864724661.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4661/9784864724661.jpg",
     "highlights": []
   },
   {
@@ -17568,7 +17568,7 @@ export const books = [
     "isbn": "9784864723428",
     "asin": "4864723427",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3428/9784864723428.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3428/9784864723428.jpg",
     "highlights": []
   },
   {
@@ -17579,7 +17579,7 @@ export const books = [
     "isbn": "9784864724999",
     "asin": "4864724997",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4999/9784864724999.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4999/9784864724999.jpg",
     "highlights": []
   },
   {
@@ -17590,7 +17590,7 @@ export const books = [
     "isbn": "9784864723978",
     "asin": "4864723974",
     "readDate": "2016/08/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3978/9784864723978.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3978/9784864723978.jpg",
     "highlights": []
   },
   {
@@ -17601,7 +17601,7 @@ export const books = [
     "isbn": "9784763131201",
     "asin": "4763131206",
     "readDate": "2016/08/02",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784763131201.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1201/9784763131201.jpg",
     "highlights": [
       {
         "text": "は「モノ別」に片づけること。「今日はこの部屋を片づけよう」ではなく、「今日は洋服」「明日は本類」というふうに、「モノ」ごとに片づけを進めていくようにするのです。",
@@ -17633,7 +17633,7 @@ export const books = [
     "isbn": "9784150504106",
     "asin": "4150504105",
     "readDate": "2016/07/30",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4106/9784150504106.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4106/9784150504106.jpg",
     "highlights": []
   },
   {
@@ -17644,7 +17644,7 @@ export const books = [
     "isbn": "9784560070512",
     "asin": "4560070512",
     "readDate": "2016/07/28",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0512/9784560070512.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0512/9784560070512.jpg",
     "highlights": []
   },
   {
@@ -17655,7 +17655,7 @@ export const books = [
     "isbn": "9784048704823",
     "asin": "4048704826",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4823/9784048704823.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4823/9784048704823.jpg",
     "highlights": []
   },
   {
@@ -17666,7 +17666,7 @@ export const books = [
     "isbn": "9784048678100",
     "asin": "4048678108",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867810.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04867810.jpg",
     "highlights": []
   },
   {
@@ -17677,7 +17677,7 @@ export const books = [
     "isbn": "9784048681384",
     "asin": "4048681389",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868138.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868138.jpg",
     "highlights": []
   },
   {
@@ -17688,7 +17688,7 @@ export const books = [
     "isbn": "9784048683951",
     "asin": "4048683950",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868395.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868395.jpg",
     "highlights": []
   },
   {
@@ -17699,7 +17699,7 @@ export const books = [
     "isbn": "9784048685962",
     "asin": "4048685961",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868596.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868596.jpg",
     "highlights": []
   },
   {
@@ -17710,7 +17710,7 @@ export const books = [
     "isbn": "9784048688802",
     "asin": "4048688804",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868880.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0486/04868880.jpg",
     "highlights": []
   },
   {
@@ -17721,7 +17721,7 @@ export const books = [
     "isbn": "9784048701259",
     "asin": "4048701258",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0487/04870125.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0487/04870125.jpg",
     "highlights": []
   },
   {
@@ -17732,7 +17732,7 @@ export const books = [
     "isbn": "9784048704304",
     "asin": "4048704303",
     "readDate": "2016/07/26",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784048704304.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4304/9784048704304.jpg",
     "highlights": []
   },
   {
@@ -17743,7 +17743,7 @@ export const books = [
     "isbn": "9784040707426",
     "asin": "4040707427",
     "readDate": "2016/07/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7426/9784040707426.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7426/9784040707426.jpg",
     "highlights": []
   },
   {
@@ -17754,7 +17754,7 @@ export const books = [
     "isbn": "9784822279981",
     "asin": "4822279987",
     "readDate": "2016/07/18",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9981/9784822279981.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9981/9784822279981.jpg",
     "highlights": []
   },
   {
@@ -17765,7 +17765,7 @@ export const books = [
     "isbn": "9784873115146",
     "asin": "4873115140",
     "readDate": "2016/07/17",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5146/9784873115146.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5146/9784873115146.jpg",
     "highlights": []
   },
   {
@@ -17776,7 +17776,7 @@ export const books = [
     "isbn": "9784167906474",
     "asin": "4167906473",
     "readDate": "2016/07/16",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6474/9784167906474.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6474/9784167906474.jpg",
     "highlights": []
   },
   {
@@ -17787,7 +17787,7 @@ export const books = [
     "isbn": "9784098235018",
     "asin": "4098235013",
     "readDate": "2016/07/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5018/9784098235018.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5018/9784098235018.jpg",
     "highlights": []
   },
   {
@@ -17798,7 +17798,7 @@ export const books = [
     "isbn": "9784041039540",
     "asin": "4041039541",
     "readDate": "2016/07/13",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9540/9784041039540.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9540/9784041039540.jpg",
     "highlights": []
   },
   {
@@ -17809,7 +17809,7 @@ export const books = [
     "isbn": "9784594074760",
     "asin": "4594074766",
     "readDate": "2016/07/10",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4760/9784594074760.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4760/9784594074760.jpg",
     "highlights": []
   },
   {
@@ -17820,7 +17820,7 @@ export const books = [
     "isbn": "9784041037188",
     "asin": "4041037182",
     "readDate": "2016/07/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7188/9784041037188.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7188/9784041037188.jpg",
     "highlights": []
   },
   {
@@ -17831,7 +17831,7 @@ export const books = [
     "isbn": "9784140018569",
     "asin": "4140018569",
     "readDate": "2016/07/08",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1400/14001856.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1400/14001856.jpg",
     "highlights": []
   },
   {
@@ -17842,7 +17842,7 @@ export const books = [
     "isbn": "9784062923682",
     "asin": "4062923688",
     "readDate": "2016/07/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3682/9784062923682.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3682/9784062923682.jpg",
     "highlights": []
   },
   {
@@ -17853,7 +17853,7 @@ export const books = [
     "isbn": "9784150114589",
     "asin": "4150114587",
     "readDate": "2016/07/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011458.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1501/15011458.jpg",
     "highlights": [
       {
         "text": "一七七〇年、クック船長の船、〈エンデヴァー〉がオーストラリアはクイーンズランドの海岸に座礁した。クックは部下の数人を修理にとりくませておき、その間に探検隊を率いて出かけ、アボリジニのひとびとに遭遇した。船員のひとりが、袋に子を入れて跳ねまわっている動物を指さして、あれはなんと呼ばれているのかとアボリジニにたずねた。そのアボリジニは、「カンガルー」と答えた。そのときから、クックと部下の船員たちはその動物をその語で呼ぶことになる。それは、のちになって彼らがその語は、〝あなたはなにを言っているのか？〟という意味であることを知るまで、変わらなかった。",
@@ -17873,7 +17873,7 @@ export const books = [
     "isbn": "9784480068248",
     "asin": "4480068244",
     "readDate": "2016/06/03",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8248/9784480068248.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8248/9784480068248.jpg",
     "highlights": [
       {
         "text": "心理学に最も多大な貢献をした心理学者として、アメリカでたびたび第一位にランクされるのが、行動主義心理学の祖スキナー（Burrhus Skinner） である。スキナーはネズミやハトを対象に、迷路やスキナー箱という実験的装置を用いて、その理論を発展させていった。",
@@ -17893,7 +17893,7 @@ export const books = [
     "isbn": "9784844396192",
     "asin": "4844396196",
     "readDate": "2016/05/24",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6192/9784844396192.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6192/9784844396192.jpg",
     "highlights": [
       {
         "text": "1-3-1 OSI参照モデル 代表的なネットワークの階層モデルは、OSI（Open Systems Interconnection、開放型システム間相互接続）参照モデルと呼ばれるものです。これはISOによって制定されたモデルで、ネットワークを以下の7階層に分けています。 ・アプリケーション層 アプリケーション固有のデータの形式ややり取りの手順などを定めます。 ・プレゼンテーション層 データの表現形式、具体的には文字コードやファイル形式の処理や変換を行います。 ・セッション層 通信の開始から終了までの手順を規定します。 ・トランスポート層 エラーの検出や回復など、データ伝送を制御します。 ・ネットワーク層 複数のネットワークから構成されたインターネットで、ルーターを介した機器間のデータ伝送を実現します。 ・データリンク層 単一のネットワーク内で、機器間（ルーターも含みます）のデータ伝送を実現します。 ・物理層 実際の通信に使われる各種の規格、仕様を定めます。",
@@ -17913,7 +17913,7 @@ export const books = [
     "isbn": "9784334751067",
     "asin": "4334751067",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475106.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475106.jpg",
     "highlights": []
   },
   {
@@ -17924,7 +17924,7 @@ export const books = [
     "isbn": "9784101098166",
     "asin": "4101098166",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8166/9784101098166.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8166/9784101098166.jpg",
     "highlights": []
   },
   {
@@ -17935,7 +17935,7 @@ export const books = [
     "isbn": "9784334751449",
     "asin": "433475144X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475144.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475144.jpg",
     "highlights": [
       {
         "text": "アクトン卿の〝権力は腐敗する。絶対的権力は絶対的に腐敗する〟",
@@ -17963,7 +17963,7 @@ export const books = [
     "isbn": "9784140816974",
     "asin": "414081697X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6974/9784140816974.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6974/9784140816974.jpg",
     "highlights": []
   },
   {
@@ -17974,7 +17974,7 @@ export const books = [
     "isbn": "9784101098197",
     "asin": "4101098190",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "童話の末尾のこの欠陥を指摘し、問題にしようかと思ったのだが、やめた。やはり「二人はいつまでもしあわせ」なのだと気づいたからである。二人は大冒険、大悲劇という共通体験を持っている。ぬるま湯のような状態のなかにあっても、それを話題にしさえすれば、過去の大苦痛の思い出がよみがえり、たちまち幸福感にひたれるというわけである。まったく、うらやましい限りだ。だからこそ、いつまでも語りつがれる童話ということになっているのだろう。",
@@ -18022,7 +18022,7 @@ export const books = [
     "isbn": "9784101098173",
     "asin": "4101098174",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10109817.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1010/10109817.jpg",
     "highlights": []
   },
   {
@@ -18033,7 +18033,7 @@ export const books = [
     "isbn": "9784101098111",
     "asin": "4101098115",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8111/9784101098111.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8111/9784101098111.jpg",
     "highlights": []
   },
   {
@@ -18044,7 +18044,7 @@ export const books = [
     "isbn": "9784167651862",
     "asin": "4167651866",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1862/9784167651862.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1862/9784167651862.jpg",
     "highlights": [
       {
         "text": "人物だ。マンガーは、一九九五年、ハーヴァード・ビジネス・スクールで〝人間が判断を誤る心理〟と題する講演を行なった。他人の行動を予測するには、動機に目を向けさえすればいい、とマンガーは言う。",
@@ -18064,7 +18064,7 @@ export const books = [
     "isbn": "9784003361313",
     "asin": "4003361318",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1313/9784003361313.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1313/9784003361313.jpg",
     "highlights": [
       {
         "text": "わたしたちの意見が分かれるのは、ある人が他人よりも理性があるということによるのではなく、ただ、わたしたちが思考を異なる道筋で導き、同一のことを考察してはいないことから生じるのである。",
@@ -18128,7 +18128,7 @@ export const books = [
     "isbn": "9784422100982",
     "asin": "442210098X",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0982/9784422100982.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0982/9784422100982.jpg",
     "highlights": [
       {
         "text": "世の中の人は皆、幸福を求めているが、その幸福を必ず見つける方法が一つある。それは、自分の気の持ち方を工夫することだ。幸福は外的な条件によって得られるものではなく、自分の気の持ち方一つで、どうにでもなる。 幸不幸は、財産、地位、職業などで決まるものではない。何を幸福と考え、また不幸と考えるか──その考え方が、幸不幸の分かれ目なのである。",
@@ -18152,7 +18152,7 @@ export const books = [
     "isbn": "9784047912755",
     "asin": "4047912751",
     "readDate": "2016/05/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0479/04791275.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0479/04791275.gif",
     "highlights": []
   },
   {
@@ -18163,7 +18163,7 @@ export const books = [
     "isbn": "9784041036235",
     "asin": "4041036232",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6235/9784041036235.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6235/9784041036235.jpg",
     "highlights": []
   },
   {
@@ -18174,7 +18174,7 @@ export const books = [
     "isbn": "9784334751418",
     "asin": "4334751415",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475141.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475141.jpg",
     "highlights": []
   },
   {
@@ -18185,7 +18185,7 @@ export const books = [
     "isbn": "9784102071014",
     "asin": "4102071016",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1014/9784102071014.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1014/9784102071014.jpg",
     "highlights": []
   },
   {
@@ -18196,7 +18196,7 @@ export const books = [
     "isbn": "9784043878017",
     "asin": "404387801X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8017/9784043878017.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/8017/9784043878017.jpg",
     "highlights": [
       {
         "text": "「我々の大方の苦悩は、あり得べき別の人生を夢想することから始まる。自分の可能性という当てにならないものに望みを託すことが諸悪の根元だ。今ここにある君以外、ほかの何者にもなれない自分を認めなくてはいけない。君がいわゆる薔薇色の学生生活を満喫できるわけがない。私が保証するからどっしりかまえておれ」",
@@ -18212,7 +18212,7 @@ export const books = [
     "isbn": "9784150120436",
     "asin": "4150120439",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784150120436.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0436/9784150120436.jpg",
     "highlights": []
   },
   {
@@ -18223,7 +18223,7 @@ export const books = [
     "isbn": "9784150120443",
     "asin": "4150120447",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0443/9784150120443.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0443/9784150120443.jpg",
     "highlights": []
   },
   {
@@ -18234,7 +18234,7 @@ export const books = [
     "isbn": "9784041305225",
     "asin": "4041305225",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": []
   },
   {
@@ -18245,7 +18245,7 @@ export const books = [
     "isbn": "9784894563698",
     "asin": "489456369X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3698/9784894563698.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3698/9784894563698.jpg",
     "highlights": [
       {
         "text": "したがって、無限の未来は、『無限遠』として距離──空間感覚に翻訳される。もっとも粗雑なたとえとして、時は『流れ』として表象される。これは、人間の意識の〝ふりかえり〟作用と〝予見〟作用により、時の経過感覚が、空間的な移動感覚として表象されたものである……。",
@@ -18265,7 +18265,7 @@ export const books = [
     "isbn": "9784150311193",
     "asin": "4150311196",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784150311193.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1193/9784150311193.jpg",
     "highlights": []
   },
   {
@@ -18276,7 +18276,7 @@ export const books = [
     "isbn": "9784167903169",
     "asin": "4167903164",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3169/9784167903169.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3169/9784167903169.jpg",
     "highlights": []
   },
   {
@@ -18287,7 +18287,7 @@ export const books = [
     "isbn": "9784167900366",
     "asin": "416790036X",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0366/9784167900366.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0366/9784167900366.jpg",
     "highlights": []
   },
   {
@@ -18298,7 +18298,7 @@ export const books = [
     "isbn": "9784478066119",
     "asin": "4478066116",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6119/9784478066119.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6119/9784478066119.jpg",
     "highlights": [
       {
         "text": "哲人 多くの親や教育者たちは、これに 眉 をひそめ、もっと「役に立つもの」や「価値のあるもの」を与えようとします。その行為を 諌め、書物や玩具を没収し、自分たちがそこに価値を認めたものだけを与えるわけです。 無論、親たちは「子どものためを思って」そうしているのでしょう。しかしこれは、いっさいの「尊敬」を欠いた、子どもとの距離を遠ざけるだけの行為だと考えねばなりません。子どもたちの自然な関心を否定しているのですから。",
@@ -18346,7 +18346,7 @@ export const books = [
     "isbn": "9784761270438",
     "asin": "4761270438",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0438/9784761270438.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0438/9784761270438.jpg",
     "highlights": [
       {
         "text": "成功した企業がいかにして衰退するかを分析した（ ３）。コリンズによると、失敗の主な理由は企業が「規律なき拡大路線」に陥ったことだと言う。つまり、やたらと多くを求めすぎたのだ。このことは企業だけでなく、そこで働く個人にも当てはまる。",
@@ -18402,7 +18402,7 @@ export const books = [
     "isbn": "9784334752712",
     "asin": "4334752713",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2712/9784334752712.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2712/9784334752712.jpg",
     "highlights": [
       {
         "text": "そういうわけで重圧を与え続けると、バネの弾力がなくなるように、多読に走ると、精神のしなやかさが奪われる。自分の考えを持ちたくなければ、その絶対確実な方法（１） は、一分でも空き時間ができたら、すぐさま本を手に取ることだ。これを実践すると、生まれながら凡庸で単純な多くの人間は、博識が 仇 となってますます精神のひらめきを失い、またあれこれ書き散らすと、ことごとく失敗するはめになる。つまりポープ（２） の言葉通りになってしまう。",
@@ -18462,7 +18462,7 @@ export const books = [
     "isbn": "9784334751081",
     "asin": "4334751083",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475108.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/3347/33475108.jpg",
     "highlights": [
       {
         "text": "啓蒙とは何か。 それは人間が、 みずから招いた未成年の状態から抜けでることだ。 未成年の状態とは、他人の指示を仰がなければ自分の理性を使うことができないということである（ １）。人間が未成年の状態にあるのは、理性がないからではなく、他人の指示を仰がないと、自分の理性を使う決意も勇気ももてないからなのだ。だから人間はみずからの責任において、未成年の状態にとどまっていることになる。こうして啓蒙の標語とでもいうものがあるとすれば、それは「 知る勇気をもて」（ ２）だ。すなわち「自分の理性を使う勇気をもて」ということだ。",
@@ -18518,7 +18518,7 @@ export const books = [
     "isbn": "9784062579681",
     "asin": "4062579685",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9681/9784062579681.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/9681/9784062579681.jpg",
     "highlights": []
   },
   {
@@ -18529,7 +18529,7 @@ export const books = [
     "isbn": "9784797321944",
     "asin": "4797321946",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1944/9784797321944.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1944/9784797321944.jpg",
     "highlights": []
   },
   {
@@ -18540,7 +18540,7 @@ export const books = [
     "isbn": "9784844365624",
     "asin": "4844365622",
     "readDate": "2016/02/09",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5624/9784844365624.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5624/9784844365624.jpg",
     "highlights": []
   },
   {
@@ -18551,7 +18551,7 @@ export const books = [
     "isbn": "9784802510028",
     "asin": "4802510020",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0028/9784802510028.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0028/9784802510028.jpg",
     "highlights": []
   },
   {
@@ -18562,7 +18562,7 @@ export const books = [
     "isbn": "9784150116798",
     "asin": "4150116792",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6798/9784150116798.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6798/9784150116798.jpg",
     "highlights": []
   },
   {
@@ -18573,7 +18573,7 @@ export const books = [
     "isbn": "9784750514505",
     "asin": "4750514500",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4505/9784750514505.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4505/9784750514505.jpg",
     "highlights": []
   },
   {
@@ -18584,7 +18584,7 @@ export const books = [
     "isbn": "9784105393021",
     "asin": "4105393022",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/10539302.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/1053/10539302.jpg",
     "highlights": []
   },
   {
@@ -18595,7 +18595,7 @@ export const books = [
     "isbn": "9784152095787",
     "asin": "4152095784",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5787/9784152095787.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5787/9784152095787.jpg",
     "highlights": []
   },
   {
@@ -18606,7 +18606,7 @@ export const books = [
     "isbn": "9784873117386",
     "asin": "4873117380",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7386/9784873117386.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/7386/9784873117386.jpg",
     "highlights": []
   },
   {
@@ -18617,7 +18617,7 @@ export const books = [
     "isbn": "9784873116983",
     "asin": "4873116988",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6983/9784873116983.jpg",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6983/9784873116983.jpg",
     "highlights": []
   },
   {
@@ -18628,7 +18628,7 @@ export const books = [
     "isbn": "9784150300012",
     "asin": "4150300011",
     "readDate": "2016/01/21",
-    "thumnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
+    "thumbnailImage": "http://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/noimage_01.gif",
     "highlights": [
       {
         "text": "したがって、無限の未来は、『無限遠』として距離──空間感覚に翻訳される。もっとも粗雑なたとえとして、時は『流れ』として表象される。これは、人間の意識の〝ふりかえり〟作用と〝予見〟作用により、時の経過感覚が、空間的な移動感覚として表象されたものである……。",
@@ -18648,7 +18648,7 @@ export const books = [
     "isbn": "9784150312015",
     "asin": "415031201X",
     "readDate": "2015/09/10",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2015/9784150312015.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/2015/9784150312015.jpg",
     "highlights": []
   },
   {
@@ -18659,7 +18659,7 @@ export const books = [
     "isbn": "9784478025819",
     "asin": "4478025819",
     "readDate": "2015/09/08",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5819/9784478025819.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/5819/9784478025819.jpg",
     "highlights": [
       {
         "text": "いかなる経験も、それ自体では成功の原因でも失敗の原因でもない。われわれは自分の経験によるショック——いわゆるトラウマ——に苦しむのではなく、経験の中から目的にかなうものを見つけ出す。 自分の経験によって決定されるのではなく、経験に与える意味によって自らを決定するのである」",
@@ -18715,7 +18715,7 @@ export const books = [
     "isbn": "9784040800202",
     "asin": "4040800206",
     "readDate": "2015/08/27",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0202/9784040800202.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0202/9784040800202.jpg",
     "highlights": [
       {
         "text": "特徴表現学習（＊注",
@@ -18815,7 +18815,7 @@ export const books = [
     "isbn": "9784062560313",
     "asin": "4062560313",
     "readDate": "2015/08/18",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0313/9784062560313.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0313/9784062560313.jpg",
     "highlights": [
       {
         "text": "成人をしのぐ活躍をする子どものイメージが、昔話や神話などには世界共通の現象として存在することが認められる。つまり、人類はこのような超人的な子どもの話を好むのである。",
@@ -18955,7 +18955,7 @@ export const books = [
     "isbn": "9784151200533",
     "asin": "4151200533",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0533/9784151200533.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/0533/9784151200533.jpg",
     "highlights": []
   },
   {
@@ -18966,7 +18966,7 @@ export const books = [
     "isbn": "9784003226223",
     "asin": "4003226224",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6223/9784003226223.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6223/9784003226223.jpg",
     "highlights": []
   },
   {
@@ -18977,7 +18977,7 @@ export const books = [
     "isbn": "9784042334019",
     "asin": "4042334016",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784042334019.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/4019/9784042334019.jpg",
     "highlights": []
   },
   {
@@ -18988,7 +18988,7 @@ export const books = [
     "isbn": "9784150116774",
     "asin": "4150116776",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6774/9784150116774.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6774/9784150116774.jpg",
     "highlights": []
   },
   {
@@ -18999,7 +18999,7 @@ export const books = [
     "isbn": "9784150116781",
     "asin": "4150116784",
     "readDate": "2015/01/01",
-    "thumnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6781/9784150116781.jpg",
+    "thumbnailImage": "https://thumbnail.image.rakuten.co.jp/@0_mall/book/cabinet/6781/9784150116781.jpg",
     "highlights": []
   }
 ];

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -10,6 +10,9 @@ interface BookCardProps {
   onIsbnClick: (e: React.MouseEvent<HTMLAnchorElement>, isbn: string) => void;
 }
 
+const cardClassName =
+  "group m-4 w-[400px] cursor-pointer rounded-[10px] border border-[#222] p-6 text-left text-inherit no-underline transition-colors duration-150 ease-in-out hover:border-[#0070f3] focus:border-[#0070f3] active:border-[#0070f3]";
+
 export default function BookCard({
   book,
   onCardClick,
@@ -24,7 +27,7 @@ export default function BookCard({
 
   return (
     <div
-      className="group m-4 w-[400px] cursor-pointer rounded-[10px] border border-[#222] p-6 text-left text-inherit no-underline transition-colors duration-150 ease-in-out hover:border-[#0070f3] focus:border-[#0070f3] active:border-[#0070f3]"
+      className={cardClassName}
       onClick={() => onCardClick(book.id)}
       onKeyDown={handleKeyDown}
       tabIndex={0}
@@ -33,7 +36,7 @@ export default function BookCard({
     >
       <div className="relative z-10 flex overflow-hidden rounded-lg">
         <Image
-          src={book.thumnailImage}
+          src={book.thumbnailImage}
           alt={`${book.title}の表紙画像`}
           width={200}
           height={300}

--- a/src/components/BookCard.tsx
+++ b/src/components/BookCard.tsx
@@ -1,28 +1,43 @@
+import { type KeyboardEvent, type MouseEvent } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faUser, faBookmark, faBarcode, faCalendarAlt } from "@fortawesome/free-solid-svg-icons";
-import { Book } from "../types/book";
+import {
+  faBarcode,
+  faBookmark,
+  faCalendarAlt,
+  faUser,
+} from "@fortawesome/free-solid-svg-icons";
+import type { Book } from "@/types/book";
 
 interface BookCardProps {
   book: Book;
   onCardClick: (id: string) => void;
-  onIsbnClick: (e: React.MouseEvent<HTMLAnchorElement>, isbn: string) => void;
+  onIsbnClick: (event: MouseEvent<HTMLAnchorElement>, isbn: string) => void;
 }
 
 const cardClassName =
   "group m-4 w-[400px] cursor-pointer rounded-[10px] border border-[#222] p-6 text-left text-inherit no-underline transition-colors duration-150 ease-in-out hover:border-[#0070f3] focus:border-[#0070f3] active:border-[#0070f3]";
+
+const labelClassName =
+  "inline-block w-1/5 text-gray-700 dark:text-gray-400";
+
+const detailTextClassName = "my-1 block text-xs leading-[1.5]";
 
 export default function BookCard({
   book,
   onCardClick,
   onIsbnClick,
 }: BookCardProps) {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
-    if (e.key === "Enter" || e.key === " ") {
-      e.preventDefault();
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
       onCardClick(book.id);
     }
+  };
+
+  const handleIsbnLinkClick = (event: MouseEvent<HTMLAnchorElement>) => {
+    onIsbnClick(event, book.isbn);
   };
 
   return (
@@ -44,30 +59,28 @@ export default function BookCard({
         />
       </div>
       <div className="flex">
-        <div className="my-4 w-full items-center">
-          {book.title}
-        </div>
-        <div className="my-6 border-b border-[#222]"></div>
+        <div className="my-4 w-full items-center">{book.title}</div>
+        <div className="my-6 border-b border-[#222]" />
       </div>
-       <p className="my-1 block text-xs leading-[1.5]">
-         <span className="inline-block w-1/5 text-gray-700 dark:text-gray-400">
-           <FontAwesomeIcon icon={faUser} className="mr-[0.375rem]" />著者
-         </span>
-         {book.author}
-       </p>
-       <p className="my-1 block text-xs leading-[1.5]">
-         <span className="inline-block w-1/5 text-gray-700 dark:text-gray-400">
-           <FontAwesomeIcon icon={faBookmark} className="mr-[0.375rem]" />出版社
-         </span>
-         {book.publisher}
-       </p>
-       <p className="my-1 block text-xs leading-[1.5]">
-         <span className="inline-block w-1/5 text-gray-700 dark:text-gray-400">
-           <FontAwesomeIcon icon={faBarcode} className="mr-[0.375rem]" />ISBN
-         </span>
+      <p className={detailTextClassName}>
+        <span className={labelClassName}>
+          <FontAwesomeIcon icon={faUser} className="mr-[0.375rem]" />著者
+        </span>
+        {book.author}
+      </p>
+      <p className={detailTextClassName}>
+        <span className={labelClassName}>
+          <FontAwesomeIcon icon={faBookmark} className="mr-[0.375rem]" />出版社
+        </span>
+        {book.publisher}
+      </p>
+      <p className={detailTextClassName}>
+        <span className={labelClassName}>
+          <FontAwesomeIcon icon={faBarcode} className="mr-[0.375rem]" />ISBN
+        </span>
         <Link
           href={`https://www.books.or.jp/book-details/${book.isbn}`}
-          onClick={(e) => onIsbnClick(e, book.isbn)}
+          onClick={handleIsbnLinkClick}
           target="_blank"
           rel="noopener noreferrer"
           className="hover:underline"
@@ -75,12 +88,12 @@ export default function BookCard({
           {book.isbn}
         </Link>
       </p>
-       <p className="my-1 block text-xs leading-[1.5]">
-         <span className="inline-block w-1/5 text-gray-700 dark:text-gray-400">
-           <FontAwesomeIcon icon={faCalendarAlt} className="mr-[0.375rem]" />読了日
-         </span>
-         {book.readDate}
-       </p>
+      <p className={detailTextClassName}>
+        <span className={labelClassName}>
+          <FontAwesomeIcon icon={faCalendarAlt} className="mr-[0.375rem]" />読了日
+        </span>
+        {book.readDate}
+      </p>
     </div>
   );
 }

--- a/src/components/BookGrid.tsx
+++ b/src/components/BookGrid.tsx
@@ -1,11 +1,11 @@
-import { forwardRef } from "react";
-import { Book } from "../types/book";
-import BookCard from "./BookCard";
+import { type MouseEvent, forwardRef } from "react";
+import BookCard from "@/components/BookCard";
+import type { Book } from "@/types/book";
 
 interface BookGridProps {
   books: Book[];
   onCardClick: (id: string) => void;
-  onIsbnClick: (e: React.MouseEvent<HTMLAnchorElement>, isbn: string) => void;
+  onIsbnClick: (event: MouseEvent<HTMLAnchorElement>, isbn: string) => void;
   hasMore?: boolean;
   isLoading?: boolean;
 }
@@ -15,12 +15,14 @@ const BookGrid = forwardRef<HTMLDivElement, BookGridProps>(
     { books, onCardClick, onIsbnClick, hasMore = false, isLoading = false },
     ref,
   ) => {
+    const totalBooksMessage = `${books.length}冊の本を表示中`;
+
     return (
       <div>
         <div
           className="flex flex-wrap items-center justify-center transition-transform duration-[3500ms]"
           role="grid"
-          aria-label={`${books.length}冊の本を表示中`}
+          aria-label={totalBooksMessage}
         >
           {books.map((book) => (
             <div key={book.id} role="gridcell">
@@ -33,7 +35,7 @@ const BookGrid = forwardRef<HTMLDivElement, BookGridProps>(
           ))}
         </div>
         {hasMore && (
-          <div ref={ref}>
+          <div ref={ref} aria-hidden>
             {isLoading && (
               <div aria-live="polite" aria-label="更に本を読み込み中">
                 読み込み中...

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from "react";
+import Head from "next/head";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faBookmark } from "@fortawesome/free-solid-svg-icons";
+
+interface LayoutProps {
+  children: ReactNode;
+  pageTitle?: string;
+  pageDescription?: string;
+  mainClassName?: string;
+  containerClassName?: string;
+}
+
+const BASE_TITLE = "読書管理";
+const DEFAULT_DESCRIPTION = "読んだ本をリスト化したサイトです。";
+
+export default function Layout({
+  children,
+  pageTitle,
+  pageDescription,
+  mainClassName = "flex min-h-screen flex-col items-center justify-center py-8",
+  containerClassName = "px-8",
+}: LayoutProps) {
+  const computedTitle = pageTitle && pageTitle !== BASE_TITLE
+    ? `${BASE_TITLE} | ${pageTitle}`
+    : BASE_TITLE;
+
+  return (
+    <div className={containerClassName}>
+      <Head>
+        <title>{computedTitle}</title>
+        <meta
+          name="description"
+          content={pageDescription ?? DEFAULT_DESCRIPTION}
+        />
+        <link rel="icon" href="/favicon.ico" />
+      </Head>
+
+      <header className="flex w-full items-center border-b border-[#222] py-4 text-2xl font-bold">
+        <FontAwesomeIcon icon={faBookmark} className="mr-[1.125rem]" />
+        {BASE_TITLE}
+      </header>
+
+      <main className={mainClassName}>{children}</main>
+
+      <footer className="flex w-full flex-1 items-center justify-center border-t border-[#222] py-8">
+        <p>© 2024 読書管理. All rights reserved.</p>
+      </footer>
+    </div>
+  );
+}

--- a/src/components/YearFilter.tsx
+++ b/src/components/YearFilter.tsx
@@ -1,3 +1,5 @@
+import { ALL_YEARS_LABEL } from "@/constants/books";
+
 interface YearFilterProps {
   selectedYear: string;
   onYearChange: (year: string) => void;
@@ -15,7 +17,6 @@ export default function YearFilter({
   onYearChange,
   availableYears,
 }: YearFilterProps) {
-
   return (
     <div className="flex flex-1" role="region" aria-label="年度フィルター">
       <div
@@ -23,22 +24,26 @@ export default function YearFilter({
         role="tablist"
         aria-label="読了年で絞り込み"
       >
-        {availableYears.map((year) => (
-          <button
-            key={year}
-            onClick={() => onYearChange(year)}
-            className={`${buttonBaseClasses} ${
-              year === selectedYear ? selectedClasses : unselectedClasses
-            }`}
-            role="tab"
-            aria-selected={year === selectedYear}
-            aria-label={
-              year === "All" ? "すべての年の本を表示" : `${year}年の本を表示`
-            }
-          >
-            {year === "All" ? "All" : year}
-          </button>
-        ))}
+        {availableYears.map((year) => {
+          const isSelected = year === selectedYear;
+          const label =
+            year === ALL_YEARS_LABEL ? "すべての年の本を表示" : `${year}年の本を表示`;
+
+          return (
+            <button
+              key={year}
+              onClick={() => onYearChange(year)}
+              className={`${buttonBaseClasses} ${
+                isSelected ? selectedClasses : unselectedClasses
+              }`}
+              role="tab"
+              aria-selected={isSelected}
+              aria-label={label}
+            >
+              {year === ALL_YEARS_LABEL ? ALL_YEARS_LABEL : year}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/YearFilter.tsx
+++ b/src/components/YearFilter.tsx
@@ -4,16 +4,17 @@ interface YearFilterProps {
   availableYears: string[];
 }
 
+const buttonBaseClasses =
+  "flex text-xs h-12 w-24 cursor-pointer items-center justify-center rounded-[5px] duration-300";
+const unselectedClasses =
+  "border border-[#222] bg-black hover:border-[#0070f3]";
+const selectedClasses = "border border-[#0070f3] bg-black";
+
 export default function YearFilter({
   selectedYear,
   onYearChange,
   availableYears,
 }: YearFilterProps) {
-  const buttonBaseClasses =
-    "flex text-xs h-12 w-24 cursor-pointer items-center justify-center rounded-[5px] duration-300";
-  const unselectedClasses =
-    "border border-[#222] bg-black hover:border-[#0070f3]";
-  const selectedClasses = "border border-[#0070f3] bg-black";
 
   return (
     <div className="flex flex-1" role="region" aria-label="年度フィルター">

--- a/src/constants/books.ts
+++ b/src/constants/books.ts
@@ -1,0 +1,11 @@
+export const ALL_YEARS_LABEL = "All" as const;
+
+export const ITEMS_PER_PAGE = 48;
+
+export const BOOKS_RENDERED_EVENT = "books-rendered" as const;
+
+export const STORAGE_KEYS = {
+  selectedYear: "selectedYear" as const,
+  itemCountPrefix: "itemCount" as const,
+  scrollPositionPrefix: "scrollPos" as const,
+};

--- a/src/data/books.ts
+++ b/src/data/books.ts
@@ -1,0 +1,1 @@
+export { books } from "../../public/books";

--- a/src/hooks/useScrollRestoration.ts
+++ b/src/hooks/useScrollRestoration.ts
@@ -1,0 +1,85 @@
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import { BOOKS_RENDERED_EVENT, STORAGE_KEYS } from "@/constants/books";
+import { buildStorageKey, readSessionStorage, writeSessionStorage } from "@/utils/storage";
+
+const FALLBACK_DELAY_MS = 300;
+const MAX_ATTEMPTS = 5;
+const RESTORE_THRESHOLD = 1;
+
+export function useScrollRestoration() {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return undefined;
+    }
+
+    const storageKey = buildStorageKey(
+      STORAGE_KEYS.scrollPositionPrefix,
+      router.asPath || "/",
+    );
+
+    const handleRouteChangeStart = () => {
+      writeSessionStorage(storageKey, String(window.scrollY));
+    };
+
+    router.events.on("routeChangeStart", handleRouteChangeStart);
+
+    const savedScroll = readSessionStorage(storageKey);
+    const targetScroll =
+      savedScroll !== null ? Number.parseInt(savedScroll, 10) : null;
+
+    if (targetScroll === null || Number.isNaN(targetScroll)) {
+      return () => {
+        router.events.off("routeChangeStart", handleRouteChangeStart);
+      };
+    }
+
+    let restored = false;
+    let attempts = 0;
+    let rafId: number | undefined;
+    let timeoutId: number | undefined;
+
+    const clearRestoration = () => {
+      if (rafId !== undefined) {
+        window.cancelAnimationFrame(rafId);
+      }
+      if (timeoutId !== undefined) {
+        window.clearTimeout(timeoutId);
+      }
+      window.removeEventListener(BOOKS_RENDERED_EVENT, handleBooksRendered);
+    };
+
+    const tryRestore = () => {
+      if (restored) {
+        return;
+      }
+
+      window.scrollTo(0, targetScroll);
+      attempts += 1;
+      const distance = Math.abs(window.scrollY - targetScroll);
+
+      if (distance <= RESTORE_THRESHOLD || attempts >= MAX_ATTEMPTS) {
+        restored = true;
+        clearRestoration();
+      } else {
+        rafId = window.requestAnimationFrame(tryRestore);
+      }
+    };
+
+    const handleBooksRendered = () => {
+      tryRestore();
+    };
+
+    window.addEventListener(BOOKS_RENDERED_EVENT, handleBooksRendered);
+
+    rafId = window.requestAnimationFrame(tryRestore);
+    timeoutId = window.setTimeout(tryRestore, FALLBACK_DELAY_MS);
+
+    return () => {
+      clearRestoration();
+      router.events.off("routeChangeStart", handleRouteChangeStart);
+    };
+  }, [router, router.asPath, router.events]);
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,55 +1,9 @@
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 import type { AppProps } from "next/app";
+import { useScrollRestoration } from "@/hooks/useScrollRestoration";
 import "../styles/globals.css";
 import "../fontawesome";
 
 export default function App({ Component, pageProps }: AppProps) {
-  const router = useRouter();
-
-  useEffect(() => {
-    // ページを離れる際にスクロール位置を保存
-    const handleRouteChangeStart = () => {
-      sessionStorage.setItem(
-        `scrollPos:${router.asPath}`,
-        window.scrollY.toString(),
-      );
-    };
-    router.events.on("routeChangeStart", handleRouteChangeStart);
-
-    // ページが表示されるたびにスクロール位置の復元を試みる
-    const scrollPos = sessionStorage.getItem(`scrollPos:${router.asPath}`);
-    if (scrollPos) {
-      let restored = false;
-
-      const restoreScroll = () => {
-        if (restored) return;
-        window.scrollTo(0, parseInt(scrollPos, 10));
-        restored = true;
-      };
-
-      // 無限スクロールページからのカスタムイベントを待つ
-      const handleBooksRendered = () => {
-        restoreScroll();
-        // eslint-disable-next-line no-use-before-define
-        clearTimeout(fallbackTimeout);
-      };
-
-      window.addEventListener("books-rendered", handleBooksRendered, {
-        once: true,
-      });
-
-      // フォールバック: イベントが発生しないページのためにタイムアウトを設定
-      const fallbackTimeout = setTimeout(() => {
-        window.removeEventListener("books-rendered", handleBooksRendered);
-        restoreScroll();
-      }, 300);
-    }
-
-    return () => {
-      router.events.off("routeChangeStart", handleRouteChangeStart);
-    };
-  }, [router.asPath, router.events]);
-
+  useScrollRestoration();
   return <Component {...pageProps} />;
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,65 +1,49 @@
-import Head from "next/head";
+import { type MouseEvent, useCallback } from "react";
 import { useRouter } from "next/router";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBookmark } from "@fortawesome/free-solid-svg-icons";
-import { books } from "../../public/books";
+import Layout from "@/components/Layout";
+import BookGrid from "@/components/BookGrid";
+import YearFilter from "@/components/YearFilter";
+import { books } from "@/data/books";
 import { useBookFilter } from "@/hooks/useBookFilter";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
-import YearFilter from "@/components/YearFilter";
-import BookGrid from "@/components/BookGrid";
 
 export default function Home() {
   const router = useRouter();
-
-  // カスタムフックを使用してビジネスロジックを分離
   const { selectedYear, setSelectedYear, filteredBooks, availableYears } =
     useBookFilter(books);
   const { displayedBooks, observerTarget, hasMore, isLoading } =
     useInfiniteScroll(filteredBooks);
 
-  const handleCardClick = (id: string) => {
-    router.push(`/items/${id}`);
-  };
+  const handleCardClick = useCallback(
+    (id: string) => {
+      router.push(`/items/${id}`);
+    },
+    [router],
+  );
 
-  const handleIsbnClick = (
-    e: React.MouseEvent<HTMLAnchorElement>,
-    isbn: string,
-  ) => {
-    e.stopPropagation();
-  };
+  const handleIsbnClick = useCallback(
+    (event: MouseEvent<HTMLAnchorElement>, _isbn?: string) => {
+      event.stopPropagation();
+    },
+    [],
+  );
 
   return (
-    <div className="px-8">
-      <Head>
-        <title>読書管理</title>
-        <meta name="description" content="読んだ本をリスト化したサイトです。" />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
+    <Layout>
+      <YearFilter
+        selectedYear={selectedYear}
+        onYearChange={setSelectedYear}
+        availableYears={availableYears}
+      />
 
-      <header className="flex items-center border-b border-[#222] py-4 text-2xl font-bold">
-        <FontAwesomeIcon icon={faBookmark} className="mr-[1.125rem]" />読書管理
-      </header>
-
-      <main className="flex min-h-screen flex-col items-center justify-center py-8">
-        <YearFilter
-          selectedYear={selectedYear}
-          onYearChange={setSelectedYear}
-          availableYears={availableYears}
-        />
-
-        <BookGrid
-          books={displayedBooks}
-          onCardClick={handleCardClick}
-          onIsbnClick={handleIsbnClick}
-          hasMore={hasMore}
-          isLoading={isLoading}
-          ref={observerTarget}
-        />
-      </main>
-
-      <footer className="flex flex-1 items-center justify-center border-t border-[#222] py-8">
-        <p>© 2024 読書管理. All rights reserved.</p>
-      </footer>
-    </div>
+      <BookGrid
+        books={displayedBooks}
+        onCardClick={handleCardClick}
+        onIsbnClick={handleIsbnClick}
+        hasMore={hasMore}
+        isLoading={isLoading}
+        ref={observerTarget}
+      />
+    </Layout>
   );
 }

--- a/src/pages/items/[id].tsx
+++ b/src/pages/items/[id].tsx
@@ -1,125 +1,125 @@
-import { useRouter } from "next/router";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faBookmark, faUser, faBarcode, faCalendarAlt, faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
-import { books } from "../../../public/books";
-import { Book } from "@/types/book";
+import { ReactNode, useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
-import Head from "next/head";
+import { useRouter } from "next/router";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import {
+  faBarcode,
+  faBookmark,
+  faCalendarAlt,
+  faExternalLinkAlt,
+  faUser,
+} from "@fortawesome/free-solid-svg-icons";
+import Layout from "@/components/Layout";
+import { books } from "@/data/books";
+import type { Book } from "@/types/book";
 
-function DetailPage() {
+const NOT_FOUND_TITLE = "Book not found";
+const NOT_FOUND_DESCRIPTION = "指定された本が見つかりませんでした。";
+
+export default function DetailPage() {
   const router = useRouter();
-  const { id } = router.query;
-  const details: Book | undefined = books.find((book: Book) => book.id === id);
+  const rawId = router.query.id;
+  const bookId = Array.isArray(rawId) ? rawId[0] : rawId;
+
+  const details: Book | undefined = useMemo(
+    () => books.find((book) => book.id === bookId),
+    [bookId],
+  );
 
   if (!details) {
-    return <div className="px-8">Book not found</div>;
+    return (
+      <Layout
+        pageTitle={NOT_FOUND_TITLE}
+        pageDescription={NOT_FOUND_DESCRIPTION}
+        mainClassName="flex min-h-[50vh] flex-col items-center justify-center py-8"
+      >
+        <p className="text-center text-lg text-gray-400">Book not found</p>
+        <Link
+          className="mt-6 rounded-md border border-[#222] px-12 py-2 hover:border-[#0070f3]"
+          href="/"
+        >
+          戻る
+        </Link>
+      </Layout>
+    );
   }
 
+  const pageDescription = `${details.title}（著者: ${details.author}）の詳細ページです。`;
+
   return (
-    <div className="px-8">
-      <Head>
-        <title>
-          {details
-            ? `読書管理 | ${details.title}`
-            : "読書管理 | Book not found"}
-        </title>
-        <meta
-          name="description"
-          content={
-            details
-              ? `${details.title}（著者: ${details.author}）の詳細ページです。`
-              : "指定された本が見つかりませんでした。"
-          }
-        />
-        <link rel="icon" href="/favicon.ico" />
-      </Head>
-
-      <header className="flex w-full items-center border-b border-[#222] py-4 text-2xl font-bold">
-        <FontAwesomeIcon icon={faBookmark} className="mr-[1.125rem]" />
-        <span>読書管理</span>
-      </header>
-
-      <main className="flex min-h-[50vh] flex-1 flex-col items-center justify-start py-8">
-        <div className="my-8 flex w-full max-w-[1200px] flex-col rounded-[10px] border border-[#222] p-6 md:flex-row">
-          <div className="mb-8 flex-shrink-0 md:mr-8 md:mb-0 md:basis-[350px]">
-            <Image
-              src={details.thumbnailImage}
-              alt={details.title}
-              width={350}
-              height={500}
-              className="h-auto w-full rounded-lg object-cover object-center dark:brightness-90 md:h-[500px] md:w-[350px]"
-            />
-          </div>
-          <div className="flex w-full flex-col justify-center">
-            <h2 className="mb-4 text-[2rem] font-bold leading-[1.15]">
-              {details.title}
-            </h2>
-            <div className="my-6 border-b border-[#222]"></div>
-            <p className="my-1 flex items-center text-[0.9rem] leading-[1.5]">
-              <span className="inline-block w-1/5 font-bold text-gray-700 dark:text-gray-400">
-                <FontAwesomeIcon icon={faUser} className="mr-[0.45rem]" />著者
-              </span>
-              {details.author}
-            </p>
-            <p className="my-1 flex items-center text-[0.9rem] leading-[1.5]">
-              <span className="inline-block w-1/5 font-bold text-gray-700 dark:text-gray-400">
-                <FontAwesomeIcon icon={faBookmark} className="mr-[0.45rem]" />出版社
-              </span>
-              {details.publisher}
-            </p>
-            <p className="my-1 flex items-center text-[0.9rem] leading-[1.5]">
-              <span className="inline-block w-1/5 font-bold text-gray-700 dark:text-gray-400">
-                <FontAwesomeIcon icon={faBarcode} className="mr-[0.45rem]" />ISBN
-              </span>
-              <Link
-                href={`https://www.books.or.jp/book-details/${details.isbn}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="hover:underline"
-              >
-                {details.isbn}
-              </Link>
-            </p>
-            <p className="my-1 flex items-center text-[0.9rem] leading-[1.5]">
-              <span className="inline-block w-1/5 font-bold text-gray-700 dark:text-gray-400">
-                <FontAwesomeIcon icon={faCalendarAlt} className="mr-[0.45rem]" />読了日
-              </span>
-              {details.readDate}
-            </p>
-          </div>
+    <Layout
+      pageTitle={details.title}
+      pageDescription={pageDescription}
+      mainClassName="flex min-h-[50vh] flex-col items-center justify-start py-8"
+    >
+      <div className="my-8 flex w-full max-w-[1200px] flex-col rounded-[10px] border border-[#222] p-6 md:flex-row">
+        <div className="mb-8 flex-shrink-0 md:mr-8 md:mb-0 md:basis-[350px]">
+          <Image
+            src={details.thumbnailImage}
+            alt={details.title}
+            width={350}
+            height={500}
+            className="h-auto w-full rounded-lg object-cover object-center dark:brightness-90 md:h-[500px] md:w-[350px]"
+          />
         </div>
+        <div className="flex w-full flex-col justify-center">
+          <h2 className="mb-4 text-[2rem] font-bold leading-[1.15]">
+            {details.title}
+          </h2>
+          <div className="my-6 border-b border-[#222]" />
+          <DetailRow icon={faUser} label="著者">
+            {details.author}
+          </DetailRow>
+          <DetailRow icon={faBookmark} label="出版社">
+            {details.publisher}
+          </DetailRow>
+          <DetailRow icon={faBarcode} label="ISBN">
+            <Link
+              href={`https://www.books.or.jp/book-details/${details.isbn}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:underline"
+            >
+              {details.isbn}
+            </Link>
+          </DetailRow>
+          <DetailRow icon={faCalendarAlt} label="読了日">
+            {details.readDate}
+          </DetailRow>
+        </div>
+      </div>
 
-        {details.highlights && details.highlights.length > 0 && (
-          <div className="my-8 w-full max-w-[1200px] rounded-lg border border-[#222] p-6 text-gray-800">
-            <h3 className="mb-4 flex items-center border-b border-[#222] pb-2 text-base font-bold text-gray-300">
-              ハイライト
-            </h3>
-            <ul className="list-none p-0">
-              {details.highlights.map((highlight, index) => (
-                <li
-                  key={index}
-                  className="border-b border-[#222] py-4 leading-snug text-gray-400 last:border-b-0"
-                >
-                  <p>{highlight.text}</p>
-                  {details.asin && (
-                    <a
-                      href={`kindle://book?action=open&asin=${details.asin}&location=${highlight.location}`}
-                      className="mt-2 inline-block text-sm hover:underline text-right"
-                      style={{ display: "block", textAlign: "right" }}
-                    >
-                      Location. {highlight.location}
-                       <span style={{ marginLeft: "6px" }}>
-                        <FontAwesomeIcon icon={faExternalLinkAlt} />
-                      </span>
-                    </a>
-                  )}
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-      </main>
+      {details.highlights.length > 0 && (
+        <div className="my-8 w-full max-w-[1200px] rounded-lg border border-[#222] p-6 text-gray-800">
+          <h3 className="mb-4 flex items-center border-b border-[#222] pb-2 text-base font-bold text-gray-300">
+            ハイライト
+          </h3>
+          <ul className="list-none p-0">
+            {details.highlights.map((highlight, index) => (
+              <li
+                key={`${details.id}-highlight-${index}`}
+                className="border-b border-[#222] py-4 leading-snug text-gray-400 last:border-b-0"
+              >
+                <p>{highlight.text}</p>
+                {details.asin && (
+                  <a
+                    href={`kindle://book?action=open&asin=${details.asin}&location=${highlight.location}`}
+                    className="mt-2 inline-block text-sm hover:underline"
+                    style={{ display: "block", textAlign: "right" }}
+                  >
+                    Location. {highlight.location}
+                    <span className="ml-[6px]">
+                      <FontAwesomeIcon icon={faExternalLinkAlt} />
+                    </span>
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="flex justify-center py-8">
         <Link
@@ -129,12 +129,24 @@ function DetailPage() {
           戻る
         </Link>
       </div>
-
-      <footer className="flex w-full flex-1 items-center justify-center border-t border-[#222] py-4">
-        <p>© 2024 読書管理. All rights reserved.</p>
-      </footer>
-    </div>
+    </Layout>
   );
 }
 
-export default DetailPage;
+interface DetailRowProps {
+  icon: IconDefinition;
+  label: string;
+  children: ReactNode;
+}
+
+function DetailRow({ icon, label, children }: DetailRowProps) {
+  return (
+    <p className="my-1 flex items-center text-[0.9rem] leading-[1.5]">
+      <span className="inline-block w-1/5 font-bold text-gray-700 dark:text-gray-400">
+        <FontAwesomeIcon icon={icon} className="mr-[0.45rem]" />
+        {label}
+      </span>
+      {children}
+    </p>
+  );
+}

--- a/src/pages/items/[id].tsx
+++ b/src/pages/items/[id].tsx
@@ -44,7 +44,7 @@ function DetailPage() {
         <div className="my-8 flex w-full max-w-[1200px] flex-col rounded-[10px] border border-[#222] p-6 md:flex-row">
           <div className="mb-8 flex-shrink-0 md:mr-8 md:mb-0 md:basis-[350px]">
             <Image
-              src={details.thumnailImage}
+              src={details.thumbnailImage}
               alt={details.title}
               width={350}
               height={500}

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -11,6 +11,6 @@ export interface Book {
   isbn: string;
   asin: string | null;
   readDate: string;
-  thumnailImage: string;
+  thumbnailImage: string;
   highlights: Highlight[];
 }

--- a/src/utils/books.ts
+++ b/src/utils/books.ts
@@ -1,7 +1,6 @@
 import { ALL_YEARS_LABEL } from "@/constants/books";
 import { Book } from "@/types/book";
 
-const YEAR_INDEX = 0;
 const DATE_DELIMITER = "/";
 
 export function deriveAvailableYears(books: Book[]): string[] {

--- a/src/utils/books.ts
+++ b/src/utils/books.ts
@@ -1,0 +1,30 @@
+import { ALL_YEARS_LABEL } from "@/constants/books";
+import { Book } from "@/types/book";
+
+const YEAR_INDEX = 0;
+const DATE_DELIMITER = "/";
+
+export function deriveAvailableYears(books: Book[]): string[] {
+  const years = new Set<string>();
+
+  books.forEach((book) => {
+    const [year] = book.readDate.split(DATE_DELIMITER);
+    if (year) {
+      years.add(year);
+    }
+  });
+
+  const sortedYears = Array.from(years).sort((a, b) => b.localeCompare(a));
+  return [ALL_YEARS_LABEL, ...sortedYears];
+}
+
+export function filterBooksByYear(books: Book[], year: string): Book[] {
+  if (year === ALL_YEARS_LABEL) {
+    return books;
+  }
+
+  return books.filter((book) => {
+    const [readYear] = book.readDate.split(DATE_DELIMITER);
+    return readYear === year;
+  });
+}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,0 +1,42 @@
+const isBrowser = typeof window !== "undefined";
+
+export function readSessionStorage(key: string): string | null {
+  if (!isBrowser) {
+    return null;
+  }
+
+  try {
+    return window.sessionStorage.getItem(key);
+  } catch (error) {
+    console.warn(`[storage] Failed to read key "${key}":`, error);
+    return null;
+  }
+}
+
+export function writeSessionStorage(key: string, value: string) {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.setItem(key, value);
+  } catch (error) {
+    console.warn(`[storage] Failed to write key "${key}":`, error);
+  }
+}
+
+export function removeSessionStorage(key: string) {
+  if (!isBrowser) {
+    return;
+  }
+
+  try {
+    window.sessionStorage.removeItem(key);
+  } catch (error) {
+    console.warn(`[storage] Failed to remove key "${key}":`, error);
+  }
+}
+
+export function buildStorageKey(prefix: string, suffix: string): string {
+  return `${prefix}:${suffix}`;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,10 @@
       "@/components/*": ["src/components/*"],
       "@/hooks/*": ["src/hooks/*"],
       "@/styles/*": ["src/styles/*"],
-      "@/types/*": ["src/types/*"]
+      "@/types/*": ["src/types/*"],
+      "@/constants/*": ["src/constants/*"],
+      "@/utils/*": ["src/utils/*"],
+      "@/data/*": ["src/data/*"]
     }
   },
   "include": ["next-env.d.ts", "src/**/*.ts", "src/**/*.tsx", "convert.js"],


### PR DESCRIPTION
## Summary
- replace the legacy agent notes with a contributor-friendly Repository Guidelines doc
- document project layout, npm scripts, style conventions, and testing expectations tailored to this Next.js codebase
- add environment/tooling notes so new contributors configure Node, Biome, and Tailwind correctly

## Testing
- not run (docs only)