### PR TITLE
refactor: Font Awesome を自前の SVG アイコンに置き換え

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 - **フレームワーク**: Next.js 15.x（Pages Router）
 - **言語**: TypeScript 5.9（strict モード）
 - **UI**: Tailwind CSS v4（CSS ファースト設定。配色は `src/styles/globals.css` の `--app-*` トークンに集約し、`prefers-color-scheme` でライト/ダークを切り替え）
-- **アイコン**: Font Awesome（`src/fontawesome.ts` で全 Solid アイコンを登録）
+- **アイコン**: 自前の SVG アイコン（`src/components/atoms/Icon` に必要なものだけを定義）
 - **リンター/フォーマッター**: Biome（`lint` / `lint:fix` / `format`）
 - **データ変換**: Node.js スクリプト `convert.js`（CSV→型安全な TS + JSON 出力）
 
@@ -83,7 +83,7 @@ npm run books:update # convert のエイリアス（慣用コマンド）
 - 年選択・表示冊数・スクロール位置は `sessionStorage` に保持し、`storage` ユーティリティで安全に読み書きしています。
 - 無限スクロールは Intersection Observer + 遅延ロードで負荷を抑え、`books-rendered` イベントでスクロール復元と連携しています。
 - 詳細画面の Kindle リンクは ASIN が生成できる ISBN のみ deeplink を表示し、未対応の本でも一覧からの遷移は阻害しません。
-- Font Awesome の Solid アイコンをグローバル登録し、アイコン読み込みを 1 か所に集約しています。
+- アイコンは `Icon` コンポーネントの `name` で指定します。新しいアイコンは `src/components/atoms/Icon/Icon.tsx` の `paths` に 24x24 の SVG として追加してください。
 - 配色は `--app-*` トークン経由でのみ参照します。`bg-black` や `#222` のような直値を足すと、片方のカラースキームで文字や境界線が消えるため避けてください。
 - カードは stretched link パターン（擬似要素をカード全面に広げる）で全体をクリック可能にしています。カード内に別のリンクを足す場合は `relative z-10` で前面に出してください。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "book-read-history",
       "version": "1.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-svg-core": "^7.2.0",
-        "@fortawesome/free-solid-svg-icons": "^7.2.0",
-        "@fortawesome/react-fontawesome": "^3.3.1",
         "next": "^16.2.6",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -520,52 +517,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-common-types": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.3.1.tgz",
-      "integrity": "sha512-k0C0sdHmZtAo6dRDtd1Z/qcpyHbL0CKsjV8seMY/21xGhY5Wsv0XRmiI/xEEH4y2c9b1+jvgNs/3EqhV27yUEA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.3.1.tgz",
-      "integrity": "sha512-BoxVN3PKnMbgStHhjoaky/oWdxHomDqmBVA24IA3KEmssFGeI7u9YT/BJceOjIum/t6TpPa/vcMKaVYQeIQ/3Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/free-solid-svg-icons": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-7.3.1.tgz",
-      "integrity": "sha512-v0BLa0eqg7ubvVWeNSHVBs8fWH/GJicERZoJaxJ3FE/lj67VSqzoMg9pzfZVOfLMX10y0pGwQAuxoRVVH2patg==",
-      "license": "(CC-BY-4.0 AND MIT)",
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-3.5.0.tgz",
-      "integrity": "sha512-63mlRr6fiBbJ0wjr1Cf6dsDGtP2lNvk9lnatKgxs/fIkhslsZT291hIUzJkuUkI9yr69ZvWnWfgb2qXm4QyVaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
-        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@img/colour": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-svg-core": "^7.2.0",
-    "@fortawesome/free-solid-svg-icons": "^7.2.0",
-    "@fortawesome/react-fontawesome": "^3.3.1",
     "next": "^16.2.6",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",

--- a/src/components/atoms/BackToTopButton/BackToTopButton.tsx
+++ b/src/components/atoms/BackToTopButton/BackToTopButton.tsx
@@ -1,6 +1,5 @@
-import { faArrowUp } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useState } from "react";
+import Icon from "../Icon/Icon";
 
 const SHOW_THRESHOLD_PX = 600;
 
@@ -40,7 +39,7 @@ export default function BackToTopButton() {
       aria-label="ページの先頭に戻る"
       className="fixed right-4 bottom-4 z-40 flex size-12 cursor-pointer items-center justify-center rounded-full border border-app-border-strong bg-app-surface text-app-fg shadow-lg transition-colors hover:border-app-accent hover:text-app-accent"
     >
-      <FontAwesomeIcon icon={faArrowUp} aria-hidden />
+      <Icon name="arrowUp" width="1.25em" height="1.25em" />
     </button>
   );
 }

--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -1,0 +1,114 @@
+import type { ReactElement, SVGProps } from "react";
+
+export type IconName =
+  | "arrowUp"
+  | "barcode"
+  | "book"
+  | "bookOpen"
+  | "bookmark"
+  | "calendar"
+  | "externalLink"
+  | "user";
+
+// 24x24 のグリッドで線幅を揃えた自前のアイコン。
+// アイコンライブラリを丸ごと読み込まずに済むよう、使うものだけをここに置く。
+const paths: Record<IconName, ReactElement> = {
+  arrowUp: (
+    <>
+      <path d="M12 20V4.5" />
+      <path d="M5 11.5 12 4.5l7 7" />
+    </>
+  ),
+  barcode: (
+    <>
+      <path d="M3.5 5v14" />
+      <path d="M7 5v14" />
+      <path d="M10.5 5v9.5" />
+      <path d="M14 5v14" />
+      <path d="M17 5v9.5" />
+      <path d="M20.5 5v14" />
+    </>
+  ),
+  // 背表紙（左の縦線）と小口のふくらみで、閉じた本の輪郭を 1 本の線で描く
+  book: (
+    <>
+      <path d="M5 19.5V5a3 3 0 0 1 3-3h11v15.5H8a2 2 0 0 0 0 4h11" />
+    </>
+  ),
+  bookOpen: (
+    <>
+      <path d="M12 8v13" />
+      <path d="M3 18.5V5.5a1 1 0 0 1 1-1h4A4 4 0 0 1 12 8a4 4 0 0 1 4-3.5h4a1 1 0 0 1 1 1v13" />
+      <path d="M3 18.5h5A4 4 0 0 1 12 21a4 4 0 0 1 4-2.5h5" />
+    </>
+  ),
+  bookmark: (
+    <>
+      <path d="M6 3h12v18.25L12 17.25 6 21.25z" />
+    </>
+  ),
+  calendar: (
+    <>
+      <path d="M4 6.75A1.75 1.75 0 0 1 5.75 5h12.5A1.75 1.75 0 0 1 20 6.75v11.5A1.75 1.75 0 0 1 18.25 20H5.75A1.75 1.75 0 0 1 4 18.25z" />
+      <path d="M4 10h16" />
+      <path d="M8.5 3v4" />
+      <path d="M15.5 3v4" />
+    </>
+  ),
+  externalLink: (
+    <>
+      <path d="M14 4h6v6" />
+      <path d="M20 4l-8.5 8.5" />
+      <path d="M18 14v4.25A1.75 1.75 0 0 1 16.25 20H5.75A1.75 1.75 0 0 1 4 18.25V7.75A1.75 1.75 0 0 1 5.75 6H10" />
+    </>
+  ),
+  user: (
+    <>
+      <path d="M12 11.5a4.25 4.25 0 1 0 0-8.5 4.25 4.25 0 0 0 0 8.5z" />
+      <path d="M4.5 21v-1a5.5 5.5 0 0 1 5.5-5.5h4a5.5 5.5 0 0 1 5.5 5.5v1" />
+    </>
+  ),
+};
+
+interface IconProps
+  extends Omit<SVGProps<SVGSVGElement>, "children" | "aria-hidden"> {
+  name: IconName;
+}
+
+/**
+ * 意味は必ず隣接するテキストが持たせる前提の装飾アイコンなので、
+ * 常に aria-hidden で読み上げ対象から外す。
+ * 大きさは width/height 属性で受け取る（既定は文字サイズと同じ 1em）。
+ * Tailwind の size-* で上書きすると同種ユーティリティの優先順位が
+ * 読み手に見えなくなるため、クラスでは寸法を指定しない。
+ */
+export default function Icon({
+  name,
+  className,
+  width = "1em",
+  height = "1em",
+  ...rest
+}: IconProps) {
+  const classes = ["inline-block align-[-0.125em]", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={width}
+      height={height}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.75}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={classes}
+      focusable="false"
+      {...rest}
+      aria-hidden="true"
+    >
+      {paths[name]}
+    </svg>
+  );
+}

--- a/src/components/atoms/SiteHeader/SiteHeader.tsx
+++ b/src/components/atoms/SiteHeader/SiteHeader.tsx
@@ -1,6 +1,5 @@
-import { faBookmark } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Link from "next/link";
+import Icon from "../Icon/Icon";
 
 interface SiteHeaderProps {
   title: string;
@@ -9,7 +8,7 @@ interface SiteHeaderProps {
 export default function SiteHeader({ title }: SiteHeaderProps) {
   return (
     <header className="flex w-full items-center border-b border-app-border py-4 text-2xl font-bold">
-      <FontAwesomeIcon icon={faBookmark} className="mr-[1.125rem]" />
+      <Icon name="book" className="mr-[1.125rem]" />
       <Link
         href="/"
         className="text-current no-underline hover:underline focus-visible:underline"

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -1,4 +1,5 @@
 export { default as BackToTopButton } from "./BackToTopButton/BackToTopButton";
 export { default as Button } from "./Button/Button";
+export { default as Icon, type IconName } from "./Icon/Icon";
 export { default as SiteFooter } from "./SiteFooter/SiteFooter";
 export { default as SiteHeader } from "./SiteHeader/SiteHeader";

--- a/src/components/molecules/BookCover/BookCover.tsx
+++ b/src/components/molecules/BookCover/BookCover.tsx
@@ -1,7 +1,6 @@
-import { faBook } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import Image from "next/image";
 import { useState } from "react";
+import Icon from "../../atoms/Icon/Icon";
 
 interface BookCoverProps {
   src: string;
@@ -41,7 +40,7 @@ export default function BookCover({
     return (
       <div className={[frameClasses, fallbackFrameClass].join(" ")}>
         <span className="flex flex-col items-center gap-2 text-app-muted">
-          <FontAwesomeIcon icon={faBook} size="2x" aria-hidden />
+          <Icon name="book" width="2em" height="2em" />
           <span className="text-xs">表紙画像なし</span>
         </span>
       </div>

--- a/src/components/molecules/DetailProperty/DetailProperty.tsx
+++ b/src/components/molecules/DetailProperty/DetailProperty.tsx
@@ -1,9 +1,8 @@
-import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import type { ReactNode } from "react";
+import Icon, { type IconName } from "../../atoms/Icon/Icon";
 
 interface DetailPropertyProps {
-  icon: IconDefinition;
+  icon: IconName;
   label: string;
   children: ReactNode;
   className?: string;
@@ -34,7 +33,7 @@ export default function DetailProperty({
   return (
     <div className={containerClasses}>
       <dt className={labelClasses}>
-        <FontAwesomeIcon icon={icon} className="mr-[0.45rem]" aria-hidden />
+        <Icon name={icon} className="mr-[0.45rem]" />
         {label}
       </dt>
       <dd className="m-0 break-words">{children}</dd>

--- a/src/components/organisms/BookCard/BookCard.tsx
+++ b/src/components/organisms/BookCard/BookCard.tsx
@@ -1,9 +1,3 @@
-import {
-  faBarcode,
-  faBookmark,
-  faCalendarAlt,
-  faUser,
-} from "@fortawesome/free-solid-svg-icons";
 import Link from "next/link";
 import { BookCover, DetailProperty } from "@/components";
 import type { BookSummary } from "@/types/book";
@@ -41,13 +35,13 @@ export default function BookCard({ book }: BookCardProps) {
         </Link>
       </h2>
       <dl className="m-0">
-        <DetailProperty icon={faUser} label="著者">
+        <DetailProperty icon="user" label="著者">
           {book.author}
         </DetailProperty>
-        <DetailProperty icon={faBookmark} label="出版社">
+        <DetailProperty icon="bookmark" label="出版社">
           {book.publisher}
         </DetailProperty>
-        <DetailProperty icon={faBarcode} label="ISBN">
+        <DetailProperty icon="barcode" label="ISBN">
           {/* stretched link の擬似要素より前面に出さないとクリックできない */}
           <Link
             href={`https://www.books.or.jp/book-details/${book.isbn}`}
@@ -59,7 +53,7 @@ export default function BookCard({ book }: BookCardProps) {
             {book.isbn}
           </Link>
         </DetailProperty>
-        <DetailProperty icon={faCalendarAlt} label="読了日">
+        <DetailProperty icon="calendar" label="読了日">
           {book.readDate}
         </DetailProperty>
       </dl>

--- a/src/components/organisms/BookDetails/BookDetails.tsx
+++ b/src/components/organisms/BookDetails/BookDetails.tsx
@@ -1,9 +1,3 @@
-import {
-  faBarcode,
-  faBookmark,
-  faCalendarAlt,
-  faUser,
-} from "@fortawesome/free-solid-svg-icons";
 import Link from "next/link";
 import { BookCover, DetailProperty } from "@/components";
 import type { Book } from "@/types/book";
@@ -30,18 +24,18 @@ export default function BookDetails({ book }: BookDetailsProps) {
         </h1>
         <div className="my-6 border-b border-app-border" />
         <dl className="m-0">
-          <DetailProperty icon={faUser} label="著者" labelClassName="font-bold">
+          <DetailProperty icon="user" label="著者" labelClassName="font-bold">
             {book.author}
           </DetailProperty>
           <DetailProperty
-            icon={faBookmark}
+            icon="bookmark"
             label="出版社"
             labelClassName="font-bold"
           >
             {book.publisher}
           </DetailProperty>
           <DetailProperty
-            icon={faBarcode}
+            icon="barcode"
             label="ISBN"
             labelClassName="font-bold"
           >
@@ -56,7 +50,7 @@ export default function BookDetails({ book }: BookDetailsProps) {
             </Link>
           </DetailProperty>
           <DetailProperty
-            icon={faCalendarAlt}
+            icon="calendar"
             label="読了日"
             labelClassName="font-bold"
           >

--- a/src/components/organisms/BookGrid/BookGrid.tsx
+++ b/src/components/organisms/BookGrid/BookGrid.tsx
@@ -1,7 +1,5 @@
-import { faBookOpen } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { forwardRef } from "react";
-import { BookCard } from "@/components";
+import { BookCard, Icon } from "@/components";
 import type { BookSummary } from "@/types/book";
 
 interface BookGridProps {
@@ -17,7 +15,7 @@ const BookGrid = forwardRef<HTMLDivElement, BookGridProps>(
     if (totalCount === 0) {
       return (
         <div className="flex flex-col items-center gap-3 py-16 text-app-muted">
-          <FontAwesomeIcon icon={faBookOpen} size="2x" aria-hidden />
+          <Icon name="bookOpen" width="2em" height="2em" />
           <p>この条件で読んだ本はまだありません。</p>
         </div>
       );

--- a/src/components/organisms/BookHighlights/BookHighlights.tsx
+++ b/src/components/organisms/BookHighlights/BookHighlights.tsx
@@ -1,5 +1,4 @@
-import { faExternalLinkAlt } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Icon } from "@/components";
 import type { Highlight } from "@/types/book";
 
 interface BookHighlightsProps {
@@ -39,7 +38,7 @@ export default function BookHighlights({
               >
                 Location. {highlight.location}
                 <span className="ml-[6px]">
-                  <FontAwesomeIcon icon={faExternalLinkAlt} aria-hidden />
+                  <Icon name="externalLink" />
                 </span>
               </a>
             )}

--- a/src/fontawesome.ts
+++ b/src/fontawesome.ts
@@ -1,6 +1,0 @@
-import { config, library } from "@fortawesome/fontawesome-svg-core";
-import { fas } from "@fortawesome/free-solid-svg-icons";
-
-config.autoAddCss = false;
-// Add all solid icons to the library so icons can be referenced globally.
-library.add(fas);

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,8 +1,6 @@
 import type { AppProps } from "next/app";
 import { useScrollRestoration } from "@/hooks/useScrollRestoration";
-import "@fortawesome/fontawesome-svg-core/styles.css";
 import "../styles/globals.css";
-import "../fontawesome";
 
 export default function App({ Component, pageProps }: AppProps) {
   useScrollRestoration();


### PR DESCRIPTION
- `src/components/atoms/Icon` に必要なアイコンだけを 24x24 の SVG で定義し、
  `@fortawesome/*` 3 パッケージと `src/fontawesome.ts` のグローバル登録を削除
- 装飾用途に限るため Icon は常に aria-hidden、寸法は width/height 属性
  （既定 1em）で受け取り Tailwind の size-* と競合させない
- ヘッダーのアイコンをしおり（bookmark）から本（book）に変更