### PR TITLE
fix: 書影の高さを揃えてタイトル位置を統一する

### DIFF
--- a/src/components/molecules/BookCover/BookCover.tsx
+++ b/src/components/molecules/BookCover/BookCover.tsx
@@ -7,6 +7,8 @@ interface BookCoverProps {
   width: number;
   height: number;
   sizes?: string;
+  /** 書影を3:4の枠内に収め、周囲のカードと高さを揃える。 */
+  fitFrame?: boolean;
   /** 書影を収める枠のクラス。幅の制御はこちらで行う。 */
   frameClassName?: string;
   imageClassName?: string;
@@ -27,12 +29,23 @@ export default function BookCover({
   width,
   height,
   sizes,
+  fitFrame = false,
   frameClassName,
   imageClassName,
 }: BookCoverProps) {
   const [hasError, setHasError] = useState(false);
 
-  const frameClasses = [baseFrameClass, frameClassName]
+  const frameClasses = [
+    baseFrameClass,
+    fitFrame ? "aspect-3/4 bg-app-surface-subtle" : undefined,
+    frameClassName,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const imageClasses = [
+    fitFrame ? "h-full w-full object-contain" : "h-auto w-full",
+    imageClassName,
+  ]
     .filter(Boolean)
     .join(" ");
 
@@ -52,11 +65,6 @@ export default function BookCover({
 
   return (
     <div className={frameClasses}>
-      {/*
-       * 高さを固定して object-contain で収めると、書影の比率が枠と違うぶん
-       * 余白が出てしまう。枠の高さは指定せず、書影の実寸比率のまま
-       * 幅いっぱいに表示する（切り抜きも余白も発生しない）。
-       */}
       <Image
         src={src}
         alt=""
@@ -64,7 +72,7 @@ export default function BookCover({
         height={height}
         sizes={sizes}
         onError={() => setHasError(true)}
-        className={`h-auto w-full ${imageClassName ?? ""}`.trim()}
+        className={imageClasses}
       />
     </div>
   );

--- a/src/components/organisms/BookCard/BookCard.tsx
+++ b/src/components/organisms/BookCard/BookCard.tsx
@@ -21,6 +21,7 @@ export default function BookCard({ book }: BookCardProps) {
         src={book.thumbnailImage}
         width={350}
         height={466}
+        fitFrame
         sizes="(max-width: 640px) 100vw, (max-width: 1280px) 50vw, 350px"
         imageClassName="transition-transform duration-500 ease-in-out group-hover:scale-105 motion-reduce:transform-none dark:brightness-90"
       />


### PR DESCRIPTION
## 概要

本棚一覧の書影領域を3:4に統一し、各カードのタイトル開始位置が揃うようにしました。

## 変更内容

- `BookCover` に一覧向けの枠内表示モードを追加
- 有効時は書影領域を `aspect-3/4` に固定
- 画像を `h-full w-full object-contain` で枠内に収め、切り抜きを防止
- 画像と枠の比率が異なる場合は既存の補助背景色で余白を表示
- `BookCard` のみで固定枠を有効化
- 詳細画面の書影は従来どおり本来の縦横比で表示

## 背景・影響

書影ごとの縦横比の違いによってカード内のタイトル開始位置がずれていました。タイトル側へ個別の余白を設けず、書影領域そのものを統一することでカード構造を揃えています。

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅（3ファイル、21テスト）
- `npm run build` ✅（1047ページの静的生成を完了）
