### PR TITLE
fix: スマホで本棚を2列表示にする

### DIFF
--- a/src/components/organisms/BookGrid/BookGrid.tsx
+++ b/src/components/organisms/BookGrid/BookGrid.tsx
@@ -23,7 +23,7 @@ const BookGrid = forwardRef<HTMLDivElement, BookGridProps>(
 
     return (
       <div className="w-full">
-        <ul className="mx-auto grid w-full max-w-[1400px] list-none grid-cols-1 justify-items-center gap-6 p-0 sm:grid-cols-2 xl:grid-cols-3">
+        <ul className="mx-auto grid w-full max-w-[1400px] list-none grid-cols-2 justify-items-center gap-3 p-0 sm:gap-6 xl:grid-cols-3">
           {books.map((book) => (
             <li key={book.id} className="w-full max-w-[400px]">
               <BookCard book={book} />


### PR DESCRIPTION
## 概要

スマホ幅でも本棚を2列で表示するように変更しました。

## 変更内容

- `BookGrid` の既定列数を1列から2列へ変更
- 狭い画面でカード間隔が収まるよう、既定の gap を `gap-3` に調整
- `sm` 以上では従来どおり `gap-6` を維持
- `xl` 以上の3列表示は変更なし

## 背景・影響

スマホでは `grid-cols-1` が適用されていたため、本が1列で表示されていました。既定値を2列にすることで、スマホでも一覧性が高くなります。

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅（3ファイル、21テスト）
- `npm run build` ⚠️ TypeScript 検査完了後、実行環境固有の `ENOENT: uv_resident_set_memory` で停止