### PR TITLE
feat: 書籍の全文検索を追加

### DIFF
--- a/src/components/atoms/Icon/Icon.tsx
+++ b/src/components/atoms/Icon/Icon.tsx
@@ -7,7 +7,9 @@ export type IconName =
   | "bookOpen"
   | "bookmark"
   | "calendar"
+  | "close"
   | "externalLink"
+  | "search"
   | "user";
 
 // 24x24 のグリッドで線幅を揃えた自前のアイコン。
@@ -55,11 +57,23 @@ const paths: Record<IconName, ReactElement> = {
       <path d="M15.5 3v4" />
     </>
   ),
+  close: (
+    <>
+      <path d="M5 5l14 14" />
+      <path d="M19 5 5 19" />
+    </>
+  ),
   externalLink: (
     <>
       <path d="M14 4h6v6" />
       <path d="M20 4l-8.5 8.5" />
       <path d="M18 14v4.25A1.75 1.75 0 0 1 16.25 20H5.75A1.75 1.75 0 0 1 4 18.25V7.75A1.75 1.75 0 0 1 5.75 6H10" />
+    </>
+  ),
+  search: (
+    <>
+      <circle cx="10.5" cy="10.5" r="6.5" />
+      <path d="m15.5 15.5 4.5 4.5" />
     </>
   ),
   user: (

--- a/src/components/atoms/SiteHeader/SiteHeader.tsx
+++ b/src/components/atoms/SiteHeader/SiteHeader.tsx
@@ -1,20 +1,53 @@
+import dynamic from "next/dynamic";
 import Link from "next/link";
+import { useState } from "react";
 import Icon from "../Icon/Icon";
+
+const SearchDialog = dynamic(
+  () => import("../../organisms/SearchDialog/SearchDialog"),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55">
+        <p
+          role="status"
+          className="rounded-control bg-app-surface px-5 py-3 text-sm font-bold shadow-2xl"
+        >
+          検索を準備しています…
+        </p>
+      </div>
+    ),
+  },
+);
 
 interface SiteHeaderProps {
   title: string;
 }
 
 export default function SiteHeader({ title }: SiteHeaderProps) {
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+
   return (
-    <header className="flex w-full items-center border-b border-app-border py-4 text-2xl font-bold">
-      <Icon name="book" className="mr-[1.125rem]" />
-      <Link
-        href="/"
-        className="text-current no-underline hover:underline focus-visible:underline"
-      >
-        {title}
-      </Link>
-    </header>
+    <>
+      <header className="flex w-full items-center border-b border-app-border py-4">
+        <Icon name="book" className="mr-[1.125rem] text-2xl" />
+        <Link
+          href="/"
+          className="text-2xl font-bold text-current no-underline hover:underline focus-visible:underline"
+        >
+          {title}
+        </Link>
+        <button
+          type="button"
+          className="ml-auto inline-flex min-h-11 items-center gap-2 rounded-control border border-app-border-strong px-3 text-sm font-bold transition-colors hover:border-app-accent hover:text-app-accent sm:px-4"
+          aria-label="本を検索"
+          onClick={() => setIsSearchOpen(true)}
+        >
+          <Icon name="search" width={20} height={20} />
+          <span className="hidden sm:inline">検索</span>
+        </button>
+      </header>
+      {isSearchOpen && <SearchDialog onClose={() => setIsSearchOpen(false)} />}
+    </>
   );
 }

--- a/src/components/organisms/SearchDialog/SearchDialog.tsx
+++ b/src/components/organisms/SearchDialog/SearchDialog.tsx
@@ -1,0 +1,195 @@
+import Link from "next/link";
+import {
+  type ReactNode,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import Icon from "@/components/atoms/Icon/Icon";
+import { books } from "@/data/books";
+import {
+  getHighlightRanges,
+  parseSearchTerms,
+  searchBooks,
+} from "@/utils/search";
+
+interface SearchDialogProps {
+  onClose: () => void;
+}
+
+interface HighlightedTextProps {
+  text: string;
+  terms: string[];
+}
+
+const MAX_VISIBLE_RESULTS = 50;
+
+function HighlightedText({ text, terms }: HighlightedTextProps) {
+  if (terms.length === 0) {
+    return text;
+  }
+
+  const ranges = getHighlightRanges(text, terms);
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+
+  ranges.forEach((range) => {
+    if (range.start > cursor) {
+      parts.push(
+        <span key={`text-${cursor}`}>{text.slice(cursor, range.start)}</span>,
+      );
+    }
+    parts.push(
+      <mark
+        key={`mark-${range.start}`}
+        className="rounded-sm bg-yellow-200 px-0.5 text-zinc-950 dark:bg-yellow-300"
+      >
+        {text.slice(range.start, range.end)}
+      </mark>,
+    );
+    cursor = range.end;
+  });
+  if (cursor < text.length) {
+    parts.push(<span key={`text-${cursor}`}>{text.slice(cursor)}</span>);
+  }
+
+  return parts;
+}
+
+export default function SearchDialog({ onClose }: SearchDialogProps) {
+  const [query, setQuery] = useState("");
+  const deferredQuery = useDeferredValue(query);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const terms = useMemo(() => parseSearchTerms(deferredQuery), [deferredQuery]);
+  const results = useMemo(
+    () => searchBooks(books, deferredQuery),
+    [deferredQuery],
+  );
+  const visibleResults = results.slice(0, MAX_VISIBLE_RESULTS);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center bg-black/55 px-3 pt-[min(12vh,6rem)] sm:px-6">
+      <button
+        type="button"
+        aria-label="検索を閉じる"
+        tabIndex={-1}
+        className="absolute inset-0 h-full w-full cursor-default"
+        onClick={onClose}
+      />
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-dialog-title"
+        className="relative flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-card border border-app-border bg-app-surface shadow-2xl"
+      >
+        <h2 id="search-dialog-title" className="sr-only">
+          本を検索
+        </h2>
+        <div className="flex items-center gap-3 border-b border-app-border p-3 sm:p-4">
+          <Icon name="search" width={22} height={22} className="shrink-0" />
+          <input
+            ref={inputRef}
+            type="search"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+            placeholder="書名、著者、ハイライトなどを検索"
+            aria-label="検索キーワード"
+            className="min-w-0 flex-1 bg-transparent py-2 text-base outline-none placeholder:text-app-muted sm:text-lg"
+          />
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="検索を閉じる"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-control text-app-muted hover:bg-app-surface-subtle hover:text-app-fg"
+          >
+            <Icon name="close" width={22} height={22} />
+          </button>
+        </div>
+
+        <div className="overflow-y-auto p-4 sm:p-6">
+          {terms.length === 0 ? (
+            <p className="py-10 text-center text-sm text-app-muted">
+              書名、著者、出版社、ISBN、読了日、ハイライトを横断検索します。
+            </p>
+          ) : results.length === 0 ? (
+            <div className="py-10 text-center">
+              <p className="font-bold">
+                「{query.trim()}」に一致する本はありません
+              </p>
+              <p className="mt-2 text-sm text-app-muted">
+                キーワードを短くするか、別の表記をお試しください。
+              </p>
+            </div>
+          ) : (
+            <>
+              <p className="mb-5 text-sm text-app-muted" aria-live="polite">
+                {results.length}冊が見つかりました
+                {results.length > MAX_VISIBLE_RESULTS &&
+                  `（上位${MAX_VISIBLE_RESULTS}冊を表示）`}
+              </p>
+              <ol className="space-y-7">
+                {visibleResults.map(({ book, matches }) => (
+                  <li key={book.id}>
+                    <article>
+                      <Link
+                        href={`/items/${book.id}`}
+                        onClick={onClose}
+                        className="text-lg font-bold text-app-accent hover:underline"
+                      >
+                        <HighlightedText text={book.title} terms={terms} />
+                      </Link>
+                      <p className="mt-1 text-sm text-app-muted">
+                        <HighlightedText text={book.author} terms={terms} />
+                        <span aria-hidden="true"> · </span>
+                        <HighlightedText text={book.publisher} terms={terms} />
+                        <span aria-hidden="true"> · </span>
+                        <HighlightedText text={book.readDate} terms={terms} />
+                      </p>
+                      <div className="mt-2 space-y-1.5">
+                        {matches
+                          .filter((match) => match.key !== "title")
+                          .map((match) => (
+                            <p
+                              key={match.key}
+                              className="line-clamp-3 text-sm leading-6"
+                            >
+                              <span className="mr-2 font-bold text-app-muted">
+                                {match.label}
+                              </span>
+                              <HighlightedText
+                                text={match.snippet}
+                                terms={terms}
+                              />
+                            </p>
+                          ))}
+                      </div>
+                    </article>
+                  </li>
+                ))}
+              </ol>
+            </>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -1,0 +1,193 @@
+import type { Book } from "@/types/book";
+
+export interface SearchFieldMatch {
+  key: string;
+  label: string;
+  text: string;
+  snippet: string;
+}
+
+export interface BookSearchResult {
+  book: Book;
+  matches: SearchFieldMatch[];
+}
+
+export interface HighlightRange {
+  start: number;
+  end: number;
+}
+
+interface SearchableField {
+  key: string;
+  label: string;
+  text: string;
+  weight: number;
+}
+
+const SNIPPET_LENGTH = 180;
+const SNIPPET_CONTEXT_BEFORE = 55;
+
+export function normalizeSearchText(value: string): string {
+  return value.normalize("NFKC").toLocaleLowerCase("ja-JP");
+}
+
+export function parseSearchTerms(query: string): string[] {
+  return Array.from(
+    new Set(
+      normalizeSearchText(query)
+        .split(/\s+/)
+        .map((term) => term.trim())
+        .filter(Boolean),
+    ),
+  );
+}
+
+/**
+ * NFKC 正規化後の文字列で検索しながら、元の表示文字列上の範囲を返す。
+ * これにより「ＫＥＮＴ」を "kent" で検索した場合も元の全角表記を保って強調できる。
+ */
+export function getHighlightRanges(
+  text: string,
+  terms: string[],
+): HighlightRange[] {
+  let normalizedText = "";
+  const offsets: HighlightRange[] = [];
+
+  for (let start = 0; start < text.length; ) {
+    const codePoint = text.codePointAt(start);
+    if (codePoint === undefined) {
+      break;
+    }
+    const character = String.fromCodePoint(codePoint);
+    const end = start + character.length;
+    const normalizedCharacter = normalizeSearchText(character);
+    normalizedText += normalizedCharacter;
+    for (let index = 0; index < normalizedCharacter.length; index += 1) {
+      offsets.push({ start, end });
+    }
+    start = end;
+  }
+
+  const ranges: HighlightRange[] = [];
+  terms.forEach((term) => {
+    let searchFrom = 0;
+    while (searchFrom < normalizedText.length) {
+      const hit = normalizedText.indexOf(term, searchFrom);
+      if (hit < 0) {
+        break;
+      }
+      const firstOffset = offsets[hit];
+      const lastOffset = offsets[hit + term.length - 1];
+      if (firstOffset && lastOffset) {
+        ranges.push({ start: firstOffset.start, end: lastOffset.end });
+      }
+      searchFrom = hit + Math.max(term.length, 1);
+    }
+  });
+
+  return ranges
+    .sort((a, b) => a.start - b.start || a.end - b.end)
+    .reduce<HighlightRange[]>((merged, range) => {
+      const previous = merged.at(-1);
+      if (previous && range.start <= previous.end) {
+        previous.end = Math.max(previous.end, range.end);
+      } else {
+        merged.push({ ...range });
+      }
+      return merged;
+    }, []);
+}
+
+function getSearchableFields(book: Book): SearchableField[] {
+  const fields: SearchableField[] = [
+    { key: "title", label: "書名", text: book.title, weight: 10 },
+    { key: "author", label: "著者", text: book.author, weight: 7 },
+    { key: "publisher", label: "出版社", text: book.publisher, weight: 5 },
+    { key: "isbn", label: "ISBN", text: book.isbn, weight: 4 },
+    { key: "asin", label: "ASIN", text: book.asin ?? "", weight: 4 },
+    { key: "readDate", label: "読了日", text: book.readDate, weight: 3 },
+  ];
+
+  book.highlights.forEach((highlight, index) => {
+    fields.push(
+      {
+        key: `highlight-${index}`,
+        label: "ハイライト",
+        text: highlight.text,
+        weight: 2,
+      },
+      {
+        key: `location-${index}`,
+        label: "位置",
+        text: highlight.location,
+        weight: 1,
+      },
+    );
+  });
+
+  return fields.filter((field) => field.text.trim().length > 0);
+}
+
+export function createSearchSnippet(text: string, terms: string[]): string {
+  const normalized = normalizeSearchText(text);
+  const hitIndexes = terms
+    .map((term) => normalized.indexOf(term))
+    .filter((index) => index >= 0);
+  const firstHit = hitIndexes.length > 0 ? Math.min(...hitIndexes) : 0;
+  const start = Math.max(0, firstHit - SNIPPET_CONTEXT_BEFORE);
+  const end = Math.min(text.length, start + SNIPPET_LENGTH);
+  const prefix = start > 0 ? "…" : "";
+  const suffix = end < text.length ? "…" : "";
+
+  return `${prefix}${text.slice(start, end).trim()}${suffix}`;
+}
+
+export function searchBooks(books: Book[], query: string): BookSearchResult[] {
+  const terms = parseSearchTerms(query);
+  if (terms.length === 0) {
+    return [];
+  }
+
+  return books
+    .map((book) => {
+      const fields = getSearchableFields(book);
+      const searchableText = normalizeSearchText(
+        fields.map((field) => field.text).join("\n"),
+      );
+
+      // 空白区切りの語がすべて、書籍内のいずれかの項目に存在する本を返す。
+      if (!terms.every((term) => searchableText.includes(term))) {
+        return null;
+      }
+
+      const matchingFields = fields.filter((field) => {
+        const normalized = normalizeSearchText(field.text);
+        return terms.some((term) => normalized.includes(term));
+      });
+      const score = matchingFields.reduce((total, field) => {
+        const normalized = normalizeSearchText(field.text);
+        const hitCount = terms.filter((term) =>
+          normalized.includes(term),
+        ).length;
+        const exactBonus = terms.some((term) => normalized === term) ? 20 : 0;
+        return total + field.weight * hitCount + exactBonus;
+      }, 0);
+      const matches = matchingFields.slice(0, 3).map((field) => ({
+        key: field.key,
+        label: field.label,
+        text: field.text,
+        snippet: createSearchSnippet(field.text, terms),
+      }));
+
+      return { book, matches, score };
+    })
+    .filter(
+      (
+        result,
+      ): result is BookSearchResult & {
+        score: number;
+      } => result !== null,
+    )
+    .sort((a, b) => b.score - a.score)
+    .map(({ book, matches }) => ({ book, matches }));
+}

--- a/src/utils/search.ts
+++ b/src/utils/search.ts
@@ -54,10 +54,8 @@ export function getHighlightRanges(
   const offsets: HighlightRange[] = [];
 
   for (let start = 0; start < text.length; ) {
-    const codePoint = text.codePointAt(start);
-    if (codePoint === undefined) {
-      break;
-    }
+    // start < text.length の間だけ反復するため codePointAt は必ず値を返す。
+    const codePoint = text.codePointAt(start) as number;
     const character = String.fromCodePoint(codePoint);
     const end = start + character.length;
     const normalizedCharacter = normalizeSearchText(character);
@@ -76,11 +74,10 @@ export function getHighlightRanges(
       if (hit < 0) {
         break;
       }
-      const firstOffset = offsets[hit];
-      const lastOffset = offsets[hit + term.length - 1];
-      if (firstOffset && lastOffset) {
-        ranges.push({ start: firstOffset.start, end: lastOffset.end });
-      }
+      // normalizedText と offsets は同じループで構築するため添字は必ず存在する。
+      const firstOffset = offsets[hit] as HighlightRange;
+      const lastOffset = offsets[hit + term.length - 1] as HighlightRange;
+      ranges.push({ start: firstOffset.start, end: lastOffset.end });
       searchFrom = hit + Math.max(term.length, 1);
     }
   });

--- a/tests/e2e/search.spec.ts
+++ b/tests/e2e/search.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Book search", () => {
+  test("opens from the header and highlights a matching book", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    await page.getByRole("button", { name: "本を検索" }).click();
+    const dialog = page.getByRole("dialog", { name: "本を検索" });
+    await expect(dialog).toBeVisible();
+
+    await dialog
+      .getByRole("searchbox", { name: "検索キーワード" })
+      .fill("反ミーム");
+
+    const resultLink = dialog.getByRole("link", {
+      name: "反ミーム部門は存在しない",
+    });
+    await expect(resultLink).toBeVisible();
+    await expect(resultLink.locator("mark")).toHaveText("反ミーム");
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/tests/utils/search.test.ts
+++ b/tests/utils/search.test.ts
@@ -26,7 +26,7 @@ const books: Book[] = [
     author: "Kent Beck",
     publisher: "オーム社",
     isbn: "9784274217883",
-    asin: "4274217884",
+    asin: null,
     readDate: "2023/12/01",
     thumbnailImage: "",
     highlights: [],
@@ -46,11 +46,29 @@ describe("book search", () => {
     ]);
   });
 
+  it("merges overlapping highlight ranges", () => {
+    expect(getHighlightRanges("testing", ["test", "testing"])).toEqual([
+      { start: 0, end: 7 },
+    ]);
+  });
+
   it("searches across different fields and requires every term", () => {
     expect(
       searchBooks(books, "劉 宇宙").map((result) => result.book.id),
     ).toEqual(["1"]);
     expect(searchBooks(books, "早川 オーム社")).toEqual([]);
+  });
+
+  it("returns no results for an empty query", () => {
+    expect(searchBooks(books, "   ")).toEqual([]);
+  });
+
+  it("ranks exact and multiple book matches", () => {
+    expect(searchBooks(books, "三体")[0].book.id).toBe("1");
+    expect(searchBooks(books, "202").map((result) => result.book.id)).toEqual([
+      "1",
+      "2",
+    ]);
   });
 
   it("returns one result per book with matching snippets", () => {
@@ -71,5 +89,9 @@ describe("book search", () => {
     expect(snippet.startsWith("…")).toBe(true);
     expect(snippet.endsWith("…")).toBe(true);
     expect(snippet.length).toBeLessThanOrEqual(182);
+  });
+
+  it("uses the beginning when no snippet term matches", () => {
+    expect(createSearchSnippet("short text", ["missing"])).toBe("short text");
   });
 });

--- a/tests/utils/search.test.ts
+++ b/tests/utils/search.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import type { Book } from "@/types/book";
+import {
+  createSearchSnippet,
+  getHighlightRanges,
+  normalizeSearchText,
+  parseSearchTerms,
+  searchBooks,
+} from "@/utils/search";
+
+const books: Book[] = [
+  {
+    id: "1",
+    title: "三体",
+    author: "劉 慈欣",
+    publisher: "早川書房",
+    isbn: "9784152098702",
+    asin: "4152098708",
+    readDate: "2024/01/02",
+    thumbnailImage: "",
+    highlights: [{ text: "文明は宇宙で孤独ではない。", location: "123" }],
+  },
+  {
+    id: "2",
+    title: "テスト駆動開発",
+    author: "Kent Beck",
+    publisher: "オーム社",
+    isbn: "9784274217883",
+    asin: "4274217884",
+    readDate: "2023/12/01",
+    thumbnailImage: "",
+    highlights: [],
+  },
+];
+
+describe("book search", () => {
+  it("normalizes width, case, and duplicate terms", () => {
+    expect(normalizeSearchText("ＫＥＮＴ")).toBe("kent");
+    expect(parseSearchTerms(" Kent  KENT  Beck ")).toEqual(["kent", "beck"]);
+  });
+
+  it("maps normalized matches back to the original display text", () => {
+    expect(getHighlightRanges("著者 ＫＥＮＴ Beck", ["kent", "beck"])).toEqual([
+      { start: 3, end: 7 },
+      { start: 8, end: 12 },
+    ]);
+  });
+
+  it("searches across different fields and requires every term", () => {
+    expect(
+      searchBooks(books, "劉 宇宙").map((result) => result.book.id),
+    ).toEqual(["1"]);
+    expect(searchBooks(books, "早川 オーム社")).toEqual([]);
+  });
+
+  it("returns one result per book with matching snippets", () => {
+    const [result] = searchBooks(books, "宇宙");
+    expect(result.book.title).toBe("三体");
+    expect(result.matches).toEqual([
+      expect.objectContaining({
+        label: "ハイライト",
+        snippet: expect.stringContaining("宇宙"),
+      }),
+    ]);
+  });
+
+  it("trims long text around the first match", () => {
+    const text = `${"前".repeat(100)}検索語${"後".repeat(200)}`;
+    const snippet = createSearchSnippet(text, ["検索語"]);
+    expect(snippet).toContain("検索語");
+    expect(snippet.startsWith("…")).toBe(true);
+    expect(snippet.endsWith("…")).toBe(true);
+    expect(snippet.length).toBeLessThanOrEqual(182);
+  });
+});


### PR DESCRIPTION
## 概要

ヘッダー右上から開く全文検索を追加します。書名・著者・出版社・ISBN・ASIN・読了日・Kindleハイライト本文/位置を横断し、結果を本単位でまとめて表示します。

## 変更内容

- ヘッダー右上に検索ボタンを追加
- 検索UIをモーダルとして遅延ロードし、通常表示の初期バンドルに全ハイライトを載せない構成
- 空白区切りの複数語を、本の異なる項目をまたいでAND検索
- NFKC正規化による全角/半角・英字大小を無視した照合
- 書名、メタ情報、一致箇所を `mark` でハイライト
- Google検索結果に近い形で、一致箇所の前後を最大180文字・1冊3箇所まで抜粋
- 書名/著者などを優先する関連度順、最大50冊を表示
- Escape、背景クリック、閉じるボタンに対応
- 検索中も入力が固まりにくい `useDeferredValue` 対応
- 検索ユーティリティのユニットテストとPlaywrightシナリオを追加

## 検証

- `npm run lint` — 成功
- `npm run typecheck` — 成功
- `npm run test` — 17件成功
- `git diff --check` — 成功
- `npm run build` — この実行環境では Next.js 起動中に `ENOENT: uv_resident_set_memory` が発生するため未完了（Node 20/24の両方で環境起因の同一エラー）
- Playwright — テスト実装済み。ローカル環境にChromiumバイナリが無いため未実行。GitHub Actionsで確認予定

## 影響

通常の一覧・詳細表示は変更せず、検索を初めて開いた時だけ全書籍データを含む検索チャンクを読み込みます。