### PR TITLE
fix: 書影の角丸とカード情報の文字サイズを調整する

### DIFF
--- a/src/components/molecules/BookCover/BookCover.tsx
+++ b/src/components/molecules/BookCover/BookCover.tsx
@@ -37,13 +37,17 @@ export default function BookCover({
 
   const frameClasses = [
     baseFrameClass,
-    fitFrame ? "aspect-3/4 bg-app-surface-subtle" : undefined,
+    fitFrame
+      ? "flex aspect-3/4 items-center justify-center bg-app-surface-subtle"
+      : undefined,
     frameClassName,
   ]
     .filter(Boolean)
     .join(" ");
   const imageClasses = [
-    fitFrame ? "h-full w-full object-contain" : "h-auto w-full",
+    fitFrame
+      ? "h-auto max-h-full w-auto max-w-full rounded-lg object-contain"
+      : "h-auto w-full",
     imageClassName,
   ]
     .filter(Boolean)

--- a/src/components/organisms/BookCard/BookCard.tsx
+++ b/src/components/organisms/BookCard/BookCard.tsx
@@ -36,17 +36,17 @@ export default function BookCard({ book }: BookCardProps) {
         </Link>
       </h2>
       <dl className="m-0">
-        <DetailProperty icon="user" label="著者">
+        <DetailProperty icon="user" label="著者" className="text-xs">
           {book.author}
         </DetailProperty>
-        <DetailProperty icon="bookmark" label="出版社">
+        <DetailProperty icon="bookmark" label="出版社" className="text-xs">
           {book.publisher}
         </DetailProperty>
-        <DetailProperty icon="barcode" label="ISBN">
+        <DetailProperty icon="barcode" label="ISBN" className="text-xs">
           {/* stretched link の擬似要素より前面に出さないとクリックできない */}
           <IsbnLink isbn={book.isbn} className="relative z-10" />
         </DetailProperty>
-        <DetailProperty icon="calendar" label="読了日">
+        <DetailProperty icon="calendar" label="読了日" className="text-xs">
           {book.readDate}
         </DetailProperty>
       </dl>


### PR DESCRIPTION
## 概要

実機確認で見つかった、枠内表示した書影本体に角丸が付かない問題を修正しました。あわせて、本棚カードの著者以下の情報を少し小さくしています。

## 変更内容

- 3:4の書影枠をFlexで中央揃え
- 書影を自然比率のまま枠内へ収めるよう調整
- 外側の枠だけでなく書影画像本体にも `rounded-lg` を適用
- 著者・出版社・ISBN・読了日の文字サイズを `text-sm` から `text-xs` へ変更
- 詳細画面の書影・文字サイズには影響なし

## 背景・影響

`object-contain` では画像要素のボックスが3:4枠全体を占めるため、外枠の角丸だけでは余白の内側にある表紙本体の角が四角いまま見えていました。画像本体のサイズを自然比率に合わせて角丸を付けることで、余白がある書影でも輪郭が丸く表示されます。

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅（3ファイル、21テスト）
- `npm run build` ✅（1047ページの静的生成を完了）
