### PR TITLE
fix: 書影を上端基準でクロップする

### DIFF
--- a/src/components/molecules/BookCover/BookCover.tsx
+++ b/src/components/molecules/BookCover/BookCover.tsx
@@ -37,16 +37,14 @@ export default function BookCover({
 
   const frameClasses = [
     baseFrameClass,
-    fitFrame
-      ? "flex aspect-3/4 items-center justify-center bg-app-surface-subtle"
-      : undefined,
+    fitFrame ? "aspect-3/4 bg-app-surface-subtle" : undefined,
     frameClassName,
   ]
     .filter(Boolean)
     .join(" ");
   const imageClasses = [
     fitFrame
-      ? "h-auto max-h-full w-auto max-w-full rounded-lg object-contain"
+      ? "h-full w-full rounded-lg object-cover object-top"
       : "h-auto w-full",
     imageClassName,
   ]


### PR DESCRIPTION
## 概要

本棚一覧の書影を中央配置ではなく、上端を基準に3:4枠へクロップするよう変更しました。

## 変更内容

- 枠内の中央寄せ・余白表示を削除
- 書影を `h-full w-full object-cover` で3:4枠いっぱいに表示
- `object-top` で上端を固定し、主に下側をトリミング
- 既存の角丸とカード情報の文字サイズ調整は維持
- 詳細画面の書影には影響なし

## 検証

- `npm run lint` ✅
- `npm run typecheck` ✅
- `npm run test` ✅（3ファイル、21テスト）
- `npm run build` ✅（1047ページの静的生成を完了）
